### PR TITLE
Windows: restore SwiftInstaller Custom Action

### DIFF
--- a/platforms/Windows/CustomActions/SwiftInstaller/Headers/logging.hh
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Headers/logging.hh
@@ -1,0 +1,62 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SWIFT_INSTALLER_HEADERS_LOGGING_HH
+#define SWIFT_INSTALLER_HEADERS_LOGGING_HH
+
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <MsiQuery.h>
+#include <Msi.h>
+
+#include <string>
+#include <sstream>
+
+namespace msi::logging {
+enum class severity {
+  info,     /// INSTALLMESSAGE_INFO
+  warning,  /// INSTALLMESSAGE_WARNING
+  error,    /// INSTALLMESSAGE_ERROR
+  fatal,    /// INSTALLMESSAGE_FATALEXIT
+};
+
+class log_message {
+  MSIHANDLE install_;
+  const severity severity_;
+  const char *file_;
+  const unsigned line_;
+  std::ostringstream stream_;
+
+  template <typename Value_>
+  friend log_message &operator<<(log_message &, const Value_ &) noexcept;
+
+ public:
+  log_message(MSIHANDLE install, severity severity,
+              const char *file, unsigned line);
+  ~log_message();
+
+  log_message(const log_message &) = delete;
+  log_message &operator=(const log_message &) = delete;
+
+  std::string str() { return stream_.str(); }
+  severity severity() const { return severity_; }
+};
+
+template <typename Value_>
+log_message &operator<<(log_message &message, const Value_ &value) noexcept {
+  message.stream_ << value;
+  return message;
+}
+
+extern template
+log_message &operator<<<std::wstring>(log_message &,
+                                      const std::wstring &) noexcept;
+}
+
+#define LOG(Install,Severity)                                                   \
+  msi::logging::log_message(Install, msi::logging::severity::##Severity,        \
+                            __FILE__, __LINE__)
+
+#endif

--- a/platforms/Windows/CustomActions/SwiftInstaller/Headers/scoped_raii.hh
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Headers/scoped_raii.hh
@@ -1,0 +1,51 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SWIFT_INSTALLER_HEADERS_SCOPED_RAII_HH
+#define SWIFT_INSTALLER_HEADERS_SCOPED_RAII_HH
+
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <objbase.h>
+
+namespace windows {
+namespace raii {
+class hkey {
+  HKEY hKey_;
+
+ public:
+  explicit hkey(HKEY hKey) noexcept : hKey_(hKey) {}
+
+  // TODO(compnerd) log failure
+  ~hkey() noexcept { (void)RegCloseKey(hKey_); }
+};
+
+class com_initializer {
+  HRESULT hr_;
+
+ public:
+   enum threading_model { multithreaded };
+
+   explicit com_initializer() {
+     hr_ = ::CoInitializeEx(nullptr,
+                            COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+   }
+
+   explicit com_initializer(threading_model) {
+     hr_ = ::CoInitializeEx(nullptr,
+                            COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
+   }
+
+   ~com_initializer() {
+     if (SUCCEEDED(hr_))
+       ::CoUninitialize();
+   }
+
+   bool succeeded() const { return SUCCEEDED(hr_); }
+};
+}
+}
+
+#endif

--- a/platforms/Windows/CustomActions/SwiftInstaller/Headers/swift_installer.hh
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Headers/swift_installer.hh
@@ -1,0 +1,34 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SWIFT_INSTALLER_HEADERS_SWIFT_INSTALLER_HH
+#define SWIFT_INSTALLER_HEADERS_SWIFT_INSTALLER_HH
+
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <msi.h>
+
+#if defined(_WINDLL)
+# if defined(SwiftInstaller_EXPORTS)
+#   define SWIFT_INSTALLER_API __declspec(dllexport)
+# else
+#   define SWIFT_INSTALLER_API __declspec(dllimport)
+# endif
+#else
+# define SWIFT_INSTALLER_API
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+UINT SWIFT_INSTALLER_API
+SwiftInstaller_InstallAuxiliaryFiles(MSIHANDLE hInstall);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/dllmain.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/dllmain.cc
@@ -1,0 +1,19 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: Apache-2.0
+
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+
+extern "C" BOOL APIENTRY
+DllMain(HANDLE hModule, DWORD ulReason, LPVOID lpReserved) {
+  switch (ulReason) {
+  case DLL_PROCESS_ATTACH:
+    break;
+  case DLL_PROCESS_DETACH:
+    break;
+  }
+
+  return TRUE;
+}

--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/logging.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/logging.cc
@@ -1,0 +1,72 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: Apache-2.0
+
+#include "logging.hh"
+
+#include <cassert>
+#include <codecvt>
+#include <iomanip>
+#include <string>
+#include <vector>
+
+namespace {
+std::string to_string(const msi::logging::severity &severity) {
+  switch (severity) {
+  case msi::logging::severity::info: return "INFO";
+  case msi::logging::severity::warning: return "WARN";
+  case msi::logging::severity::error: return "ERROR";
+  case msi::logging::severity::fatal: return "FATAL";
+  }
+  __assume(false);
+}
+}
+
+namespace msi::logging {
+log_message::log_message(MSIHANDLE install, msi::logging::severity severity,
+                         const char *file, unsigned line)
+    : install_(install), severity_(severity), file_(file), line_(line) {
+  std::string_view filename(file);
+
+  auto separator = filename.find_last_of("\\/");
+  if (separator != std::string_view::npos)
+    filename.remove_prefix(separator + 1);
+
+  SYSTEMTIME time;
+  GetLocalTime(&time);
+
+  stream_ << "[\\[]"
+          // TODO(compnerd) should we size the pid and tid?
+          << GetCurrentProcessId() << ':' << GetCurrentThreadId() << ':'
+          << std::setfill('0')
+          << std::setw(2) << time.wMonth
+          << std::setw(2) << time.wDay
+          << '/'
+          << std::setw(2) << time.wHour
+          << std::setw(2) << time.wMinute
+          << std::setw(2) << time.wSecond
+          << '.'
+          << std::setw(3) << time.wMilliseconds
+          << ':'
+          << to_string(severity_)
+          << ':' << filename << '(' << line << ')'
+          << "[\\]]" << ' ';
+}
+
+log_message::~log_message() {
+  std::string message = stream_.str();
+
+  PMSIHANDLE record;
+  record = MsiCreateRecord(0);
+  (void)MsiRecordSetStringA(record, 0, message.c_str());
+  (void)MsiProcessMessage(install_, INSTALLMESSAGE_INFO, record);
+}
+
+template <>
+log_message &operator<<<std::wstring>(log_message &message,
+                                      const std::wstring &str) noexcept {
+  std::wstring_convert<std::codecvt_utf8<std::wstring::traits_type::char_type>,
+                       std::wstring::traits_type::char_type> utf8;
+  message.stream_ << utf8.to_bytes(str.data(), str.data() + str.size());
+  return message;
+}
+}

--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
@@ -1,0 +1,427 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: Apache-2.0
+
+#include "swift_installer.hh"
+#include "logging.hh"
+#include "scoped_raii.hh"
+
+#include <comip.h>
+#include <comdef.h>
+
+#include <algorithm>
+#include <cassert>
+#include <ciso646>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// NOTE(compnerd) `Unknwn.h` must be included before `Setup.Configuration.h` as
+// the header is not fully self-contained.
+#include <Unknwn.h>
+#include <Setup.Configuration.h>
+
+_COM_SMARTPTR_TYPEDEF(IEnumSetupInstances, __uuidof(IEnumSetupInstances));
+_COM_SMARTPTR_TYPEDEF(ISetupConfiguration, __uuidof(ISetupConfiguration));
+_COM_SMARTPTR_TYPEDEF(ISetupConfiguration2, __uuidof(ISetupConfiguration2));
+_COM_SMARTPTR_TYPEDEF(ISetupHelper, __uuidof(ISetupHelper));
+_COM_SMARTPTR_TYPEDEF(ISetupInstance, __uuidof(ISetupInstance));
+_COM_SMARTPTR_TYPEDEF(ISetupInstance2, __uuidof(ISetupInstance2));
+_COM_SMARTPTR_TYPEDEF(ISetupPackageReference, __uuidof(ISetupPackageReference));
+
+namespace {
+std::string contents(const std::filesystem::path &path) noexcept {
+  std::ostringstream buffer;
+  std::ifstream stream(path);
+  if (!stream)
+    return {};
+  buffer << stream.rdbuf();
+  return buffer.str();
+}
+
+template <typename CharType_>
+void trim(std::basic_string<CharType_> &string) noexcept {
+  string.erase(std::remove_if(std::begin(string), std::end(string),
+                              [](CharType_ ch) { return !std::isprint(ch); }),
+               std::end(string));
+}
+}
+
+// This is technically a misnomer.  We are not looking for the Windows SDK but
+// rather the Universal CRT SDK.
+//
+// The Windows SDK installation is found by querying:
+//  HKLM\SOFTWARE\[Wow6432Node]\Microsoft\Microsoft SDKs\Windows\v10.0\InstallationFolder
+// We can identify the SDK version using:
+//  HKLM\SOFTWARE\[Wow6432Node]\Microsoft\Microsoft SDKs\Windows\v10.0\ProductVersion
+//
+// We currently only query:
+//  HKLM\SOFTWARE\Microsoft\Windows Kits\Installed Roots\KitsRoot10
+// which gives us the Universal CRT installation root.
+//
+// FIXME(compnerd) we should support additional installation configurations by
+// also querying the HKCU hive.
+namespace winsdk {
+static const wchar_t kits_root_key[] = L"KitsRoot10";
+static const wchar_t kits_installed_roots_keypath[] =
+    L"SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots";
+
+std::filesystem::path install_root() noexcept {
+  DWORD cbData = 0;
+
+  if (FAILED(RegGetValueW(HKEY_LOCAL_MACHINE, kits_installed_roots_keypath,
+                          kits_root_key, RRF_RT_REG_SZ, nullptr, nullptr,
+                          &cbData)))
+    return {};
+
+  if (cbData == 0)
+    return {};
+
+  std::vector<wchar_t> buffer;
+  buffer.resize(cbData);
+
+  if (FAILED(RegGetValueW(HKEY_LOCAL_MACHINE, kits_installed_roots_keypath,
+                          kits_root_key, RRF_RT_REG_SZ, nullptr, buffer.data(),
+                          &cbData)))
+    return {};
+
+  return std::filesystem::path(buffer.data());
+}
+
+std::vector<std::wstring> available_versions() noexcept {
+  HKEY hKey;
+
+  if (FAILED(RegOpenKeyExW(HKEY_LOCAL_MACHINE, kits_installed_roots_keypath,
+                           0, KEY_READ, &hKey)))
+    return {};
+
+  windows::raii::hkey key{hKey};
+
+  DWORD cSubKeys;
+  DWORD cbMaxSubKeyLen;
+  if (FAILED(RegQueryInfoKeyW(hKey, nullptr, nullptr, nullptr, &cSubKeys,
+                              &cbMaxSubKeyLen, nullptr, nullptr, nullptr,
+                              nullptr, nullptr, nullptr)))
+    return {};
+
+  std::vector<wchar_t> buffer;
+  buffer.resize(static_cast<size_t>(cbMaxSubKeyLen) + 1);
+
+  std::vector<std::wstring> versions;
+  for (DWORD dwIndex = 0; dwIndex < cSubKeys; ++dwIndex) {
+    DWORD cchName = cbMaxSubKeyLen + 1;
+
+    // TODO(compnerd) handle error
+    (void)RegEnumKeyExW(hKey, dwIndex, buffer.data(), &cchName, nullptr,
+                        nullptr, nullptr, nullptr);
+
+    versions.emplace_back(buffer.data());
+  }
+  return versions;
+}
+}
+
+namespace msvc {
+// TODO(compnerd) add support for VS2022
+
+// VS2019 v142 Build Tools
+static const wchar_t toolset_v142_x86_x64[] =
+    L"Microsoft.VisualStudio.Component.VC.Tools.x86.x64";
+static const wchar_t toolset_v142_arm[] =
+    L"Microsoft.VisualStudio.Component.VC.Tools.ARM";
+static const wchar_t toolset_v142_arm64[] =
+    L"Microsoft.VisualStudio.Component.VC.Tools.ARM64";
+static const wchar_t toolset_v142_arm64ec[] =
+    L"Microsoft.VisualStudio.Component.VC.Tools.ARM64EC";
+
+// VS2017 v141 Build Tools
+static const wchar_t toolset_v141_x86_x64[] =
+    L"Microsoft.VisualStudio.Component.VC.v141.x86.x64";
+static const wchar_t toolset_v141_arm[] =
+    L"Microsoft.VisualStudio.Component.VC.v141.ARM";
+static const wchar_t toolset_v141_arm64[] =
+    L"Microsoft.VisualStudio.Component.VC.v141.ARM64";
+
+static const wchar_t *known_toolsets[] = {
+  toolset_v142_x86_x64,
+  toolset_v142_arm64ec,
+  toolset_v142_arm64,
+  toolset_v142_arm,
+
+  toolset_v141_x86_x64,
+  toolset_v141_arm64,
+  toolset_v141_arm,
+};
+
+// The name is misleading.  This currently returns the default toolset in all
+// VS2015+ installations.
+std::vector<std::filesystem::path> available_toolsets() noexcept {
+  windows::raii::com_initializer com;
+
+  std::vector<std::filesystem::path> toolsets;
+
+  ISetupConfigurationPtr configuration;
+  if (FAILED(configuration.CreateInstance(__uuidof(SetupConfiguration))))
+    return toolsets;
+
+  ISetupConfiguration2Ptr configuration2;
+  if (FAILED(configuration->QueryInterface(&configuration2)))
+    return toolsets;
+
+  IEnumSetupInstancesPtr instances;
+  if (FAILED(configuration2->EnumAllInstances(&instances)))
+    return toolsets;
+
+  ULONG fetched;
+  ISetupInstancePtr instance;
+  while (SUCCEEDED(instances->Next(1, &instance, &fetched)) && fetched) {
+    ISetupInstance2Ptr instance2;
+    if (FAILED(instance->QueryInterface(&instance2)))
+      continue;
+
+    InstanceState state;
+    if (FAILED(instance2->GetState(&state)))
+      continue;
+
+    // Ensure that the instance state matches
+    //  eLocal: The instance installation path exists.
+    //  eRegistered: A product is registered to the instance.
+    if (~state & eLocal or ~state & eRegistered)
+      continue;
+
+    LPSAFEARRAY packages;
+    if (FAILED(instance2->GetPackages(&packages)))
+      continue;
+
+    LONG lower, upper;
+    if (FAILED(SafeArrayGetLBound(packages, 1, &lower)) ||
+        FAILED(SafeArrayGetUBound(packages, 1, &upper)))
+      continue;
+
+    for (LONG index = 0, count = upper - lower + 1; index < count; ++index) {
+      IUnknownPtr element;
+      if (FAILED(SafeArrayGetElement(packages, &index, &element)))
+        continue;
+
+      ISetupPackageReferencePtr package;
+      if (FAILED(element->QueryInterface(&package)))
+        continue;
+
+      _bstr_t package_id;
+      if (FAILED(package->GetId(package_id.GetAddress())))
+        continue;
+
+      // Ensure that we are dealing with a (known) MSVC ToolSet
+      if (std::none_of(std::begin(known_toolsets), std::end(known_toolsets),
+                      [package_id = package_id.GetBSTR()](const wchar_t *id) {
+                        return wcscmp(package_id, id) == 0;
+                      }))
+        continue;
+
+      _bstr_t VSInstallDir;
+      if (FAILED(instance2->GetInstallationPath(VSInstallDir.GetAddress())))
+        continue;
+
+      std::filesystem::path VCInstallDir{static_cast<wchar_t *>(VSInstallDir)};
+      VCInstallDir.append("VC");
+
+      std::string VCToolsVersion;
+      // VSInstallDir\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt
+      // contains the default version of the v141 MSVC toolset.  Prefer to use
+      // VSInstallDir\VC\Auxiliary\Build\Microsoft.VCToolsVersion.v142.default.txt
+      // which contains the default v142 version of the toolset.
+      for (const auto &file : {"Microsoft.VCToolsVersion.v142.default.txt",
+                               "Microsoft.VCToolsVersion.default.txt"}) {
+        std::filesystem::path path{VCInstallDir};
+        path.append("Auxiliary");
+        path.append("Build");
+        path.append(file);
+
+        VCToolsVersion = contents(path);
+        // Strip any line ending characters from the contents of the file.
+        trim(VCToolsVersion);
+        if (!VCToolsVersion.empty())
+          break;
+      }
+
+      if (VCToolsVersion.empty())
+        continue;
+
+      std::filesystem::path VCToolsInstallDir{VCInstallDir};
+      VCToolsInstallDir.append("Tools");
+      VCToolsInstallDir.append("MSVC");
+      VCToolsInstallDir.append(VCToolsVersion);
+
+      // FIXME(compnerd) should we actually just walk the directory structure
+      // instead and populate all the toolsets?  That would match roughly what
+      // we do with the UCRT currently.
+
+      toolsets.push_back(VCToolsInstallDir);
+    }
+  }
+
+  return toolsets;
+}
+}
+
+namespace msi {
+std::wstring get_property(MSIHANDLE hInstall, std::wstring_view key) noexcept {
+  DWORD size = 0;
+  UINT status;
+
+  status = MsiGetPropertyW(hInstall, key.data(), L"", &size);
+  assert(status == ERROR_MORE_DATA);
+
+  std::vector<wchar_t> buffer;
+  buffer.resize(size + 1);
+
+  size = buffer.capacity();
+  status = MsiGetPropertyW(hInstall, key.data(), buffer.data(), &size);
+  // TODO(compnerd) handle error
+
+  return {buffer.data(), buffer.capacity()};
+}
+}
+
+UINT SwiftInstaller_InstallAuxiliaryFiles(MSIHANDLE hInstall) {
+  std::wstring data = msi::get_property(hInstall, L"CustomActionData");
+  trim(data);
+
+  std::filesystem::path SDKROOT{data};
+  LOG(hInstall, info) << "SDKROOT: " << SDKROOT.string();
+
+  // Copy SDK Module Maps
+  std::filesystem::path UniversalCRTSdkDir = winsdk::install_root();
+  LOG(hInstall, info) << "UniversalCRTSdkDir: " << UniversalCRTSdkDir;
+  if (!UniversalCRTSdkDir.empty()) {
+    // FIXME(compnerd) Technically we are using the UniversalCRTSdkDir here
+    // instead of the WindowsSdkDir which would contain `um`.
+
+    // FIXME(compnerd) we may end up in a state where the ucrt and Windows SDKs
+    // do not match.  Users have reported cases where they somehow managed to
+    // setup such a configuration.  We should split this up to explicitly
+    // handle the UCRT and WinSDK paths separately.
+    for (const auto &version : winsdk::available_versions()) {
+      const struct {
+        std::filesystem::path src;
+        std::filesystem::path dst;
+      } items[] = {
+        { SDKROOT / "usr" / "share" / "ucrt.modulemap",
+          UniversalCRTSdkDir / "Include" / version / "ucrt" / "module.modulemap" },
+        { SDKROOT / "usr" / "share" / "winsdk.modulemap",
+          UniversalCRTSdkDir / "Include" / version / "um" / "module.modulemap" },
+      };
+
+      for (const auto &item : items) {
+        static const constexpr std::filesystem::copy_options options =
+            std::filesystem::copy_options::overwrite_existing;
+
+        std::error_code ec;
+        if (!std::filesystem::copy_file(item.src, item.dst, options, ec)) {
+          LOG(hInstall, error)
+              << "unable to copy " << item.src << " to " << item.dst << ": "
+              << ec.message();
+          continue;
+        }
+        LOG(hInstall, info) << "Deployed " << item.dst;
+      }
+    }
+  }
+
+  // Copy MSVC Tools Module Maps
+  for (const auto &VCToolsInstallDir : msvc::available_toolsets()) {
+    const struct {
+      std::filesystem::path src;
+      std::filesystem::path dst;
+    } items[] = {
+      { SDKROOT / "usr" / "share" / "visualc.modulemap",
+        VCToolsInstallDir / "include" / "module.modulemap" },
+      { SDKROOT / "usr" / "share" / "visualc.apinotes",
+        VCToolsInstallDir / "include" / "visualc.apinotes" },
+    };
+
+    for (const auto &item : items) {
+      static const constexpr std::filesystem::copy_options options =
+          std::filesystem::copy_options::overwrite_existing;
+
+      std::error_code ec;
+      if (!std::filesystem::copy_file(item.src, item.dst, options, ec)) {
+        LOG(hInstall, error)
+            << "unable to copy " << item.src << " to " << item.dst << ": "
+            << ec.message();
+        continue;
+      }
+      LOG(hInstall, info) << "Deployed " << item.dst;
+    }
+  }
+
+  // TODO(compnerd) it would be ideal to record the files deployed here to the
+  // `RemoveFile` table which would allow them to be cleaned up on removal.
+  // This is tricky as we cannot modify the on-disk database.  The deferred
+  // action is already executed post-InstallExecute which means that we can now
+  // identify the cached MSI by:
+  //
+  //  std::wstring product_code = msi::get_property(hInstall, L"ProductCode");
+  //
+  //  DWORD size = 0;
+  //  (void)MsiGetProductInfoW(product_code.c_str(),
+  //                           INSTALLPROPERTY_LOCALPACKAGE, L"", &size);
+  //  std::vector<wchar_t> buffer;
+  //  buffer.resize(++size);
+  //  (void)MsiGetProductInfoW(product_code.c_str(),
+  //                           INSTALLPROPERTY_LOCALPACKAGE, buffer.data(),
+  //                           &size);
+  //
+  // We can then create a new property for the location of the entry and a new
+  // RemoveFile entry for cleaning up the file.  Note that we may have to tweak
+  // things to get repairs to work properly with the tracking.
+  //
+  //  PMSIHANDLE database;
+  //  (void)MsiOpenDatabaseW(buffer.data(), MSIDBOPEN_TRANSACT, &database);
+  //
+  //  static const wchar_t query[] =
+  //      LR"SQL(
+  //INSERT INTO `Property` (`Property`, `Value`)
+  //  VALUES(?, ?);
+  //INSERT INTO `RemoveFile` (`FileKey`, `Component_`, `FileName`, `DirProperty`, `InstallMode`
+  //  VALUES (?, ?, ?, ?, ?);
+  //      )SQL";
+  //
+  //  PMSIHANDLE view;
+  //  (void)MsiDatabaseOpenViewW(database, query, &view);
+  //
+  //  std::hash<std::wstring> hasher;
+  //
+  //  std::wostringstream component;
+  //  component << "cmp" << hasher(path.wstring());
+  //
+  //  std::wostringstream property;
+  //  property << "prop" << hasher(path.wstring());
+  //
+  //  PMSIHANDLE record = MsiRecordCreate(7);
+  //  (void)MsiRecordSetStringW(record, 1, property.str().c_str());
+  //  (void)MsiRecordSetStringW(record, 2, path.parent_path().wstring().c_str());
+  //  (void)MsiRecordSetStringW(record, 3, component.str().c_str());
+  //  (void)MsiRecordSetStringW(record, 4, component.str().c_str());
+  //  (void)MsiRecordSetStringW(record, 5, path.filename().wstring().c_str());
+  //  (void)MsiRecordSetStringW(record, 6, property.str().c_str());
+  //  (void)MsiRecordSetInteger(record, 7, 2);
+  //
+  //  (void)MsiViewExecute(view, record);
+  //
+  //  (void)MsiDatabaseCommit(database);
+  //
+  // Currently, this seems to fail with the commiting of the database, which is
+  // still a mystery to me.  This relies on the clever usage of the
+  // `EnsureTable` in the WiX definition to ensure that we do not need to create
+  // the table.
+  //
+  // The error handling has been elided here for brevity's sake.
+
+  return ERROR_SUCCESS;
+}

--- a/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
+++ b/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <MSBuildProjectExtensionsPath>$(ProjectDir)build\ThirdParty\</MSBuildProjectExtensionsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.default.props"/>
+
+  <PropertyGroup>
+    <ProjectGuid>{84027311-67A4-4351-AD3A-53529767BFA0}</ProjectGuid>
+    <RootNamespace>SwiftInstaller</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CharacterSet>Unicode</CharacterSet>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <TargetName>SwiftInstaller</TargetName>
+
+    <NuGetTargetMoniker>native,Version=v0.0</NuGetTargetMoniker>
+
+    <!-- NOTE(compnerd) default to v142 (VS2019) toolset; VS2022 is v143 -->
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v142</PlatformToolset>
+    <PlatformToolset>$(PlatformToolset)</PlatformToolset>
+
+    <IntDir>$(ProjectDir)build\$(Configuration)\$(PlatformShortName)\$(PlatformToolset)\obj\</IntDir>
+    <OutDir>$(ProjectDir)build\$(Configuration)\$(PlatformShortName)\$(PlatformToolset)\bin\</OutDir>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir)Headers</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <PreprocessorDefinitions>SwiftInstaller_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>msi.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)' == 'Debug'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)' == 'Release'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
+
+  <ItemGroup>
+    <ClCompile Include="Sources\swift_installer.cc"/>
+    <ClCompile Include="Sources\dllmain.cc"/>
+    <ClCompile Include="Sources\logging.cc"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="Headers\scoped_raii.hh"/>
+    <ClInclude Include="Headers\swift_installer.hh"/>
+    <ClInclude Include="Headers\logging.hh"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="2.3.2262"/>
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Targets"/>
+</Project>

--- a/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj.filters
+++ b/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj.filters
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmls="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Sources\dllmain.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Sources\logging.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Sources\swift_installer.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="Headers\logging.hh">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Headers\scoped_raii.hh">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Headers\swift_installer.hh">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{485df023-ca0b-4390-b9e5-bb574625ac42}</UniqueIdentifier>
+      <Extensions>h;hh</Extensions>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{b2fa78cd-13ff-4b88-9e63-112e1ac92329}</UniqueIdentifier>
+      <Extensions>cc</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This restores the SwiftInstaller custom action, relicensed under the
Apache 2.0.  The third party dependency on the Microsoft code is now
managed via nuget, and will be fetched as appropriate when building.