### PR TITLE
Windows: tweak the custom action platform

### DIFF
--- a/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
+++ b/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ProjectConfiguration Include="Debug|x86">
+    <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>x86</Platform>
     </ProjectConfiguration>
 
-    <ProjectConfiguration Include="Release|x86">
+    <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>x86</Platform>
     </ProjectConfiguration>


### PR DESCRIPTION
The platform name is `Win32` rather than `x86` (the short name).  This
should allow building the SDK MSI.