### PR TITLE
debian: add initial control files for debian packaging

### DIFF
--- a/platforms/Linux/debian/swift-lang-control
+++ b/platforms/Linux/debian/swift-lang-control
@@ -1,5 +1,5 @@
 Package: swift-lang
 Version: @VERSION@
 Architecture: @ARCH@
-Maintainer: Saleem Abdulrasool <compnerd@compnerd.org>
+Maintainer: Swift Open Source Project <swift-infrastructure@forums.swift.org>
 Description: C/C++/Objective-C/Swift Toolchain

--- a/platforms/Linux/debian/swift-lang-control
+++ b/platforms/Linux/debian/swift-lang-control
@@ -1,0 +1,5 @@
+Package: swift-lang
+Version: @VERSION@
+Architecture: @ARCH@
+Maintainer: Saleem Abdulrasool <compnerd@compnerd.org>
+Description: C/C++/Objective-C/Swift Toolchain

--- a/platforms/Linux/debian/swift-lang-linux-runtime-control
+++ b/platforms/Linux/debian/swift-lang-linux-runtime-control
@@ -1,5 +1,5 @@
 Package: swift-lang-linux-runtime
 Version: @VERSION@
 Architecture: @ARCH@
-Maintainer: Saleem Abdulrasool <compnerd@compnerd.org>
+Maintainer: Swift Open Source Project <swift-infrastructure@forums.swift.org>
 Description: Swift Runtime for Linux

--- a/platforms/Linux/debian/swift-lang-linux-runtime-control
+++ b/platforms/Linux/debian/swift-lang-linux-runtime-control
@@ -1,0 +1,5 @@
+Package: swift-lang-linux-runtime
+Version: @VERSION@
+Architecture: @ARCH@
+Maintainer: Saleem Abdulrasool <compnerd@compnerd.org>
+Description: Swift Runtime for Linux

--- a/platforms/Linux/debian/swift-lang-linux-sdk-control
+++ b/platforms/Linux/debian/swift-lang-linux-sdk-control
@@ -1,5 +1,5 @@
 Package: swift-lang-linux-dev
 Version: @VERSION@
 Architecture: @ARCH@
-Maintainer: Saleem Abdulrasool <compnerd@compnerd.org>
+Maintainer: Swift Open Source Project <swift-infrastructure@forums.swift.org>
 Description: Swift Development Content for Linux

--- a/platforms/Linux/debian/swift-lang-linux-sdk-control
+++ b/platforms/Linux/debian/swift-lang-linux-sdk-control
@@ -1,0 +1,5 @@
+Package: swift-lang-linux-dev
+Version: @VERSION@
+Architecture: @ARCH@
+Maintainer: Saleem Abdulrasool <compnerd@compnerd.org>
+Description: Swift Development Content for Linux


### PR DESCRIPTION
The packaging on debian mostly requires the control files and a
pre-configured layout to package as a root.  This adds the control files
as a starting point.