### PR TITLE
Support newer Clang in CentOS 7

### DIFF
--- a/platforms/Linux/centos/7/build_rpm.sh
+++ b/platforms/Linux/centos/7/build_rpm.sh
@@ -32,6 +32,9 @@ cp patches/*.patch $HOME/rpmbuild/SOURCES/
 pushd $HOME/rpmbuild/SPECS
 # install all the dependencies needed to build Swift from the spec file itself
 yum-builddep -y ./swift-lang.spec
+# Workaround to support clang-3.5 or a later version
+echo -e ". /opt/rh/sclo-git25/enable\n. /opt/rh/llvm-toolset-7/enable\n. /opt/rh/devtoolset-8/enable\n" >> $HOME/.bashrc
+sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
 # get the sources for Swift as defined in the spec file
 spectool -g -R ./swift-lang.spec
 # Now we proceed to build Swift. If this is successful, we


### PR DESCRIPTION
```
[swift/utils/build-script] ERROR: can't find clang (please install clang-3.5 or a later version)
ERROR: command terminated with a non-zero exit status 1, aborting
```

We were missing these two steps from CentOS 7 Dockerfile: 
```
RUN echo -e ". /opt/rh/sclo-git25/enable\n. /opt/rh/llvm-toolset-7/enable\n. /opt/rh/devtoolset-8/enable\n" >> /home/build-user/.bashrc
RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
```