### PR TITLE
Add support to create repodata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.input
 .output
 .DS_Store

--- a/platforms/Linux/shared/RPM/createrepo/Dockerfile
+++ b/platforms/Linux/shared/RPM/createrepo/Dockerfile
@@ -1,0 +1,16 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+
+FROM centos:8
+LABEL PURPOSE="This image is configured to create repodata"
+
+RUN yum -y update
+
+# RPM and yum development tools
+RUN yum install -y createrepo

--- a/platforms/Linux/shared/RPM/createrepo/createrepo_rpm.sh
+++ b/platforms/Linux/shared/RPM/createrepo/createrepo_rpm.sh
@@ -1,0 +1,40 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+#!/usr/bin/env bash
+
+set -ex
+
+INDIR=/input
+OUTDIR=/output
+if [[ ! -d "$INDIR" ]]; then
+    echo "$INDIR does not exist, unable to copy rpm file!"
+    exit 1
+fi
+if [[ ! -d "$OUTDIR" ]]; then
+    echo "$OUTDIR does not exist, so no place to copy the artifacts!"
+    exit 1
+fi
+
+# always make sure we're up to date
+yum update -y
+
+# prepare direcoties
+mkdir -p $HOME/createrepo/
+
+# Copy rpm file
+cp $INDIR/*.rpm $HOME/createrepo/
+
+# Create the repodata
+createrepo $HOME/createrepo/ 2>&1 | tee /root/createrepo-output.txt
+
+
+# Include the createrepo log which can be used to determine what went
+# wrong if there are no artifacts
+cp $HOME/createrepo-output.txt $OUTDIR
+cp -r $HOME/createrepo/repodata $OUTDIR/repodata

--- a/platforms/Linux/shared/RPM/createrepo/docker-compose.yaml
+++ b/platforms/Linux/shared/RPM/createrepo/docker-compose.yaml
@@ -1,0 +1,44 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+# this setup is designed to build RPM repodata
+# usage:
+# Copy rpm package into .input dir
+# docker-compose -f platforms/Linux/shared/RPM/createrepo/docker-compose.yaml build
+# to shell into the container for debugging purposes:
+# docker-compose -f platforms/Linux/shared/RPM/createrepo/docker-compose.yaml run build
+
+version: "2"
+
+services:
+
+  docker-setup:
+    image: centos8-rpm-createrepo
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+  common: &common
+    image: centos8-rpm-createrepo
+    depends_on: [docker-setup]
+    volumes:
+      - .:/code:z
+      - ./.input:/input:z
+      - ./.output:/output:z
+    working_dir: /code
+    cap_drop:
+      - CAP_NET_RAW
+      - CAP_NET_BIND_SERVICE
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "./createrepo_rpm.sh"
+
+  shell:
+    <<: *common
+    entrypoint: /bin/bash -l


### PR DESCRIPTION
Usage: 
* Create `.input` directory in `platforms/Linux/shared/RPM/createrepo/` and copy in .rpm file. 
* Build Docker image `docker-compose -f platforms/Linux/shared/RPM/createrepo/docker-compose.yaml build`
* Create repodata `docker-compose -f platforms/Linux/shared/RPM/createrepo/docker-compose.yaml run build`
* `.output` directory will contain the `createrepo-output.log` and the `repodata`