### PR TITLE
Windows: add runtime packaging scripts

### DIFF
--- a/runtime.wixproj
+++ b/runtime.wixproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputName>runtime</OutputName>
+    <OutputType>Package</OutputType>
+    <ProjectGuid></ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
+    <ProductVersion>$(ProductVersion)</ProductVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>build\</OutputPath>
+    <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
+  </PropertyGroup>
+
+  <Import Project="$(WixTargetsPath)" />
+
+  <PropertyGroup>
+    <DefineConstants>ProductVersion=$(ProductVersion);SDK_ROOT=$(SDK_ROOT);$(INCLUDE_DEBUG_INFO)</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="runtime.wxs" />
+  </ItemGroup>
+</Project>

--- a/runtime.wxs
+++ b/runtime.wxs
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Windows Swift Runtime for x86_64" UpgradeCode="850349e4-5a24-44eb-bded-f49a2709d26f" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Windows Swift Runtime for x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+    <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="runtime_PDBs.cab" EmbedCab="yes" />
+    <?endif?>
+
+    <!-- Directory Structure -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="WINDOWSVOLUME">
+        <Directory Id="LIBRARY" Name="Library">
+          <!-- TODO(compnerd) use $(var.ProductVersion) -->
+          <Directory Id="SWIFT" Name="Swift-development">
+            <Directory Id="BIN" Name="bin">
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+
+    <!-- Components -->
+    <DirectoryRef Id="BIN">
+      <Component Id="WINDOWS_SWIFT_RUNTIME" Guid="cd825076-16da-4530-84c8-810f3ae472a8">
+        <File Id="BLOCKSRUNTIME_DLL" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
+        <File Id="DISPATCH_DLL" Source="$(var.SDK_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
+        <File Id="FOUNDATION_DLL" Source="$(var.SDK_ROOT)\usr\bin\Foundation.dll" Checksum="yes" />
+        <File Id="FOUNDATION_NETWORKING_DLL" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.dll" Checksum="yes" />
+        <File Id="FOUNDATION_XML_DLL" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
+        <File Id="SWIFT_CONCURRENCY_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
+        <File Id="SWIFT_DIFFERENTIATION_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
+        <File Id="SWIFT_DISTRIBUTED_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_Distributed.dll" Checksum="yes" />
+        <File Id="SWIFTCORE_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
+        <File Id="SWIFTDISPATCH_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
+        <!-- <File Id="SWIFTDEMANGLE_DLL" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" /> -->
+        <File Id="SWIFTCRT_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.dll" Checksum="yes" />
+        <File Id="SWIFTREMOTEMIRROR_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.dll" Checksum="yes" />
+        <File Id="SWIFTSWIFTONONESUPPORT_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.dll" Checksum="yes" />
+        <File Id="SWIFTWINSDK_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.dll" Checksum="yes" />
+
+        <File Id="PLUTIL_EXE" Source="$(var.SDK_ROOT)\usr\bin\plutil.exe" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="WINDOWS_SWIFT_RUNTIME_DEBUGINFO" Guid="b61b71f4-8387-4be1-a756-1d06e796003c">
+        <File Id="BLOCKSRUNTIME_PDB" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
+        <File Id="DISPATCH_PDB" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
+        <File Id="FOUNDATION_PDB" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
+        <File Id="FOUNDATION_NETWORKING_PDB" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
+        <File Id="FOUNDATION_XML_PDB" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
+        <File Id="SWIFT_CONCURRENCY_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
+        <File Id="SWIFT_DIFFERENTIATION_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
+        <File Id="SWIFT_DISTRIBUTED_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_Distributed.pdb" Checksum="yes" DiskId="2" />
+        <File Id="SWIFTCORE_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
+        <File Id="SWIFTDISPATCH_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
+        <!-- <File Id="SWIFTDEMANGLE_PDB" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" /> -->
+        <File Id="SWIFTCRT_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
+        <File Id="SWIFTREMOTEMIRROR_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
+        <File Id="SWIFTSWIFTONONESUPPORT_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
+        <File Id="SWIFTWINSDK_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
+
+        <File Id="PLUTIL_PDB" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <?endif ?>
+    </DirectoryRef>
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="ENV_VARS" Guid="f249625e-aacd-4b17-a464-8f8df05ba5f3">
+        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\Swift-development\bin" />
+      </Component>
+    </DirectoryRef>
+
+    <!-- Feature -->
+    <Feature Id="RUNTIME" Level="1">
+      <ComponentRef Id="WINDOWS_SWIFT_RUNTIME" />
+      <ComponentRef Id="ENV_VARS" />
+    </Feature>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Feature Id="DEBUGINFO" Level="0">
+      <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <ComponentRef Id="WINDOWS_SWIFT_RUNTIME_DEBUGINFO" />
+    </Feature>
+    <?endif ?>
+
+    <!-- UI -->
+    <UI />
+  </Product>
+</Wix>


### PR DESCRIPTION
This adds the packaging for the Windows runtime (the redistributable
part of the SDK).