### PR TITLE
Windows: remove pre-build task on toolchain package

### DIFF
--- a/platforms/Windows/toolchain.wixproj
+++ b/platforms/Windows/toolchain.wixproj
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-         DefaultTargets="Build"
-         InitialTargets="DisplayBuildConfiguration">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
   </PropertyGroup>


### PR DESCRIPTION
The `DisplayBuildConfiguration` pre-build task is not particularly
useful with a single build configuration, remove the vestigial
reference.