### PR TITLE
SwiftInstaller: be more aggressive about file replacement

### DIFF
--- a/platforms/Windows/CustomActions/SwiftInstaller/Headers/scoped_raii.hh
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Headers/scoped_raii.hh
@@ -22,6 +22,16 @@ class hkey {
   ~hkey() noexcept { (void)RegCloseKey(hKey_); }
 };
 
+class handle {
+  HANDLE hHandle_;
+
+ public:
+  explicit handle(HANDLE hHandle) noexcept : hHandle_(hHandle) {}
+
+  // TODO(compnerd) log failure
+  ~handle() noexcept { (void)CloseHandle(hHandle_); }
+};
+
 class com_initializer {
   HRESULT hr_;
 

--- a/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
+++ b/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
@@ -65,7 +65,7 @@
       <PreprocessorDefinitions>SwiftInstaller_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>msi.lib</AdditionalDependencies>
+      <AdditionalDependencies>msi.lib;RpcRT4.Lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
The `std::filesystem::copy_file` implementation uses `CopyFileW` which
will copy the source to the destination.  If the destination is a
symbolic link, the link will be followed even if we are trying to
overwrite the destination.

Copy the source file renamed to the destination directory and then move
it into place.  The temporary file is named using a UUID as
`GetTempFileW` cannot be used properly here - the parent path is limited
to MAX_PATH - 14 characters, and using `GetTempPath` may provide a path
on a different volume which introduces a new race condition.  This
temporary file is then renamed into the destination by using the
`SetFileInformationByHandle` using the under-documented
`FileRenameInfoEx` to use the POSIX semantics for the rename ensuring
that the file replacement is atomic and concurrent accesses do not cause
a failure.

This should allow overwriting the existing entry even if it is a broken
symbolic link, which was reported on the forums by ericsink.