### PR TITLE
Windows: add ICU packaging rules

### DIFF
--- a/icu.wixproj
+++ b/icu.wixproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputName>icu</OutputName>
+    <OutputType>Package</OutputType>
+    <ProjectGuid></ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
+    <ProductVersion>0.0.0</ProductVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>build\</OutputPath>
+    <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
+  </PropertyGroup>
+
+  <Import Project="$(WixTargetsPath)" />
+
+  <PropertyGroup>
+    <DefineConstants>ProductVersion=$(ProductVersion);ProductVersionMajor=$(ProductVersionMajor);ICU_ROOT=$(ICU_ROOT)</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="icu.wxs" />
+  </ItemGroup>
+</Project>

--- a/icu.wxs
+++ b/icu.wxs
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="ICU" UpgradeCode="4b3bfcaf-46b1-4940-b3e3-692ea4e78a09" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="ICU" InstallScope="perMachine" Manufacturer="swift.org" />
+    <Media Id="1" Cabinet="icu.cab" EmbedCab="yes" />
+
+    <!-- Directory Structure -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="WINDOWSVOLUME">
+        <Directory Id="LIBRARY" Name="Library">
+          <Directory Id="ICU" Name="icu-$(var.ProductVersion)">
+            <Directory Id="ICU_USR" Name="usr">
+              <Directory Id="ICU_USR_BIN" Name="bin">
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+
+    <!-- Components -->
+    <DirectoryRef Id="ICU_USR_BIN">
+      <Component Id="ICU_RUNTIME" Guid="77a97eb2-4a5c-4d85-9fb7-692fd37d9b68">
+        <File Id="ICUDT" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersionMajor)\usr\bin\icudt$(var.ProductVersionMajor).dll" Checksum="yes" />
+        <File Id="ICUIN" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersionMajor)\usr\bin\icuin$(var.ProductVersionMajor).dll" Checksum="yes" />
+        <File Id="ICUUC" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersionMajor)\usr\bin\icuuc$(var.ProductVersionMajor).dll" Checksum="yes" />
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="ENV_VARS" Guid="97fe0a23-32e0-481d-8827-215f4c74f03c">
+        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\icu-$(var.ProductVersion)\usr\bin" />
+      </Component>
+    </DirectoryRef>
+
+    <!-- Features -->
+    <Feature Id="RUNTIME" Level="1">
+      <ComponentRef Id="ICU_RUNTIME" />
+      <ComponentRef Id="ENV_VARS" />
+    </Feature>
+
+    <!-- UI -->
+    <UI />
+  </Product>
+</Wix>


### PR DESCRIPTION
We currently split up the ICU packaging as it is not part of the
toolchain but a required dependency and the version must match.