### PR TITLE
Windows: add developer tools packaging rules

### DIFF
--- a/platforms/Windows/devtools.wixproj
+++ b/platforms/Windows/devtools.wixproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTarget="Build">
+  <PropertyGroup>
+    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputName>devtools</OutputName>
+    <OutputType>Package</OutputType>
+    <ProjectGuid>0a266072-af7c-43f2-b192-dd86995c2e82</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
+    <ProductVersion>0.0.0</ProductVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>build\</OutputPath>
+    <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
+  </PropertyGroup>
+
+  <Import Project="$(WixTargetsPath)" />
+
+  <PropertyGroup>
+    <DefineConstants>ProductVersion=$(ProductVersion);DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);</DefineConstants>
+    <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
+    <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
+    <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>
+    <HarvestDirectorySuppressCom>true</HarvestDirectorySuppressCom>
+    <HarvestDirectorySuppressFragments>true</HarvestDirectorySuppressFragments>
+    <HarvestDirectorySuppressRegistry>true</HarvestDirectorySuppressRegistry>
+    <HarvestDirectorySuppressRootDirectory>true</HarvestDirectorySuppressRootDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="devtools.wxs" />
+  </ItemGroup>
+</Project>

--- a/platforms/Windows/devtools.wxs
+++ b/platforms/Windows/devtools.wxs
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Developer Tools" UpgradeCode="5778fa7a-f1a6-4133-b4e0-fc0d9caf4544" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Developer Tools" InstallScope="perMachine" Manufacturer="swift.org" />
+    <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="devtools_PDBs.cab" EmbedCab="yes" />
+    <?endif?>
+
+    <!-- Directory Structure -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="WINDOWSVOLUME">
+        <Directory Id="LIBRARY" Name="Library">
+          <Directory Id="DEVELOPER" Name="Developer">
+            <Directory Id="TOOLCHAINS" Name="Toolchains">
+              <Directory Id="UNKNOWN_ASSERTS_DEVELOPMENT_XCTOOLCHAIN" Name="unknown-Asserts-development.xctoolchain">
+                <Directory Id="USR" Name="usr">
+                  <Directory Id="USR_BIN" Name="bin">
+                  </Directory>
+                  <!--
+                  FIXME(compnerd) should we include the cyaml and llbuild headers?
+                  <Directory Id="USR_INCLUDE" Name="include">
+                    <Directory Id="USR_INCLUDE_CYAML" Name="cyaml">
+                    </Directory>
+                    <Directory Id="USR_INCLUDE_LLBUILD" Name="llbuild">
+                    </Directory>
+                  </Directory>
+                  -->
+                  <Directory Id="USR_LIB" Name="lib">
+                    <!-- FIXME(compnerd) should we include the TSC, SPM import libraries? -->
+                    <Directory Id="USR_LIB_SWIFT" Name="swift">
+                      <Directory Id="USR_LIB_SWIFT_PM" Name="pm">
+                        <Directory Id="USR_LIB_SWIFT_PM_MANIFEST_API" Name="ManifestAPI">
+                        </Directory>
+                      </Directory>
+                      <!--
+                      FIXME(compnerd) should we include the import libraries and swiftmodules for Yams, ArgumentParser?
+                      <Directory Id="USR_LIB_SWIFT_WINDOWS" Name="windows">
+                        <Directory Id="USR_LIB_SWIFT_WINDOWS_X86_64" Name="x86_64">
+                        </Directory>
+                      </Directory>
+                      -->
+                    <!-- FIXME(compnerd) should we include the llbuild import libraries? -->
+                    </Directory>
+                  </Directory>
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+
+    <!-- Components -->
+    <DirectoryRef Id="USR_BIN">
+      <!-- IndexStoreDB -->
+      <Component Id="INDEXSTOREDB_BINS" Guid="cde37e2e-9f9d-4fc5-927b-55b9145c84cd">
+        <File Id="INDEXSTOREDB_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="INDEXSTOREDB_DEBUGINFO" Guid="a0b6f544-c52a-4439-b646-474d43f8c7b4">
+        <File Id="INDEXSTOREDB_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!-- llbuild -->
+      <Component Id="LLBUILD_BINS" Guid="ff7fc643-d14b-465b-ba9e-79191c27d403">
+        <File Id="LLBUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.dll" Checksum="yes" />
+        <File Id="LLBUILDSWIFT_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" Checksum="yes" />
+
+        <File Id="SWIFT_BUILD_TOOL_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="LLBUILD_DEBUGINFO" Guid="a74f4415-d0a8-42c2-adaf-abd98d2865b5">
+        <File Id="LLBUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.pdb" Checksum="yes" />
+        <File Id="LLBUILDSWIFT_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" />
+
+        <File Id="SWIFT_BUILD_TOOL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!-- SourceKit-LSP -->
+      <Component Id="SOURCEKIT_LSP_BINS" Guid="5ca5d02f-76f3-4537-9dfb-a3fdb6381ac4">
+        <File Id="BUILD_SERVER_PROTOCOL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\BuildServerProtocol.dll" Checksum="yes" />
+        <File Id="LANGUAGE_SERVER_PROTOCOL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LanguageServerProtocol.dll" Checksum="yes" />
+        <File Id="LANGUAGE_SERVER_PROTOCOL_JSONRPC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LanguageServerProtocolJSONRPC.dll" Checksum="yes" />
+        <File Id="LSP_LOGGING_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LSPLogging.dll" Checksum="yes" />
+        <File Id="SKCORE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SKCore.dll" Checksum="yes" />
+        <File Id="SKSUPPORT_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SKSupport.dll" Checksum="yes" />
+        <File Id="SKSWIFTPM_WORKSPACE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SKSwiftPMWorkspace.dll" Checksum="yes" />
+        <File Id="SOURCEKIT_LSP_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SourceKitLSP.dll" Checksum="yes" />
+        <File Id="SOURCEKIT_D_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SourceKitD.dll" Checksum="yes" />
+        <File Id="SOURCEKIT_LSP_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SOURCEKIT_LSP_DEBUGINFO" Guid="b4967969-ce4b-4d63-b2fd-0d8fc896cb28">
+        <File Id="BUILD_SERVER_PROTOCOL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\BuildServerProtocol.pdb" Checksum="yes" />
+        <File Id="LANGUAGE_SERVER_PROTOCOL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LanguageServerProtocol.pdb" Checksum="yes" />
+        <File Id="LANGUAGE_SERVER_PROTOCOL_JSONRPC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LanguageServerProtocolJSONRPC.pdb" Checksum="yes" />
+        <File Id="LSP_LOGGING_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LSPLogging.pdb" Checksum="yes" />
+        <File Id="SKCORE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SKCore.pdb" Checksum="yes" />
+        <File Id="SKSUPPORT_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SKSupport.pdb" Checksum="yes" />
+        <File Id="SKSWIFTPM_WORKSPACE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SKSwiftPMWorkspace.pdb" Checksum="yes" />
+        <File Id="SOURCEKIT_LSP_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SourceKitLSP.pdb" Checksum="yes" />
+        <File Id="SOURCEKIT_D_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SourceKitD.pdb" Checksum="yes" />
+        <File Id="SOURCEKIT_LSP_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!-- swift-argument-parser -->
+      <Component Id="SWIFT_ARGUMENT_PARSER_BINS" Guid="ead7f2bd-f3ce-4f50-a04e-a2b9af25ae03">
+        <File Id="ARGUMENT_PARSER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SWIFT_ARGUMENT_PARSER_DEBUGINFO" Guid="93c2ef9c-ba1f-462c-8701-2d77125ec9c8">
+        <File Id="ARGUMENT_PARSER_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!-- swift-crypto -->
+      <Component Id="SWIFT_CRYPTO_BINS" Guid="8f4fb997-7a41-4d37-a3d4-f5e006f5e3c4">
+        <File Id="CRYPTO_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SWIFT_CRYPTO_DEBUGINFO" Guid="0966d4bf-d9a6-46ed-9be2-5b165fff3d45">
+        <File Id="CRYPTO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!-- swift-collections -->
+      <Component Id="SWIFT_COLLECTIONS_BINS" Guid="f4634058-6477-4f8f-aa99-76a074056c2f">
+        <File Id="COLLECTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
+        <File Id="DEQUE_MODULE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.dll" Checksum="yes" />
+        <File Id="ORDERED_COLLECTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SWIFT_COLLECTIONS_DEBUGINFO" Guid="3c709129-5383-47c8-a86a-38d44a575095">
+        <File Id="COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
+        <File Id="DEQUE_MODULE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
+        <File Id="ORDERED_COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!-- swift-driver -->
+      <Component Id="SWIFT_DRIVER_BINS" Guid="6108d465-9eb5-441f-8cde-5437457fb539">
+        <File Id="SWIFT_DRIVER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
+        <File Id="SWIFT_OPTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SWIFT_DRIVER_DEBUGINFO" Guid="2e5f4e86-628c-4184-99eb-9385efdebe83">
+        <File Id="SWIFT_DRIVER_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" />
+        <File Id="SWIFT_OPTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!-- swift-package-manager -->
+      <Component Id="SWIFT_PACKAGE_MANAGER_BINS" Guid="1b6a0df3-9fd5-4262-8d90-55585f059d40">
+        <File Id="BASICS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.dll" Checksum="yes" />
+        <File Id="BUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.dll" Checksum="yes" />
+        <File Id="COMMANDS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
+        <File Id="LLBUILD_MANIFEST_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LLBuildManifest.dll" Checksum="yes" />
+        <File Id="PACKAGE_GRAPH_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
+        <File Id="PACKAGE_LOADING_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" Checksum="yes" />
+        <File Id="PACKAGE_MODEL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" Checksum="yes" />
+        <File Id="SOURCE_CONTROL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SourceControl.dll" Checksum="yes" />
+        <File Id="SPMBUILD_CORE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" Checksum="yes" />
+        <File Id="SPMLLBUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMLLBuild.dll" Checksum="yes" />
+        <File Id="WORKSPACE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.dll" Checksum="yes" />
+        <File Id="XCBUILD_SUPPORT_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\XCBuildSupport.dll" Checksum="yes" />
+        <File Id="XCODEPROJ_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Xcodeproj.dll" Checksum="yes" />
+        <File Id="PACKAGE_COLLECTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollections.dll" Checksum="yes" />
+        <File Id="PACKAGE_COLLECTIONS_MODEL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollectionsModel.dll" Checksum="yes" />
+        <File Id="PACKAGE_COLLECTIONS_SIGNING_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollectionsSigning.dll" Checksum="yes" />
+
+        <File Id="SWIFT_BUILD_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.exe" Checksum="yes" />
+        <File Id="SWIFT_PACKAGE_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
+        <File Id="SWIFT_RUN_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.exe" Checksum="yes" />
+        <File Id="SWIFT_TEST_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.exe" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SWIFT_PACKAGE_MANAGER_DEBUGINFO" Guid="642629c0-be0d-4a8f-8e8e-375f4c6c5451">
+        <File Id="BASICS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
+        <File Id="BUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
+        <File Id="COMMANDS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
+        <File Id="LLBUILD_MANIFEST_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LLBuildManifest.pdb" Checksum="yes" />
+        <File Id="PACKAGE_GRAPH_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
+        <File Id="PACKAGE_LOADING_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
+        <File Id="PACKAGE_MODEL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
+        <File Id="SOURCE_CONTROL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SourceControl.pdb" Checksum="yes" />
+        <File Id="SPMBUILD_CORE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
+        <File Id="SPMLLBUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMLLBuild.pdb" Checksum="yes" />
+        <File Id="WORKSPACE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
+        <File Id="XCBUILD_SUPPORT_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\XCBuildSupport.pdb" Checksum="yes" />
+        <File Id="XCODEPROJ_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Xcodeproj.pdb" Checksum="yes" />
+        <File Id="PACKAGE_COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollections.pdb" Checksum="yes" />
+        <File Id="PACKAGE_COLLECTIONS_MODEL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollectionsModel.pdb" Checksum="yes" />
+        <File Id="PACKAGE_COLLECTIONS_SIGNING_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollectionsSigning.pdb" Checksum="yes" />
+
+        <File Id="SWIFT_BUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
+        <File Id="SWIFT_PACKAGE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
+        <File Id="SWIFT_RUN_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />
+        <File Id="SWIFT_TEST_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!-- swift-tools-support-core -->
+      <Component Id="SWIFT_TOOLS_SUPPORT_CORE_BINS" Guid="24999b97-7709-4a57-a987-4f8b7e16bb53">
+        <File Id="TSC_BASIC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" Checksum="yes" />
+        <File Id="TSC_LIBC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.dll" Checksum="yes" />
+        <File Id="TSC_UTILITY_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SWIFT_TOOLS_SUPPORT_CORE_DEBUGINFO" Guid="9487dcfc-ceb1-4763-9db5-af7b52687197">
+        <File Id="TSC_BASIC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" />
+        <File Id="TSC_LIBC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.pdb" Checksum="yes" />
+        <File Id="TSC_UTILITY_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+
+      <!--- Yams -->
+      <Component Id="YAMS_BINS" Guid="d60b565d-9efe-42db-b821-fa1d6ad4d2e2">
+        <File Id="CYAML_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CYaml.dll" Checksum="yes" />
+        <File Id="YAMS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="YAMS_DEBUGINFO" Guid="b09420e8-6c4f-4a9e-8882-4d399ed02ed5">
+        <File Id="CYAML_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CYaml.pdb" Checksum="yes" />
+        <File Id="YAMS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+    </DirectoryRef>
+
+    <DirectoryRef Id="USR_LIB_SWIFT_PM_MANIFEST_API">
+      <Component Id="MANIFEST_API" Guid="45a219f2-f92c-4644-99a0-33f55f35a43d">
+        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" Checksum="yes" />
+        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_LIB" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" Checksum="yes" />
+        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_SWIFTDOC" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftdoc" Checksum="yes" />
+        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_SWIFTMODULE" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO?>
+      <Component Id="MANIFEST_API_DEBUGINFO" Guid="c49ea278-c632-44de-8337-360f4759ac6b">
+        <File Id="MANIFESAT_API_PACKAGE_DESCRIPTION_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+    </DirectoryRef>
+
+    <Feature Id="DEVTOOLS" Level="1">
+      <ComponentRef Id="INDEXSTOREDB_BINS" />
+      <ComponentRef Id="LLBUILD_BINS" />
+      <ComponentRef Id="SOURCEKIT_LSP_BINS" />
+      <ComponentRef Id="SWIFT_ARGUMENT_PARSER_BINS" />
+      <ComponentRef Id="SWIFT_CRYPTO_BINS" />
+      <ComponentRef Id="SWIFT_COLLECTIONS_BINS" />
+      <ComponentRef Id="SWIFT_DRIVER_BINS" />
+      <ComponentRef Id="SWIFT_PACKAGE_MANAGER_BINS" />
+      <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_BINS" />
+      <ComponentRef Id="MANIFEST_API" />
+      <ComponentRef Id="YAMS_BINS" />
+    </Feature>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Feature Id="DEBUGINFO" Level="0">
+      <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <ComponentRef Id="INDEXSTOREDB_DEBUGINFO" />
+      <ComponentRef Id="LLBUILD_DEBUGINFO" />
+      <ComponentRef Id="SOURCEKIT_LSP_DEBUGINFO" />
+      <ComponentRef Id="SWIFT_ARGUMENT_PARSER_DEBUGINFO" />
+      <ComponentRef Id="SWIFT_CRYPTO_DEBUGINFO" />
+      <ComponentRef Id="SWIFT_COLLECTIONS_DEBUGINFO" />
+      <ComponentRef Id="SWIFT_DRIVER_DEBUGINFO" />
+      <ComponentRef Id="SWIFT_PACKAGE_MANAGER_DEBUGINFO" />
+      <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_DEBUGINFO" />
+      <ComponentRef Id="MANIFEST_API_DEBUGINFO" />
+      <ComponentRef Id="YAMS_DEBUGINFO" />
+    </Feature>
+    <?endif?>
+
+    <!-- UI -->
+    <UI />
+  </Product>
+</Wix>


### PR DESCRIPTION
This adds the build support for the devtools MSI which packages the
tools such as SPM and LSP.