### PR TITLE
Windows: add Swift installer custom action

### DIFF
--- a/platforms/Windows/CustomActions/SwiftInstaller/Headers/logging.hh
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Headers/logging.hh
@@ -1,0 +1,62 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef SWIFT_INSTALLER_HEADERS_LOGGING_HH
+#define SWIFT_INSTALLER_HEADERS_LOGGING_HH
+
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <MsiQuery.h>
+#include <Msi.h>
+
+#include <string>
+#include <sstream>
+
+namespace msi::logging {
+enum class severity {
+  info,     /// INSTALLMESSAGE_INFO
+  warning,  /// INSTALLMESSAGE_WARNING
+  error,    /// INSTALLMESSAGE_ERROR
+  fatal,    /// INSTALLMESSAGE_FATALEXIT
+};
+
+class log_message {
+  MSIHANDLE install_;
+  const severity severity_;
+  const char *file_;
+  const unsigned line_;
+  std::ostringstream stream_;
+
+  template <typename Value_>
+  friend log_message &operator<<(log_message &, const Value_ &) noexcept;
+
+ public:
+  log_message(MSIHANDLE install, severity severity,
+              const char *file, unsigned line);
+  ~log_message();
+
+  log_message(const log_message &) = delete;
+  log_message &operator=(const log_message &) = delete;
+
+  std::string str() { return stream_.str(); }
+  severity severity() const { return severity_; }
+};
+
+template <typename Value_>
+log_message &operator<<(log_message &message, const Value_ &value) noexcept {
+  message.stream_ << value;
+  return message;
+}
+
+extern template
+log_message &operator<<<std::wstring>(log_message &,
+                                      const std::wstring &) noexcept;
+}
+
+#define LOG(Install,Severity)                                                   \
+  msi::logging::log_message(Install, msi::logging::severity::##Severity,        \
+                            __FILE__, __LINE__)
+
+#endif

--- a/platforms/Windows/CustomActions/SwiftInstaller/Headers/scoped_raii.hh
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Headers/scoped_raii.hh
@@ -1,0 +1,51 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef SWIFT_INSTALLER_HEADERS_SCOPED_RAII_HH
+#define SWIFT_INSTALLER_HEADERS_SCOPED_RAII_HH
+
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <objbase.h>
+
+namespace windows {
+namespace raii {
+class hkey {
+  HKEY hKey_;
+
+ public:
+  explicit hkey(HKEY hKey) noexcept : hKey_(hKey) {}
+
+  // TODO(compnerd) log failure
+  ~hkey() noexcept { (void)RegCloseKey(hKey_); }
+};
+
+class com_initializer {
+  HRESULT hr_;
+
+ public:
+   enum threading_model { multithreaded };
+
+   explicit com_initializer() {
+     hr_ = ::CoInitializeEx(nullptr,
+                            COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+   }
+
+   explicit com_initializer(threading_model) {
+     hr_ = ::CoInitializeEx(nullptr,
+                            COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
+   }
+
+   ~com_initializer() {
+     if (SUCCEEDED(hr_))
+       ::CoUninitialize();
+   }
+
+   bool succeeded() const { return SUCCEEDED(hr_); }
+};
+}
+}
+
+#endif

--- a/platforms/Windows/CustomActions/SwiftInstaller/Headers/swift_installer.hh
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Headers/swift_installer.hh
@@ -1,0 +1,34 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef SWIFT_INSTALLER_HEADERS_SWIFT_INSTALLER_HH
+#define SWIFT_INSTALLER_HEADERS_SWIFT_INSTALLER_HH
+
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <msi.h>
+
+#if defined(_WINDLL)
+# if defined(SwiftInstaller_EXPORTS)
+#   define SWIFT_INSTALLER_API __declspec(dllexport)
+# else
+#   define SWIFT_INSTALLER_API __declspec(dllimport)
+# endif
+#else
+# define SWIFT_INSTALLER_API
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+UINT SWIFT_INSTALLER_API
+SwiftInstaller_InstallAuxiliaryFiles(MSIHANDLE hInstall);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/dllmain.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/dllmain.cc
@@ -1,0 +1,19 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+
+extern "C" BOOL APIENTRY
+DllMain(HANDLE hModule, DWORD ulReason, LPVOID lpReserved) {
+  switch (ulReason) {
+  case DLL_PROCESS_ATTACH:
+    break;
+  case DLL_PROCESS_DETACH:
+    break;
+  }
+
+  return TRUE;
+}

--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/logging.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/logging.cc
@@ -1,0 +1,72 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "logging.hh"
+
+#include <cassert>
+#include <codecvt>
+#include <iomanip>
+#include <string>
+#include <vector>
+
+namespace {
+std::string to_string(const msi::logging::severity &severity) {
+  switch (severity) {
+  case msi::logging::severity::info: return "INFO";
+  case msi::logging::severity::warning: return "WARN";
+  case msi::logging::severity::error: return "ERROR";
+  case msi::logging::severity::fatal: return "FATAL";
+  }
+  __assume(false);
+}
+}
+
+namespace msi::logging {
+log_message::log_message(MSIHANDLE install, msi::logging::severity severity,
+                         const char *file, unsigned line)
+    : install_(install), severity_(severity), file_(file), line_(line) {
+  std::string_view filename(file);
+
+  auto separator = filename.find_last_of("\\/");
+  if (separator != std::string_view::npos)
+    filename.remove_prefix(separator + 1);
+
+  SYSTEMTIME time;
+  GetLocalTime(&time);
+
+  stream_ << "[\\[]"
+          // TODO(compnerd) should we size the pid and tid?
+          << GetCurrentProcessId() << ':' << GetCurrentThreadId() << ':'
+          << std::setfill('0')
+          << std::setw(2) << time.wMonth
+          << std::setw(2) << time.wDay
+          << '/'
+          << std::setw(2) << time.wHour
+          << std::setw(2) << time.wMinute
+          << std::setw(2) << time.wSecond
+          << '.'
+          << std::setw(3) << time.wMilliseconds
+          << ':'
+          << to_string(severity_)
+          << ':' << filename << '(' << line << ')'
+          << "[\\]]" << ' ';
+}
+
+log_message::~log_message() {
+  std::string message = stream_.str();
+
+  PMSIHANDLE record;
+  record = MsiCreateRecord(0);
+  (void)MsiRecordSetStringA(record, 0, message.c_str());
+  (void)MsiProcessMessage(install_, INSTALLMESSAGE_INFO, record);
+}
+
+template <>
+log_message &operator<<<std::wstring>(log_message &message,
+                                      const std::wstring &str) noexcept {
+  std::wstring_convert<std::codecvt_utf8<std::wstring::traits_type::char_type>,
+                       std::wstring::traits_type::char_type> utf8;
+  message.stream_ << utf8.to_bytes(str.data(), str.data() + str.size());
+  return message;
+}
+}

--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
@@ -1,0 +1,425 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "swift_installer.hh"
+#include "logging.hh"
+#include "scoped_raii.hh"
+
+#include <comip.h>
+#include <comdef.h>
+
+#include <algorithm>
+#include <cassert>
+#include <ciso646>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// NOTE(compnerd) `Unknwn.h` must be included before `Setup.Configuration.h` as
+// the header is not fully self-contained.
+#include <Unknwn.h>
+#include <Setup.Configuration.h>
+
+_COM_SMARTPTR_TYPEDEF(IEnumSetupInstances, __uuidof(IEnumSetupInstances));
+_COM_SMARTPTR_TYPEDEF(ISetupConfiguration, __uuidof(ISetupConfiguration));
+_COM_SMARTPTR_TYPEDEF(ISetupConfiguration2, __uuidof(ISetupConfiguration2));
+_COM_SMARTPTR_TYPEDEF(ISetupHelper, __uuidof(ISetupHelper));
+_COM_SMARTPTR_TYPEDEF(ISetupInstance, __uuidof(ISetupInstance));
+_COM_SMARTPTR_TYPEDEF(ISetupInstance2, __uuidof(ISetupInstance2));
+_COM_SMARTPTR_TYPEDEF(ISetupPackageReference, __uuidof(ISetupPackageReference));
+
+namespace {
+std::string contents(const std::filesystem::path &path) noexcept {
+  std::ostringstream buffer;
+  std::ifstream stream(path);
+  if (!stream)
+    return {};
+  buffer << stream.rdbuf();
+  return buffer.str();
+}
+
+template <typename CharType_>
+void trim(std::basic_string<CharType_> &string) noexcept {
+  string.erase(std::remove_if(std::begin(string), std::end(string),
+                              [](CharType_ ch) { return !std::isprint(ch); }),
+               std::end(string));
+}
+}
+
+// This is technically a misnomer.  We are not looking for the Windows SDK but
+// rather the Universal CRT SDK.
+//
+// The Windows SDK installation is found by querying:
+//  HKLM\SOFTWARE\[Wow6432Node]\Microsoft\Microsoft SDKs\Windows\v10.0\InstallationFolder
+// We can identify the SDK version using:
+//  HKLM\SOFTWARE\[Wow6432Node]\Microsoft\Microsoft SDKs\Windows\v10.0\ProductVersion
+//
+// We currently only query:
+//  HKLM\SOFTWARE\Microsoft\Windows Kits\Installed Roots\KitsRoot10
+// which gives us the Universal CRT installation root.
+//
+// FIXME(compnerd) we should support additional installation configurations by
+// also querying the HKCU hive.
+namespace winsdk {
+static const wchar_t kits_root_key[] = L"KitsRoot10";
+static const wchar_t kits_installed_roots_keypath[] =
+    L"SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots";
+
+std::filesystem::path install_root() noexcept {
+  DWORD cbData = 0;
+
+  if (FAILED(RegGetValueW(HKEY_LOCAL_MACHINE, kits_installed_roots_keypath,
+                          kits_root_key, RRF_RT_REG_SZ, nullptr, nullptr,
+                          &cbData)))
+    return {};
+
+  if (cbData == 0)
+    return {};
+
+  std::vector<wchar_t> buffer;
+  buffer.resize(cbData);
+
+  if (FAILED(RegGetValueW(HKEY_LOCAL_MACHINE, kits_installed_roots_keypath,
+                          kits_root_key, RRF_RT_REG_SZ, nullptr, buffer.data(),
+                          &cbData)))
+    return {};
+
+  return std::filesystem::path(buffer.data());
+}
+
+std::vector<std::wstring> available_versions() noexcept {
+  HKEY hKey;
+
+  if (FAILED(RegOpenKeyExW(HKEY_LOCAL_MACHINE, kits_installed_roots_keypath,
+                           0, KEY_READ, &hKey)))
+    return {};
+
+  windows::raii::hkey key{hKey};
+
+  DWORD cSubKeys;
+  DWORD cbMaxSubKeyLen;
+  if (FAILED(RegQueryInfoKeyW(hKey, nullptr, nullptr, nullptr, &cSubKeys,
+                              &cbMaxSubKeyLen, nullptr, nullptr, nullptr,
+                              nullptr, nullptr, nullptr)))
+    return {};
+
+  std::vector<wchar_t> buffer;
+  buffer.resize(static_cast<size_t>(cbMaxSubKeyLen) + 1);
+
+  std::vector<std::wstring> versions;
+  for (DWORD dwIndex = 0; dwIndex < cSubKeys; ++dwIndex) {
+    DWORD cchName = cbMaxSubKeyLen + 1;
+
+    // TODO(compnerd) handle error
+    (void)RegEnumKeyExW(hKey, dwIndex, buffer.data(), &cchName, nullptr,
+                        nullptr, nullptr, nullptr);
+
+    versions.emplace_back(buffer.data());
+  }
+  return versions;
+}
+}
+
+namespace msvc {
+// VS2019 v142 Build Tools
+static const wchar_t toolset_v142_x86_x64[] =
+    L"Microsoft.VisualStudio.Component.VC.Tools.x86.x64";
+static const wchar_t toolset_v142_arm[] =
+    L"Microsoft.VisualStudio.Component.VC.Tools.ARM";
+static const wchar_t toolset_v142_arm64[] =
+    L"Microsoft.VisualStudio.Component.VC.Tools.ARM64";
+static const wchar_t toolset_v142_arm64ec[] =
+    L"Microsoft.VisualStudio.Component.VC.Tools.ARM64EC";
+
+// VS2017 v141 Build Tools
+static const wchar_t toolset_v141_x86_x64[] =
+    L"Microsoft.VisualStudio.Component.VC.v141.x86.x64";
+static const wchar_t toolset_v141_arm[] =
+    L"Microsoft.VisualStudio.Component.VC.v141.ARM";
+static const wchar_t toolset_v141_arm64[] =
+    L"Microsoft.VisualStudio.Component.VC.v141.ARM64";
+
+static const wchar_t *known_toolsets[] = {
+  toolset_v142_x86_x64,
+  toolset_v142_arm64ec,
+  toolset_v142_arm64,
+  toolset_v142_arm,
+
+  toolset_v141_x86_x64,
+  toolset_v141_arm64,
+  toolset_v141_arm,
+};
+
+// The name is misleading.  This currently returns the default toolset in all
+// VS2015+ installations.
+std::vector<std::filesystem::path> available_toolsets() noexcept {
+  windows::raii::com_initializer com;
+
+  std::vector<std::filesystem::path> toolsets;
+
+  ISetupConfigurationPtr configuration;
+  if (FAILED(configuration.CreateInstance(__uuidof(SetupConfiguration))))
+    return toolsets;
+
+  ISetupConfiguration2Ptr configuration2;
+  if (FAILED(configuration->QueryInterface(&configuration2)))
+    return toolsets;
+
+  IEnumSetupInstancesPtr instances;
+  if (FAILED(configuration2->EnumAllInstances(&instances)))
+    return toolsets;
+
+  ULONG fetched;
+  ISetupInstancePtr instance;
+  while (SUCCEEDED(instances->Next(1, &instance, &fetched)) && fetched) {
+    ISetupInstance2Ptr instance2;
+    if (FAILED(instance->QueryInterface(&instance2)))
+      continue;
+
+    InstanceState state;
+    if (FAILED(instance2->GetState(&state)))
+      continue;
+
+    // Ensure that the instance state matches
+    //  eLocal: The instance installation path exists.
+    //  eRegistered: A product is registered to the instance.
+    if (~state & eLocal or ~state & eRegistered)
+      continue;
+
+    LPSAFEARRAY packages;
+    if (FAILED(instance2->GetPackages(&packages)))
+      continue;
+
+    LONG lower, upper;
+    if (FAILED(SafeArrayGetLBound(packages, 1, &lower)) ||
+        FAILED(SafeArrayGetUBound(packages, 1, &upper)))
+      continue;
+
+    for (LONG index = 0, count = upper - lower + 1; index < count; ++index) {
+      IUnknownPtr element;
+      if (FAILED(SafeArrayGetElement(packages, &index, &element)))
+        continue;
+
+      ISetupPackageReferencePtr package;
+      if (FAILED(element->QueryInterface(&package)))
+        continue;
+
+      _bstr_t package_id;
+      if (FAILED(package->GetId(package_id.GetAddress())))
+        continue;
+
+      // Ensure that we are dealing with a (known) MSVC ToolSet
+      if (std::none_of(std::begin(known_toolsets), std::end(known_toolsets),
+                      [package_id = package_id.GetBSTR()](const wchar_t *id) {
+                        return wcscmp(package_id, id) == 0;
+                      }))
+        continue;
+
+      _bstr_t VSInstallDir;
+      if (FAILED(instance2->GetInstallationPath(VSInstallDir.GetAddress())))
+        continue;
+
+      std::filesystem::path VCInstallDir{static_cast<wchar_t *>(VSInstallDir)};
+      VCInstallDir.append("VC");
+
+      std::string VCToolsVersion;
+      // VSInstallDir\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt
+      // contains the default version of the v141 MSVC toolset.  Prefer to use
+      // VSInstallDir\VC\Auxiliary\Build\Microsoft.VCToolsVersion.v142.default.txt
+      // which contains the default v142 version of the toolset.
+      for (const auto &file : {"Microsoft.VCToolsVersion.v142.default.txt",
+                               "Microsoft.VCToolsVersion.default.txt"}) {
+        std::filesystem::path path{VCInstallDir};
+        path.append("Auxiliary");
+        path.append("Build");
+        path.append(file);
+
+        VCToolsVersion = contents(path);
+        // Strip any line ending characters from the contents of the file.
+        trim(VCToolsVersion);
+        if (!VCToolsVersion.empty())
+          break;
+      }
+
+      if (VCToolsVersion.empty())
+        continue;
+
+      std::filesystem::path VCToolsInstallDir{VCInstallDir};
+      VCToolsInstallDir.append("Tools");
+      VCToolsInstallDir.append("MSVC");
+      VCToolsInstallDir.append(VCToolsVersion);
+
+      // FIXME(compnerd) should we actually just walk the directory structure
+      // instead and populate all the toolsets?  That would match roughly what
+      // we do with the UCRT currently.
+
+      toolsets.push_back(VCToolsInstallDir);
+    }
+  }
+
+  return toolsets;
+}
+}
+
+namespace msi {
+std::wstring get_property(MSIHANDLE hInstall, std::wstring_view key) noexcept {
+  DWORD size = 0;
+  UINT status;
+
+  status = MsiGetPropertyW(hInstall, key.data(), L"", &size);
+  assert(status == ERROR_MORE_DATA);
+
+  std::vector<wchar_t> buffer;
+  buffer.resize(size + 1);
+
+  size = buffer.capacity();
+  status = MsiGetPropertyW(hInstall, key.data(), buffer.data(), &size);
+  // TODO(compnerd) handle error
+
+  return {buffer.data(), buffer.capacity()};
+}
+}
+
+UINT SwiftInstaller_InstallAuxiliaryFiles(MSIHANDLE hInstall) {
+  std::wstring data = msi::get_property(hInstall, L"CustomActionData");
+  trim(data);
+
+  std::filesystem::path SDKROOT{data};
+  LOG(hInstall, info) << "SDKROOT: " << SDKROOT.string();
+
+  // Copy SDK Module Maps
+  std::filesystem::path UniversalCRTSdkDir = winsdk::install_root();
+  LOG(hInstall, info) << "UniversalCRTSdkDir: " << UniversalCRTSdkDir;
+  if (!UniversalCRTSdkDir.empty()) {
+    // FIXME(compnerd) Technically we are using the UniversalCRTSdkDir here
+    // instead of the WindowsSdkDir which would contain `um`.
+
+    // FIXME(compnerd) we may end up in a state where the ucrt and Windows SDKs
+    // do not match.  Users have reported cases where they somehow managed to
+    // setup such a configuration.  We should split this up to explicitly
+    // handle the UCRT and WinSDK paths separately.
+    for (const auto &version : winsdk::available_versions()) {
+      const struct {
+        std::filesystem::path src;
+        std::filesystem::path dst;
+      } items[] = {
+        { SDKROOT / "usr" / "share" / "ucrt.modulemap",
+          UniversalCRTSdkDir / "Include" / version / "ucrt" / "module.modulemap" },
+        { SDKROOT / "usr" / "share" / "winsdk.modulemap",
+          UniversalCRTSdkDir / "Include" / version / "um" / "module.modulemap" },
+      };
+
+      for (const auto &item : items) {
+        static const constexpr std::filesystem::copy_options options =
+            std::filesystem::copy_options::overwrite_existing;
+
+        std::error_code ec;
+        if (!std::filesystem::copy_file(item.src, item.dst, options, ec)) {
+          LOG(hInstall, error)
+              << "unable to copy " << item.src << " to " << item.dst << ": "
+              << ec.message();
+          continue;
+        }
+        LOG(hInstall, info) << "Deployed " << item.dst;
+      }
+    }
+  }
+
+  // Copy MSVC Tools Module Maps
+  for (const auto &VCToolsInstallDir : msvc::available_toolsets()) {
+    const struct {
+      std::filesystem::path src;
+      std::filesystem::path dst;
+    } items[] = {
+      { SDKROOT / "usr" / "share" / "visualc.modulemap",
+        VCToolsInstallDir / "include" / "module.modulemap" },
+      { SDKROOT / "usr" / "share" / "visualc.apinotes",
+        VCToolsInstallDir / "include" / "visualc.apinotes" },
+    };
+
+    for (const auto &item : items) {
+      static const constexpr std::filesystem::copy_options options =
+          std::filesystem::copy_options::overwrite_existing;
+
+      std::error_code ec;
+      if (!std::filesystem::copy_file(item.src, item.dst, options, ec)) {
+        LOG(hInstall, error)
+            << "unable to copy " << item.src << " to " << item.dst << ": "
+            << ec.message();
+        continue;
+      }
+      LOG(hInstall, info) << "Deployed " << item.dst;
+    }
+  }
+
+  // TODO(compnerd) it would be ideal to record the files deployed here to the
+  // `RemoveFile` table which would allow them to be cleaned up on removal.
+  // This is tricky as we cannot modify the on-disk database.  The deferred
+  // action is already executed post-InstallExecute which means that we can now
+  // identify the cached MSI by:
+  //
+  //  std::wstring product_code = msi::get_property(hInstall, L"ProductCode");
+  //
+  //  DWORD size = 0;
+  //  (void)MsiGetProductInfoW(product_code.c_str(),
+  //                           INSTALLPROPERTY_LOCALPACKAGE, L"", &size);
+  //  std::vector<wchar_t> buffer;
+  //  buffer.resize(++size);
+  //  (void)MsiGetProductInfoW(product_code.c_str(),
+  //                           INSTALLPROPERTY_LOCALPACKAGE, buffer.data(),
+  //                           &size);
+  //
+  // We can then create a new property for the location of the entry and a new
+  // RemoveFile entry for cleaning up the file.  Note that we may have to tweak
+  // things to get repairs to work properly with the tracking.
+  //
+  //  PMSIHANDLE database;
+  //  (void)MsiOpenDatabaseW(buffer.data(), MSIDBOPEN_TRANSACT, &database);
+  //
+  //  static const wchar_t query[] =
+  //      LR"SQL(
+  //INSERT INTO `Property` (`Property`, `Value`)
+  //  VALUES(?, ?);
+  //INSERT INTO `RemoveFile` (`FileKey`, `Component_`, `FileName`, `DirProperty`, `InstallMode`
+  //  VALUES (?, ?, ?, ?, ?);
+  //      )SQL";
+  //
+  //  PMSIHANDLE view;
+  //  (void)MsiDatabaseOpenViewW(database, query, &view);
+  //
+  //  std::hash<std::wstring> hasher;
+  //
+  //  std::wostringstream component;
+  //  component << "cmp" << hasher(path.wstring());
+  //
+  //  std::wostringstream property;
+  //  property << "prop" << hasher(path.wstring());
+  //
+  //  PMSIHANDLE record = MsiRecordCreate(7);
+  //  (void)MsiRecordSetStringW(record, 1, property.str().c_str());
+  //  (void)MsiRecordSetStringW(record, 2, path.parent_path().wstring().c_str());
+  //  (void)MsiRecordSetStringW(record, 3, component.str().c_str());
+  //  (void)MsiRecordSetStringW(record, 4, component.str().c_str());
+  //  (void)MsiRecordSetStringW(record, 5, path.filename().wstring().c_str());
+  //  (void)MsiRecordSetStringW(record, 6, property.str().c_str());
+  //  (void)MsiRecordSetInteger(record, 7, 2);
+  //
+  //  (void)MsiViewExecute(view, record);
+  //
+  //  (void)MsiDatabaseCommit(database);
+  //
+  // Currently, this seems to fail with the commiting of the database, which is
+  // still a mystery to me.  This relies on the clever usage of the
+  // `EnsureTable` in the WiX definition to ensure that we do not need to create
+  // the table.
+  //
+  // The error handling has been elided here for brevity's sake.
+
+  return ERROR_SUCCESS;
+}

--- a/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
+++ b/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
@@ -1,0 +1,100 @@
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <ProjectGuid>{84027311-67A4-4351-AD3A-53529767BFA0}</ProjectGuid>
+    <RootNamespace>SwiftInstaller</RootNamespace>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.default.props" />
+
+  <PropertyGroup>
+    <CharacterSet>Unicode</CharacterSet>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <TargetName>SwiftInstaller</TargetName>
+    <PlatformToolset>v142</PlatformToolset>
+    <OutDir>.build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>.build\$(Configuration)\$(Platform)\$(TargetName)\</IntDir>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir)Headers;$(ProjectDir)ThirdParty\Microsoft.VisualStudio.Setup.Configuration.Native\inc</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <PreprocessorDefinitions>SwiftInstaller_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>msi.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ItemGroup>
+    <ClCompile Include="Sources\swift_installer.cc" />
+    <ClCompile Include="Sources\dllmain.cc" />
+    <ClCompile Include="Sources\logging.cc" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="Headers\scoped_raii.hh" />
+    <ClInclude Include="Headers\swift_installer.hh" />
+    <ClInclude Include="Headers\logging.hh" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="ThirdParty\Microsoft.VisualStudio.Setup.Configuration.Native\inc\Setup.Configuration.h" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Targets" />
+</Project>

--- a/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj.filters
+++ b/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj.filters
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmls="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Sources\dllmain.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Sources\logging.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Sources\swift_installer.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="Headers\logging.hh">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Headers\scoped_raii.hh">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Headers\swift_installer.hh">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="ThirdParty\Microsoft.VisualStudio.Setup.Configuration.Native\inc\Setup.Configuration.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{485df023-ca0b-4390-b9e5-bb574625ac42}</UniqueIdentifier>
+      <Extensions>h;hh</Extensions>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{b2fa78cd-13ff-4b88-9e63-112e1ac92329}</UniqueIdentifier>
+      <Extensions>cc</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/platforms/Windows/CustomActions/SwiftInstaller/ThirdParty/Microsoft.VisualStudio.Setup.Configuration.Native/inc/Setup.Configuration.h
+++ b/platforms/Windows/CustomActions/SwiftInstaller/ThirdParty/Microsoft.VisualStudio.Setup.Configuration.Native/inc/Setup.Configuration.h
@@ -1,0 +1,1059 @@
+// The MIT License(MIT)
+// Copyright(C) Microsoft Corporation.All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+
+#pragma once
+
+// Constants
+//
+#ifndef E_NOTFOUND
+#define E_NOTFOUND HRESULT_FROM_WIN32(ERROR_NOT_FOUND)
+#endif
+
+#ifndef E_FILENOTFOUND
+#define E_FILENOTFOUND HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
+#endif
+
+#ifndef E_NOTSUPPORTED
+#define E_NOTSUPPORTED HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)
+#endif
+
+// Enumerations
+//
+/// <summary>
+/// The state of an instance.
+/// </summary>
+enum InstanceState
+{
+    /// <summary>
+    /// The instance state has not been determined.
+    /// </summary>
+    eNone = 0,
+
+    /// <summary>
+    /// The instance installation path exists.
+    /// </summary>
+    eLocal = 1,
+
+    /// <summary>
+    /// A product is registered to the instance.
+    /// </summary>
+    eRegistered = 2,
+
+    /// <summary>
+    /// No reboot is required for the instance.
+    /// </summary>
+    eNoRebootRequired = 4,
+
+    /// <summary>
+    /// No errors were reported for the instance.
+    /// </summary>
+    eNoErrors = 8,
+
+    /// <summary>
+    /// The instance represents a complete install.
+    /// </summary>
+    eComplete = MAXUINT,
+};
+
+// Forward interface declarations
+//
+#ifndef __ISetupInstance_FWD_DEFINED__
+#define __ISetupInstance_FWD_DEFINED__
+typedef struct ISetupInstance ISetupInstance;
+#endif
+
+#ifndef __ISetupInstance2_FWD_DEFINED__
+#define __ISetupInstance2_FWD_DEFINED__
+typedef struct ISetupInstance2 ISetupInstance2;
+#endif
+
+#ifndef __ISetupInstanceCatalog_FWD_DEFINED__
+#define __ISetupInstanceCatalog_FWD_DEFINED__
+typedef struct ISetupInstanceCatalog ISetupInstanceCatalog;
+#endif
+
+#ifndef __ISetupLocalizedProperties_FWD_DEFINED__
+#define __ISetupLocalizedProperties_FWD_DEFINED__
+typedef struct ISetupLocalizedProperties ISetupLocalizedProperties;
+#endif
+
+#ifndef __IEnumSetupInstances_FWD_DEFINED__
+#define __IEnumSetupInstances_FWD_DEFINED__
+typedef struct IEnumSetupInstances IEnumSetupInstances;
+#endif
+
+#ifndef __ISetupConfiguration_FWD_DEFINED__
+#define __ISetupConfiguration_FWD_DEFINED__
+typedef struct ISetupConfiguration ISetupConfiguration;
+#endif
+
+#ifndef __ISetupConfiguration2_FWD_DEFINED__
+#define __ISetupConfiguration2_FWD_DEFINED__
+typedef struct ISetupConfiguration2 ISetupConfiguration2;
+#endif
+
+#ifndef __ISetupPackageReference_FWD_DEFINED__
+#define __ISetupPackageReference_FWD_DEFINED__
+typedef struct ISetupPackageReference ISetupPackageReference;
+#endif
+
+#ifndef __ISetupProductReference_FWD_DEFINED__
+#define __ISetupProductReference_FWD_DEFINED__
+typedef struct ISetupProductReference ISetupProductReference;
+#endif
+
+#ifndef __ISetupProductReference2_FWD_DEFINED__
+#define __ISetupProductReference2_FWD_DEFINED__
+typedef struct ISetupProductReference2 ISetupProductReference2;
+#endif
+
+#ifndef __ISetupHelper_FWD_DEFINED__
+#define __ISetupHelper_FWD_DEFINED__
+typedef struct ISetupHelper ISetupHelper;
+#endif
+
+#ifndef __ISetupErrorInfo_FWD_DEFINED__
+#define __ISetupErrorInfo_FWD_DEFINED__
+typedef struct ISetupErrorInfo ISetupErrorInfo;
+#endif
+
+#ifndef __ISetupErrorState_FWD_DEFINED__
+#define __ISetupErrorState_FWD_DEFINED__
+typedef struct ISetupErrorState ISetupErrorState;
+#endif
+
+#ifndef __ISetupErrorState2_FWD_DEFINED__
+#define __ISetupErrorState2_FWD_DEFINED__
+typedef struct ISetupErrorState2 ISetupErrorState2;
+#endif
+
+#ifndef __ISetupErrorState3_FWD_DEFINED__
+#define __ISetupErrorState3_FWD_DEFINED__
+typedef struct ISetupErrorState3 ISetupErrorState3;
+#endif
+
+#ifndef __ISetupFailedPackageReference_FWD_DEFINED__
+#define __ISetupFailedPackageReference_FWD_DEFINED__
+typedef struct ISetupFailedPackageReference ISetupFailedPackageReference;
+#endif
+
+#ifndef __ISetupFailedPackageReference2_FWD_DEFINED__
+#define __ISetupFailedPackageReference2_FWD_DEFINED__
+typedef struct ISetupFailedPackageReference2 ISetupFailedPackageReference2;
+#endif
+
+#ifndef __ISetupFailedPackageReference3_FWD_DEFINED__
+#define __ISetupFailedPackageReference3_FWD_DEFINED__
+typedef struct ISetupFailedPackageReference3 ISetupFailedPackageReference3;
+#endif
+
+#ifndef __ISetupPropertyStore_FWD_DEFINED__
+#define __ISetupPropertyStore_FWD_DEFINED__
+typedef struct ISetupPropertyStore ISetupPropertyStore;
+#endif
+
+#ifndef __ISetupLocalizedPropertyStore_FWD_DEFINED__
+#define __ISetupLocalizedPropertyStore_FWD_DEFINED__
+typedef struct ISetupLocalizedPropertyStore ISetupLocalizedPropertyStore;
+#endif
+
+#ifndef __ISetupPolicy_FWD_DEFINED__
+#define __ISetupPolicy_FWD_DEFINED__
+typedef struct ISetupPolicy ISetupPolicy;
+#endif
+
+// Forward class declarations
+//
+#ifndef __SetupConfiguration_FWD_DEFINED__
+#define __SetupConfiguration_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class SetupConfiguration SetupConfiguration;
+#endif
+
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Interface definitions
+//
+EXTERN_C const IID IID_ISetupInstance;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Information about an instance of a product.
+/// </summary>
+struct DECLSPEC_UUID("B41463C3-8866-43B5-BC33-2B0676F7F42E") DECLSPEC_NOVTABLE ISetupInstance : public IUnknown
+{
+    /// <summary>
+    /// Gets the instance identifier (should match the name of the parent instance directory).
+    /// </summary>
+    /// <param name="pbstrInstanceId">The instance identifier.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist.</returns>
+    STDMETHOD(GetInstanceId)(
+        _Out_ BSTR* pbstrInstanceId
+        ) = 0;
+
+    /// <summary>
+    /// Gets the local date and time when the installation was originally installed.
+    /// </summary>
+    /// <param name="pInstallDate">The local date and time when the installation was originally installed.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property is not defined.</returns>
+    STDMETHOD(GetInstallDate)(
+        _Out_ LPFILETIME pInstallDate
+        ) = 0;
+
+    /// <summary>
+    /// Gets the unique name of the installation, often indicating the branch and other information used for telemetry.
+    /// </summary>
+    /// <param name="pbstrInstallationName">The unique name of the installation, often indicating the branch and other information used for telemetry.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property is not defined.</returns>
+    STDMETHOD(GetInstallationName)(
+        _Out_ BSTR* pbstrInstallationName
+        ) = 0;
+
+    /// <summary>
+    /// Gets the path to the installation root of the product.
+    /// </summary>
+    /// <param name="pbstrInstallationPath">The path to the installation root of the product.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property is not defined.</returns>
+    STDMETHOD(GetInstallationPath)(
+        _Out_ BSTR* pbstrInstallationPath
+        ) = 0;
+
+    /// <summary>
+    /// Gets the version of the product installed in this instance.
+    /// </summary>
+    /// <param name="pbstrInstallationVersion">The version of the product installed in this instance.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property is not defined.</returns>
+    STDMETHOD(GetInstallationVersion)(
+        _Out_ BSTR* pbstrInstallationVersion
+        ) = 0;
+
+    /// <summary>
+    /// Gets the display name (title) of the product installed in this instance.
+    /// </summary>
+    /// <param name="lcid">The LCID for the display name.</param>
+    /// <param name="pbstrDisplayName">The display name (title) of the product installed in this instance.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property is not defined.</returns>
+    STDMETHOD(GetDisplayName)(
+        _In_ LCID lcid,
+        _Out_ BSTR* pbstrDisplayName
+        ) = 0;
+
+    /// <summary>
+    /// Gets the description of the product installed in this instance.
+    /// </summary>
+    /// <param name="lcid">The LCID for the description.</param>
+    /// <param name="pbstrDescription">The description of the product installed in this instance.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property is not defined.</returns>
+    STDMETHOD(GetDescription)(
+        _In_ LCID lcid,
+        _Out_ BSTR* pbstrDescription
+        ) = 0;
+
+    /// <summary>
+    /// Resolves the optional relative path to the root path of the instance.
+    /// </summary>
+    /// <param name="pwszRelativePath">A relative path within the instance to resolve, or NULL to get the root path.</param>
+    /// <param name="pbstrAbsolutePath">The full path to the optional relative path within the instance. If the relative path is NULL, the root path will always terminate in a backslash.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property is not defined.</returns>
+    STDMETHOD(ResolvePath)(
+        _In_opt_z_ LPCOLESTR pwszRelativePath,
+        _Out_ BSTR* pbstrAbsolutePath
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupInstance2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Information about an instance of a product.
+/// </summary>
+struct DECLSPEC_UUID("89143C9A-05AF-49B0-B717-72E218A2185C") DECLSPEC_NOVTABLE ISetupInstance2 : public ISetupInstance
+{
+    /// <summary>
+    /// Gets the state of the instance.
+    /// </summary>
+    /// <param name="pState">The state of the instance.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist.</returns>
+    STDMETHOD(GetState)(
+        _Out_ InstanceState* pState
+        ) = 0;
+
+    /// <summary>
+    /// Gets an array of package references registered to the instance.
+    /// </summary>
+    /// <param name="ppsaPackages">Pointer to an array of <see cref="ISetupPackageReference"/>.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the packages property is not defined.</returns>
+    STDMETHOD(GetPackages)(
+        _Out_ LPSAFEARRAY* ppsaPackages
+        ) = 0;
+
+    /// <summary>
+    /// Gets a pointer to the <see cref="ISetupPackageReference"/> that represents the registered product.
+    /// </summary>
+    /// <param name="ppPackage">Pointer to an instance of <see cref="ISetupPackageReference"/>. This may be NULL if <see cref="GetState"/> does not return <see cref="eComplete"/>.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the packages property is not defined.</returns>
+    STDMETHOD(GetProduct)(
+        _Outptr_result_maybenull_ ISetupPackageReference** ppPackage
+        ) = 0;
+
+    /// <summary>
+    /// Gets the relative path to the product application, if available.
+    /// </summary>
+    /// <param name="pbstrProductPath">The relative path to the product application, if available.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist.</returns>
+    STDMETHOD(GetProductPath)(
+        _Outptr_result_maybenull_ BSTR* pbstrProductPath
+        ) = 0;
+
+    /// <summary>
+    /// Gets the error state of the instance, if available.
+    /// </summary>
+    /// <param name="pErrorState">The error state of the instance, if available.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist.</returns>
+    STDMETHOD(GetErrors)(
+        _Outptr_result_maybenull_ ISetupErrorState** ppErrorState
+        ) = 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the instance can be launched.
+    /// </summary>
+    /// <param name="pfIsLaunchable">Whether the instance can be launched.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    /// <remarks>
+    /// An instance could have had errors during install but still be launched. Some features may not work correctly, but others will.
+    /// </remarks>
+    STDMETHOD(IsLaunchable)(
+        _Out_ VARIANT_BOOL* pfIsLaunchable
+        ) = 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the instance is complete.
+    /// </summary>
+    /// <param name="pfIsLaunchable">Whether the instance is complete.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    /// <remarks>
+    /// An instance is complete if it had no errors during install, resume, or repair.
+    /// </remarks>
+    STDMETHOD(IsComplete)(
+        _Out_ VARIANT_BOOL* pfIsComplete
+        ) = 0;
+
+    /// <summary>
+    /// Gets product-specific properties.
+    /// </summary>
+    /// <param name="ppPropeties">A pointer to an instance of <see cref="ISetupPropertyStore"/>. This may be NULL if no properties are defined.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist.</returns>
+    STDMETHOD(GetProperties)(
+        _Outptr_result_maybenull_ ISetupPropertyStore** ppProperties
+        ) = 0;
+
+    /// <summary>
+    /// Gets the directory path to the setup engine that installed the instance.
+    /// </summary>
+    /// <param name="pbstrEnginePath">The directory path to the setup engine that installed the instance.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist.</returns>
+    STDMETHOD(GetEnginePath)(
+        _Outptr_result_maybenull_ BSTR* pbstrEnginePath
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupInstanceCatalog;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Information about a catalog used to install an instance.
+/// </summary>
+struct DECLSPEC_UUID("9AD8E40F-39A2-40F1-BF64-0A6C50DD9EEB") DECLSPEC_NOVTABLE ISetupInstanceCatalog : public IUnknown
+{
+    /// <summary>
+    /// Gets catalog information properties.
+    /// </summary>
+    /// <param name="ppCatalogInfo">A pointer to an instance of <see cref="ISetupPropertyStore"/>.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property does not exist.</returns>
+    STDMETHOD(GetCatalogInfo)(
+        _Out_ ISetupPropertyStore** ppCatalogInfo
+    ) = 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the catalog is a prerelease.
+    /// </summary>
+    /// <param name="pfIsPrerelease">Whether the catalog for the instance is a prerelease version.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_FILENOTFOUND if the instance state does not exist and E_NOTFOUND if the property does not exist.</returns>
+    STDMETHOD(IsPrerelease)(
+        _Out_ VARIANT_BOOL* pfIsPrerelease
+    ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupLocalizedProperties;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Provides localized properties of an instance of a product.
+/// </summary>
+struct DECLSPEC_UUID("F4BD7382-FE27-4AB4-B974-9905B2A148B0") DECLSPEC_NOVTABLE ISetupLocalizedProperties : public IUnknown
+{
+    /// <summary>
+    /// Gets localized product-specific properties.
+    /// </summary>
+    /// <param name="ppLocalizedProperties">A pointer to an instance of <see cref="ISetupLocalizedPropertyStore"/>. This may be NULL if no properties are defined.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetLocalizedProperties)(
+        _Outptr_result_maybenull_ ISetupLocalizedPropertyStore** ppLocalizedProperties
+    ) = 0;
+
+    /// <summary>
+    /// Gets localized channel-specific properties.
+    /// </summary>
+    /// <param name="ppLocalizedChannelProperties">A pointer to an instance of <see cref="ISetupLocalizedPropertyStore"/>. This may be NULL if no channel properties are defined.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetLocalizedChannelProperties)(
+        _Outptr_result_maybenull_ ISetupLocalizedPropertyStore** ppLocalizedChannelProperties
+    ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_IEnumSetupInstances;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// An enumerator of installed <see cref="ISetupInstance"/> objects.
+/// </summary>
+struct DECLSPEC_UUID("6380BCFF-41D3-4B2E-8B2E-BF8A6810C848") DECLSPEC_NOVTABLE IEnumSetupInstances : public IUnknown
+{
+    /// <summary>
+    /// Retrieves the next set of product instances in the enumeration sequence.
+    /// </summary>
+    /// <param name="celt">The number of product instances to retrieve.</param>
+    /// <param name="rgelt">A pointer to an array of <see cref="ISetupInstance"/>.</param>
+    /// <param name="pceltFetched">A pointer to the number of product instances retrieved. If <paramref name="celt"/> is 1 this parameter may be NULL.</param>
+    /// <returns>S_OK if the number of elements were fetched, S_FALSE if nothing was fetched (at end of enumeration), E_INVALIDARG if <paramref name="celt"/> is greater than 1 and pceltFetched is NULL, or E_OUTOFMEMORY if an <see cref="ISetupInstance"/> could not be allocated.</returns>
+    STDMETHOD(Next)(
+        _In_ ULONG celt,
+        _Out_writes_to_(celt, *pceltFetched) ISetupInstance** rgelt,
+        _Out_opt_ _Deref_out_range_(0, celt) ULONG* pceltFetched
+        ) = 0;
+
+    /// <summary>
+    /// Skips the next set of product instances in the enumeration sequence.
+    /// </summary>
+    /// <param name="celt">The number of product instances to skip.</param>
+    /// <returns>S_OK if the number of elements could be skipped; otherwise, S_FALSE;</returns>
+    STDMETHOD(Skip)(
+        _In_ ULONG celt
+        ) = 0;
+
+    /// <summary>
+    /// Resets the enumeration sequence to the beginning.
+    /// </summary>
+    /// <returns>Always returns S_OK;</returns>
+    STDMETHOD(Reset)(void) = 0;
+
+    /// <summary>
+    /// Creates a new enumeration object in the same state as the current enumeration object: the new object points to the same place in the enumeration sequence.
+    /// </summary>
+    /// <param name="ppenum">A pointer to a pointer to a new <see cref="IEnumSetupInstances"/> interface. If the method fails, this parameter is undefined.</param>
+    /// <returns>S_OK if a clone was returned; otherwise, E_OUTOFMEMORY.</returns>
+    STDMETHOD(Clone)(
+        _Deref_out_opt_ IEnumSetupInstances** ppenum
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupConfiguration;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Gets information about product instances installed on the machine.
+/// </summary>
+struct DECLSPEC_UUID("42843719-DB4C-46C2-8E7C-64F1816EFD5B") DECLSPEC_NOVTABLE ISetupConfiguration : public IUnknown
+{
+    /// <summary>
+    /// Enumerates all launchable product instances installed.
+    /// </summary>
+    /// <param name="ppEnumInstances">An enumeration of completed, installed product instances.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(EnumInstances)(
+        _Out_ IEnumSetupInstances** ppEnumInstances
+        ) = 0;
+
+    /// <summary>
+    /// Gets the instance for the current process path.
+    /// </summary>
+    /// <param name="ppInstance">The instance for the current process path.</param>
+    /// <returns>
+    /// The instance for the current process path, or E_NOTFOUND if not found.
+    /// The <see cref="ISetupInstance::GetState"/> may indicate the instance is invalid.
+    /// </returns>
+    /// <remarks>
+    /// The returned instance may not be launchable.
+    /// </remarks>
+STDMETHOD(GetInstanceForCurrentProcess)(
+        _Out_ ISetupInstance** ppInstance
+        ) = 0;
+
+    /// <summary>
+    /// Gets the instance for the given path.
+    /// </summary>
+    /// <param name="ppInstance">The instance for the given path.</param>
+    /// <returns>
+    /// The instance for the given path, or E_NOTFOUND if not found.
+    /// The <see cref="ISetupInstance::GetState"/> may indicate the instance is invalid.
+    /// </returns>
+    /// <remarks>
+    /// The returned instance may not be launchable.
+    /// </remarks>
+STDMETHOD(GetInstanceForPath)(
+        _In_z_ LPCWSTR wzPath,
+        _Out_ ISetupInstance** ppInstance
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupConfiguration2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Gets information about product instances.
+/// </summary>
+struct DECLSPEC_UUID("26AAB78C-4A60-49D6-AF3B-3C35BC93365D") DECLSPEC_NOVTABLE ISetupConfiguration2 : public ISetupConfiguration
+{
+    /// <summary>
+    /// Enumerates all product instances.
+    /// </summary>
+    /// <param name="ppEnumInstances">An enumeration of all product instances.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(EnumAllInstances)(
+        _Out_ IEnumSetupInstances** ppEnumInstances
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupPackageReference;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// A reference to a package.
+/// </summary>
+struct DECLSPEC_UUID("da8d8a16-b2b6-4487-a2f1-594ccccd6bf5") DECLSPEC_NOVTABLE ISetupPackageReference : public IUnknown
+{
+    /// <summary>
+    /// Gets the general package identifier.
+    /// </summary>
+    /// <param name="pbstrId">The general package identifier.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetId)(
+        _Out_ BSTR* pbstrId
+        ) = 0;
+
+    /// <summary>
+    /// Gets the version of the package.
+    /// </summary>
+    /// <param name="pbstrVersion">The version of the package.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetVersion)(
+        _Out_ BSTR* pbstrVersion
+        ) = 0;
+
+    /// <summary>
+    /// Gets the target process architecture of the package.
+    /// </summary>
+    /// <param name="pbstrChip">The target process architecture of the package.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetChip)(
+        _Out_ BSTR* pbstrChip
+        ) = 0;
+
+    /// <summary>
+    /// Gets the language and optional region identifier.
+    /// </summary>
+    /// <param name="pbstrLanguage">The language and optional region identifier.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetLanguage)(
+        _Out_ BSTR* pbstrLanguage
+        ) = 0;
+
+    /// <summary>
+    /// Gets the build branch of the package.
+    /// </summary>
+    /// <param name="pbstrBranch">The build branch of the package.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetBranch)(
+        _Out_ BSTR* pbstrBranch
+        ) = 0;
+
+    /// <summary>
+    /// Gets the type of the package.
+    /// </summary>
+    /// <param name="pbstrType">The type of the package.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetType)(
+        _Out_ BSTR* pbstrType
+        ) = 0;
+
+    /// <summary>
+    /// Gets the unique identifier consisting of all defined tokens.
+    /// </summary>
+    /// <param name="pbstrUniqueId">The unique identifier consisting of all defined tokens.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_UNEXPECTED if no Id was defined (required).</returns>
+    STDMETHOD(GetUniqueId)(
+        _Out_ BSTR* pbstrUniqueId
+        ) = 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the package refers to an external extension.
+    /// </summary>
+    /// <param name="pfIsExtension">A value indicating whether the package refers to an external extension.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_UNEXPECTED if no Id was defined (required).</returns>
+    STDMETHOD(GetIsExtension)(
+        _Out_ VARIANT_BOOL* pfIsExtension
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupProductReference;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// A reference to a product package.
+/// </summary>
+struct DECLSPEC_UUID("a170b5ef-223d-492b-b2d4-945032980685") DECLSPEC_NOVTABLE ISetupProductReference : public ISetupPackageReference
+{
+    /// <summary>
+    /// Gets a value indicating whether the product package is installed.
+    /// </summary>
+    /// <param name="pfIsInstalled">A value indicating whether the product package is installed.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_NOTSUPPORTED if the reference is not to a product, or E_UNEXPECTED if the Installed property is the wrong type.</returns>
+    STDMETHOD(GetIsInstalled)(
+        _Out_ VARIANT_BOOL* pfIsInstalled
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupProductReference2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// A reference to a product package.
+/// </summary>
+struct DECLSPEC_UUID("279a5db3-7503-444b-b34d-308f961b9a06") DECLSPEC_NOVTABLE ISetupProductReference2 : public ISetupProductReference
+{
+    /// <summary>
+    /// Gets a value indicating whether the product supports extensions.
+    /// </summary>
+    /// <param name="pfSupportsExtensions">A value indicating whether the product supports extensions.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_NOTSUPPORTED if the reference is not to a product, or E_UNEXPECTED if the SupportsExtensions property is the wrong type.</returns>
+    STDMETHOD(GetSupportsExtensions)(
+        _Out_ VARIANT_BOOL* pfSupportsExtensions
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupHelper;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Helper functions.
+/// </summary>
+/// <remarks>
+/// You can query for this interface from the <see cref="SetupConfiguration"/> class.
+/// </remarks>
+struct DECLSPEC_UUID("42b21b78-6192-463e-87bf-d577838f1d5c") DECLSPEC_NOVTABLE ISetupHelper : public IUnknown
+{
+    /// <summary>
+    /// Parses a dotted quad version string into a 64-bit unsigned integer.
+    /// </summary>
+    /// <param name="pwszVersion">The dotted quad version string to parse, e.g. 1.2.3.4.</param>
+    /// <param name="pullVersion">A 64-bit unsigned integer representing the version. You can compare this to other versions.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_INVALIDARG if the version is not valid.</returns>
+    STDMETHOD(ParseVersion)(
+        _In_ LPCOLESTR pwszVersion,
+        _Out_ PULONGLONG pullVersion
+        ) = 0;
+
+    /// <summary>
+    /// Parses a dotted quad version string into a 64-bit unsigned integer.
+    /// </summary>
+    /// <param name="pwszVersionRange">The string containing 1 or 2 dotted quad version strings to parse, e.g. [1.0,) that means 1.0.0.0 or newer.</param>
+    /// <param name="pullMinVersion">A 64-bit unsigned integer representing the minimum version, which may be 0. You can compare this to other versions.</param>
+    /// <param name="pullMaxVersion">A 64-bit unsigned integer representing the maximum version, which may be MAXULONGLONG. You can compare this to other versions.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_INVALIDARG if the version range is not valid.</returns>
+    STDMETHOD(ParseVersionRange)(
+        _In_ LPCOLESTR pwszVersionRange,
+        _Out_ PULONGLONG pullMinVersion,
+        _Out_ PULONGLONG pullMaxVersion
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupErrorInfo;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Information about errors that occured during install of an instance.
+/// </summary>
+/// <remarks>
+/// Objects may also implement <see cref="IErrorInfo"/> and <see cref="ISetupPropertyStore"/>.
+/// </remarks>
+struct DECLSPEC_UUID("2A2F3292-958E-4905-B36E-013BE84E27AB") DECLSPEC_NOVTABLE ISetupErrorInfo : public IUnknown
+{
+    /// <summary>
+    /// Gets the HRESULT of the error.
+    /// </summary>
+    /// <param name="plHResult">The HRESULT of the error.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetErrorHResult)(
+        _Out_ HRESULT* plHResult
+    ) = 0;
+
+    /// <summary>
+    /// Gets the class name of the error (exception).
+    /// </summary>
+    /// <param name="pbstrClassName">The class name of the error (exception).</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetErrorClassName)(
+        _Outptr_result_maybenull_ BSTR* pbstrClassName
+    ) = 0;
+
+    /// <summary>
+    /// Gets the error message.
+    /// </summary>
+    /// <param name="pbstrMessage">The error message.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetErrorMessage)(
+        _Outptr_result_maybenull_ BSTR* pbstrMessage
+    ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupErrorState;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Information about the error state of an instance.
+/// </summary>
+struct DECLSPEC_UUID("46DCCD94-A287-476A-851E-DFBC2FFDBC20") DECLSPEC_NOVTABLE ISetupErrorState : public IUnknown
+{
+    /// <summary>
+    /// Gets an array of failed package references.
+    /// </summary>
+    /// <param name="ppsaPackages">Pointer to an array of <see cref="ISetupFailedPackageReference"/>, if packages have failed.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetFailedPackages)(
+        _Outptr_result_maybenull_ LPSAFEARRAY* ppsaFailedPackages
+        ) = 0;
+
+    /// <summary>
+    /// Gets an array of skipped package references.
+    /// </summary>
+    /// <param name="ppsaPackages">Pointer to an array of <see cref="ISetupPackageReference"/>, if packages have been skipped.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetSkippedPackages)(
+        _Outptr_result_maybenull_ LPSAFEARRAY* ppsaSkippedPackages
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupErrorState2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Information about the error state of an instance.
+/// </summary>
+struct DECLSPEC_UUID("9871385B-CA69-48F2-BC1F-7A37CBF0B1EF") DECLSPEC_NOVTABLE ISetupErrorState2 : public ISetupErrorState
+{
+    /// <summary>
+    /// Gets the path to the error log.
+    /// </summary>
+    /// <param name="pbstrChip">The path to the error log.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetErrorLogFilePath)(
+        _Outptr_result_maybenull_ BSTR* pbstrErrorLogFilePath
+        ) = 0;
+
+    /// <summary>
+    /// Gets the path to the main setup log.
+    /// </summary>
+    /// <param name="pbstrChip">The path to the main setup log.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetLogFilePath)(
+        _Outptr_result_maybenull_ BSTR* pbstrLogFilePath
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupErrorState3;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Information about the error state of an instance.
+/// </summary>
+struct DECLSPEC_UUID("290019AD-28E2-46D5-9DE5-DA4B6BCF8057") DECLSPEC_NOVTABLE ISetupErrorState3 : public ISetupErrorState2
+{
+    /// <summary>
+    /// Gets the runtime error that occured during install of an instance.
+    /// </summary>
+    /// <param name="pbstrChip">The runtime error that occured during install of an instance.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetRuntimeError)(
+        _Outptr_result_maybenull_ ISetupErrorInfo** ppErrorInfo
+        ) = 0;
+};
+#endif
+
+EXTERN_C const IID IID_ISetupFailedPackageReference;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// A reference to a failed package.
+/// </summary>
+struct DECLSPEC_UUID("E73559CD-7003-4022-B134-27DC650B280F") DECLSPEC_NOVTABLE ISetupFailedPackageReference : public ISetupPackageReference
+{
+};
+
+#endif
+
+EXTERN_C const IID IID_ISetupFailedPackageReference2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// A reference to a failed package.
+/// </summary>
+struct DECLSPEC_UUID("0FAD873E-E874-42E3-B268-4FE2F096B9CA") DECLSPEC_NOVTABLE ISetupFailedPackageReference2 : public ISetupFailedPackageReference
+{
+    /// <summary>
+    /// Gets the path to the optional package log.
+    /// </summary>
+    /// <param name="pbstrId">The path to the optional package log.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetLogFilePath)(
+        _Outptr_result_maybenull_ BSTR* pbstrLogFilePath
+        ) = 0;
+
+    /// <summary>
+    /// Gets the description of the package failure.
+    /// </summary>
+    /// <param name="pbstrId">The description of the package failure.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetDescription)(
+        _Outptr_result_maybenull_ BSTR* pbstrDescription
+        ) = 0;
+
+    /// <summary>
+    /// Gets the signature to use for feedback reporting.
+    /// </summary>
+    /// <param name="pbstrId">The signature to use for feedback reporting.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetSignature)(
+        _Outptr_result_maybenull_ BSTR* pbstrSignature
+        ) = 0;
+
+    /// <summary>
+    ///  Gets the array of details for this package failure.
+    /// </summary>
+    /// <param name="ppsaDetails">Pointer to an array of details as BSTRs.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetDetails)(
+        _Out_ LPSAFEARRAY* ppsaDetails
+        ) = 0;
+
+    /// <summary>
+    /// Gets an array of packages affected by this package failure.
+    /// </summary>
+    /// <param name="ppsaPackages">Pointer to an array of <see cref="ISetupPackageReference"/> for packages affected by this package failure. This may be NULL.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetAffectedPackages)(
+        _Out_ LPSAFEARRAY* ppsaAffectedPackages
+        ) = 0;
+};
+
+#endif
+
+EXTERN_C const IID IID_ISetupFailedPackageReference3;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// A reference to a failed package.
+/// </summary>
+struct DECLSPEC_UUID("EBC3AE68-AD15-44E8-8377-39DBF0316F6C") DECLSPEC_NOVTABLE ISetupFailedPackageReference3 : public ISetupFailedPackageReference2
+{
+    /// <summary>
+    /// Gets the action attempted when the package failed.
+    /// </summary>
+    /// <param name="pbstrAction">The action, eg: Install, Download, etc.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetAction)(
+        _Outptr_result_maybenull_ BSTR* pbstrAction
+        ) = 0;
+
+    /// <summary>
+    /// Gets the return code of the failure.
+    /// </summary>
+    /// <param name="pbstrReturnCode">The return code.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetReturnCode)(
+        _Outptr_result_maybenull_ BSTR* pbstrReturnCode
+        ) = 0;
+};
+
+#endif
+
+EXTERN_C const IID IID_ISetupPropertyStore;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Provides named properties.
+/// </summary>
+/// <remarks>
+/// You can get this from an <see cref="ISetupInstance"/>, <see cref="ISetupPackageReference"/>, or derivative.
+/// </remarks>
+struct DECLSPEC_UUID("C601C175-A3BE-44BC-91F6-4568D230FC83") DECLSPEC_NOVTABLE ISetupPropertyStore : public IUnknown
+{
+    /// <summary>
+    /// Gets an array of property names in this property store.
+    /// </summary>
+    /// <param name="ppsaNames">Pointer to an array of property names as BSTRs.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetNames)(
+        _Out_ LPSAFEARRAY* ppsaNames
+        ) = 0;
+
+    /// <summary>
+    /// Gets the value of a named property in this property store.
+    /// </summary>
+    /// <param name="pwszName">The name of the property to get.</param>
+    /// <param name="pvtValue">The value of the property.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_NOTFOUND if the property is not defined or E_NOTSUPPORTED if the property type is not supported.</returns>
+    STDMETHOD(GetValue)(
+        _In_ LPCOLESTR pwszName,
+        _Out_ LPVARIANT pvtValue
+        ) = 0;
+};
+
+#endif
+
+EXTERN_C const IID IID_ISetupLocalizedPropertyStore;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Provides localized named properties.
+/// </summary>
+/// <remarks>
+/// You can get this from an <see cref="ISetupLocalizedProperties"/>.
+/// </remarks>
+struct DECLSPEC_UUID("5BB53126-E0D5-43DF-80F1-6B161E5C6F6C") DECLSPEC_NOVTABLE ISetupLocalizedPropertyStore : public IUnknown
+{
+    /// <summary>
+    /// Gets an array of property names in this property store.
+    /// </summary>
+    /// <param name="lcid">The LCID for the property names.</param>
+    /// <param name="ppsaNames">Pointer to an array of property names as BSTRs.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetNames)(
+        _In_ LCID lcid,
+        _Out_ LPSAFEARRAY* ppsaNames
+        ) = 0;
+
+    /// <summary>
+    /// Gets the value of a named property in this property store.
+    /// </summary>
+    /// <param name="pwszName">The name of the property to get.</param>
+    /// <param name="lcid">The LCID for the property.</param>
+    /// <param name="pvtValue">The value of the property.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_NOTFOUND if the property is not defined or E_NOTSUPPORTED if the property type is not supported.</returns>
+    STDMETHOD(GetValue)(
+        _In_ LPCOLESTR pwszName,
+        _In_ LCID lcid,
+        _Out_ LPVARIANT pvtValue
+        ) = 0;
+};
+
+#endif
+
+EXTERN_C const IID IID_ISetupPolicy;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+/// <summary>
+/// Gets setup policy values.
+/// </summary>
+/// <remarks>
+/// You can get this from an <see cref="ISetupConfiguration"/>.
+/// </remarks>
+struct DECLSPEC_UUID("E1DA4CBD-64C4-4C44-821D-98FAB64C4DA7") DECLSPEC_NOVTABLE ISetupPolicy : public IUnknown
+{
+    /// <summary>
+    /// Gets the value of the SharedInstallationPath policy.
+    /// </summary>
+    /// <param name="pbstrSharedInstallationPath">The value of the SharedInstallationPath policy.</param>
+    /// <returns>Standard HRESULT indicating success or failure.</returns>
+    STDMETHOD(GetSharedInstallationPath)(
+        _Out_ BSTR* pbstrSharedInstallationPath
+        ) = 0;
+
+    /// <summary>
+    /// Gets the value of a named policy.
+    /// </summary>
+    /// <param name="pwszName">The name of the policy to get.</param>
+    /// <param name="pvtValue">The value of the named policy.</param>
+    /// <returns>Standard HRESULT indicating success or failure, including E_NOTSUPPORTED if the policy is not supported by this implementation.</returns>
+    STDMETHOD(GetValue)(
+        _In_ LPCOLESTR pwszName,
+        _Out_ LPVARIANT pvtValue
+        ) = 0;
+};
+
+#endif
+
+// Class declarations
+//
+EXTERN_C const CLSID CLSID_SetupConfiguration;
+
+#ifdef __cplusplus
+/// <summary>
+/// This class implements <see cref="ISetupConfiguration"/>, <see cref="ISetupConfiguration2"/>, and <see cref="ISetupHelper"/>.
+/// </summary>
+class DECLSPEC_UUID("177F0C4A-1CD3-4DE7-A32C-71DBBB9FA36D") SetupConfiguration;
+#endif
+
+// Function declarations
+//
+/// <summary>
+/// Gets an <see cref="ISetupConfiguration"/> that provides information about product instances installed on the machine.
+/// </summary>
+/// <param name="ppConfiguration">The <see cref="ISetupConfiguration"/> that provides information about product instances installed on the machine.</param>
+/// <param name="pReserved">Reserved for future use.</param>
+/// <returns>Standard HRESULT indicating success or failure.</returns>
+STDMETHODIMP GetSetupConfiguration(
+    _Out_ ISetupConfiguration** ppConfiguration,
+    _Reserved_ LPVOID pReserved
+);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This adds the custom action that is needed for the Swift Installer.
This is responsible for automating the deployment of the support files
for the Windows SDK and Visual C++ SDK.