### PR TITLE
Windows: correct typo of distributed for import libs

### DIFF
--- a/platforms/Windows/sdk.wxs
+++ b/platforms/Windows/sdk.wxs
@@ -360,7 +360,7 @@
 
       <ComponentRef Id="_CONCURRENCY_IMPORT_LIBS" />
       <ComponentRef Id="_DIFFERENTIATION_IMPORT_LIBS" />
-      <ComponentRef Id="_DISTRIBTUED_IMPORT_LIBS" />
+      <ComponentRef Id="_DISTRIBUTED_IMPORT_LIBS" />
       <!-- <ComponentRef Id="CRT_IMPORT_LIBS" /> -->
       <!-- <ComponentRef Id="DISPATCH_IMPORT_LIBS" /> -->
       <ComponentRef Id="FOUNDATION_IMPORT_LIBS" />


### PR DESCRIPTION
Fix a typo in the reference to the `_DISTRIBUTED_IMPORT_LIBS` component.