### PR TITLE
Add Deb package convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,17 @@ Repository configuration: `/repo/<OS>/dists/<OS_VERSION>/swiftlang.list`
 ```
 /repo/centos/releases/8/x86_64/swiftlang-5.5.0-1.el8.x86_64.rpm
 /repo/centos/releases/8/aarch64/swiftlang-5.5.0-1.el8.aarch64.rpm
+/repo/ubuntu/pool/main/s/swiftlang/swiftlang-5.5.0-1-focal_amd64.deb
+/repo/ubuntu/pool/main/s/swiftlang/swiftlang-5.5.0-1-focal_arm64.deb
 ```
 
 * **Package URL:**  
 https://download.swift.org/repo/centos/releases/8/aarch64/swiftlang-5.5.0-1.el8.aarch64.rpm
+https://download.swift.org/repo/ubuntu/pool/main/s/swiftlang/swiftlang-5.5.0-1-focal_arm64.deb
 
 * **Repository configuration file URL:**  
 https://download.swift.org/repo/centos/releases/8/swiftlang.repo
+https://download.swift.org/repo/ubuntu/dists/focal/swiftlang.list
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Package naming convention: `swiftlang-<VERSION>-<RELEASE>.<DIST>.<ARCH>.rpm`
 Pakcage structure: `/repo/<OS>/releases/<OS_VERSION>/<ARCH>/`  
 Repository configuration: `/repo/<OS>/releases/<OS_VERSION>/swiftlang.repo`  
 
+### Deb Naming Convention:
+
+Package naming convention: `swiftlang-<VERSION>-<RELEASE>-<OS_VERSION>_<ARCH>.deb`  
+Package destination: `/repo/<OS>/pool/main/s/swiftlang/`  
+Index destination: `/repo/<OS>/dists/<OS_VERSION>/`  
+Repository configuration: `/repo/<OS>/dists/<OS_VERSION>/swiftlang.list`  
+
 
 #### Example
 


### PR DESCRIPTION
A few points to mention:
- Apt has native support for `release+branch`, so the repos are better arranged in `OS` instead of `OS_VERSION`. This is different from `yum`.
- The conventional path for the package is too awkward for manual downloads.
  - A usual solution is to provide the package through symbolic links (3xx redirection?).
- Apt has a different naming convention from Swift.
  - For OS version, code names like `focal` are **preferred** over `20.04` and `2004`. 
  - For Arch, `amd64` and `arm64` are **used** instead of `x86_64` and `aarch64`.