### PR TITLE
Windows: shuffle files in the MSI packaging

### DIFF
--- a/platforms/Windows/devtools.wxs
+++ b/platforms/Windows/devtools.wxs
@@ -67,23 +67,6 @@
       </Component>
       <?endif?>
 
-      <!-- llbuild -->
-      <Component Id="LLBUILD_BINS" Guid="ff7fc643-d14b-465b-ba9e-79191c27d403">
-        <File Id="LLBUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.dll" Checksum="yes" />
-        <File Id="LLBUILDSWIFT_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" Checksum="yes" />
-
-        <File Id="SWIFT_BUILD_TOOL_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="LLBUILD_DEBUGINFO" Guid="a74f4415-d0a8-42c2-adaf-abd98d2865b5">
-        <File Id="LLBUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.pdb" Checksum="yes" />
-        <File Id="LLBUILDSWIFT_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" />
-
-        <File Id="SWIFT_BUILD_TOOL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-
       <!-- SourceKit-LSP -->
       <Component Id="SOURCEKIT_LSP_BINS" Guid="5ca5d02f-76f3-4537-9dfb-a3fdb6381ac4">
         <File Id="BUILD_SERVER_PROTOCOL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\BuildServerProtocol.dll" Checksum="yes" />
@@ -113,19 +96,6 @@
       </Component>
       <?endif?>
 
-      <!-- swift-argument-parser -->
-      <Component Id="SWIFT_ARGUMENT_PARSER_BINS" Guid="ead7f2bd-f3ce-4f50-a04e-a2b9af25ae03">
-        <File Id="ARGUMENT_PARSER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
-        <File Id="ARGUMENT_PARSER_TOOL_INFO_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.dll" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_ARGUMENT_PARSER_DEBUGINFO" Guid="93c2ef9c-ba1f-462c-8701-2d77125ec9c8">
-        <File Id="ARGUMENT_PARSER_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" />
-        <File Id="ARGUMENT_PARSER_TOOL_INFO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-
       <!-- swift-crypto -->
       <Component Id="SWIFT_CRYPTO_BINS" Guid="8f4fb997-7a41-4d37-a3d4-f5e006f5e3c4">
         <File Id="CRYPTO_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
@@ -149,19 +119,6 @@
         <File Id="COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
         <File Id="DEQUE_MODULE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
         <File Id="ORDERED_COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-
-      <!-- swift-driver -->
-      <Component Id="SWIFT_DRIVER_BINS" Guid="6108d465-9eb5-441f-8cde-5437457fb539">
-        <File Id="SWIFT_DRIVER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
-        <File Id="SWIFT_OPTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_DRIVER_DEBUGINFO" Guid="2e5f4e86-628c-4184-99eb-9385efdebe83">
-        <File Id="SWIFT_DRIVER_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" />
-        <File Id="SWIFT_OPTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" />
       </Component>
       <?endif?>
 
@@ -230,34 +187,6 @@
         <File Id="SWIFT_PACKAGE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.pdb" Checksum="yes" />
       </Component>
       <?endif?>
-
-      <!-- swift-tools-support-core -->
-      <Component Id="SWIFT_TOOLS_SUPPORT_CORE_BINS" Guid="24999b97-7709-4a57-a987-4f8b7e16bb53">
-        <File Id="TSC_BASIC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" Checksum="yes" />
-        <File Id="TSC_LIBC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.dll" Checksum="yes" />
-        <File Id="TSC_UTILITY_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_TOOLS_SUPPORT_CORE_DEBUGINFO" Guid="9487dcfc-ceb1-4763-9db5-af7b52687197">
-        <File Id="TSC_BASIC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" />
-        <File Id="TSC_LIBC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.pdb" Checksum="yes" />
-        <File Id="TSC_UTILITY_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-
-      <!--- Yams -->
-      <Component Id="YAMS_BINS" Guid="d60b565d-9efe-42db-b821-fa1d6ad4d2e2">
-        <File Id="CYAML_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CYaml.dll" Checksum="yes" />
-        <File Id="YAMS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="YAMS_DEBUGINFO" Guid="b09420e8-6c4f-4a9e-8882-4d399ed02ed5">
-        <File Id="CYAML_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CYaml.pdb" Checksum="yes" />
-        <File Id="YAMS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
     </DirectoryRef>
 
     <DirectoryRef Id="USR_LIB_SWIFT_PM_MANIFEST_API">
@@ -277,34 +206,24 @@
 
     <Feature Id="DEVTOOLS" Level="1">
       <ComponentRef Id="INDEXSTOREDB_BINS" />
-      <ComponentRef Id="LLBUILD_BINS" />
       <ComponentRef Id="SOURCEKIT_LSP_BINS" />
-      <ComponentRef Id="SWIFT_ARGUMENT_PARSER_BINS" />
       <ComponentRef Id="SWIFT_CRYPTO_BINS" />
       <ComponentRef Id="SWIFT_COLLECTIONS_BINS" />
-      <ComponentRef Id="SWIFT_DRIVER_BINS" />
       <ComponentRef Id="SWIFT_PACKAGE_MANAGER_BINS" />
       <ComponentRef Id="SWIFT_SYSTEM_BINS" />
-      <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_BINS" />
       <ComponentRef Id="MANIFEST_API" />
-      <ComponentRef Id="YAMS_BINS" />
     </Feature>
 
     <?ifdef INCLUDE_DEBUG_INFO ?>
     <Feature Id="DEBUGINFO" Level="0">
       <Condition Level="1">INSTALL_DEBUGINFO</Condition>
       <ComponentRef Id="INDEXSTOREDB_DEBUGINFO" />
-      <ComponentRef Id="LLBUILD_DEBUGINFO" />
       <ComponentRef Id="SOURCEKIT_LSP_DEBUGINFO" />
-      <ComponentRef Id="SWIFT_ARGUMENT_PARSER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_CRYPTO_DEBUGINFO" />
       <ComponentRef Id="SWIFT_COLLECTIONS_DEBUGINFO" />
-      <ComponentRef Id="SWIFT_DRIVER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_PACKAGE_MANAGER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_SYSTEM_DEBUGINFO" />
-      <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_DEBUGINFO" />
       <ComponentRef Id="MANIFEST_API_DEBUGINFO" />
-      <ComponentRef Id="YAMS_DEBUGINFO" />
     </Feature>
     <?endif?>
 

--- a/platforms/Windows/toolchain.wixproj
+++ b/platforms/Windows/toolchain.wixproj
@@ -22,7 +22,7 @@
   <Import Project="$(WixTargetsPath)" />
 
   <PropertyGroup>
-    <DefineConstants>ProductVersion=$(ProductVersion);TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;$(INCLUDE_DEBUG_INFO)</DefineConstants>
+    <DefineConstants>ProductVersion=$(ProductVersion);DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;$(INCLUDE_DEBUG_INFO)</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
     <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>

--- a/platforms/Windows/toolchain.wxs
+++ b/platforms/Windows/toolchain.wxs
@@ -20,6 +20,11 @@
     <Media Id="5" Cabinet="Swift_PDBs.cab" />
     <Media Id="6" Cabinet="SourceKit_PDBs.cab" />
     <Media Id="7" Cabinet="LLD_PDBs.cab" />
+    <Media Id="8" Cabinet="LLBuild_PDBs.cab" />
+    <Media Id="9" Cabinet="SwiftDriver_PDBs.cab" />
+    <Media Id="10" Cabinet="ArgumentParser_PDBs.cab" />
+    <Media Id="11" Cabinet="ToolsSupportCore_PDBs.cab" />
+    <Media Id="12" Cabinet="Yams_PDBs.cab" />
     <?endif?>
 
     <!-- Directory Structure -->
@@ -170,12 +175,11 @@
 
         <!-- symlinks -->
         <File Id="SWIFT_AUTOLINK_EXTRACT_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-autolink-extract.exe" Checksum="yes" />
-        <File Id="SWIFTC_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftc.exe" Checksum="yes" />
         <!-- /symlinks -->
 
         <File Id="SWIFT_DEMANGLE_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.exe" Checksum="yes" />
+        <File Id="SWIFT_FRONTEND_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.exe" Checksum="yes" />
         <File Id="SWIFT_REFACTOR_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-refactor.exe" Checksum="yes" />
-        <File Id="SWIFT_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.exe" Checksum="yes" />
         <File Id="SWIFTDEMANGLE_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.dll" Checksum="yes" />
         <File Id="_INTERNALSWIFTSCAN_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.dll" Checksum="yes" />
         <File Id="_INTERNALSWIFTSYNTAXPARSER_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.dll" Checksum="yes" />
@@ -184,6 +188,39 @@
         <File Id="BLOCKSRUNTIME_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
         <File Id="DISPATCH_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
         <File Id="SOURCEKITDINPROC_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.dll" Checksum="yes" />
+
+        <!-- non-LLVM build components -->
+
+        <!-- llbuild -->
+        <File Id="LLBUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.dll" Checksum="yes" />
+        <File Id="LLBUILDSWIFT_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" Checksum="yes" />
+
+        <File Id="SWIFT_BUILD_TOOL_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
+
+        <!-- swift-driver -->
+        <!-- symlinks -->
+        <File Id="SWIFTC_EXE" Name="swiftc.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
+        <!-- /symlinks -->
+
+        <File Id="SWIFT_EXE" Name="swift.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
+        <File Id="SWIFT_HELP_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-help.exe" Checksum="yes" />
+        <File Id="SWIFT_BUILD_SDK_INTERFACES_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-sdk-interfaces.exe" Checksum="yes" />
+        <File Id="SWIFT_OPTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" Checksum="yes" />
+        <File Id="SWIFT_DRIVER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
+        <File Id="SWIFT_DRIVER_EXECUTION_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriverExecution.dll" Checksum="yes" />
+
+        <!-- swift-argument-parser -->
+        <File Id="ARGUMENT_PARSER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
+        <File Id="ARGUMENT_PARSER_TOOL_INFO_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.dll" Checksum="yes" />
+
+        <!-- tools-support-core -->
+        <File Id="TSC_BASIC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" Checksum="yes" />
+        <File Id="TSC_LIBC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.dll" Checksum="yes" />
+        <File Id="TSC_UTILITY_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
+
+        <!-- Yams -->
+        <File Id="CYAML_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CYaml.dll" Checksum="yes" />
+        <File Id="YAMS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -229,8 +266,8 @@
 
         <!-- swift -->
         <File Id="SWIFT_DEMANGLE_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.pdb" Checksum="yes" DiskId="5" />
+        <File Id="SWIFT_FRONTEND_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.pdb" Checksum="yes" DiskId="5" />
         <File Id="SWIFT_REFACTOR_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-refactor.pdb" Checksum="yes" DiskId="5" />
-        <File Id="SWIFT_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.pdb" Checksum="yes" DiskId="5" />
         <File Id="SWIFTDEMANGLE_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="5" />
         <File Id="_INTERNALSWIFTCAN_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.pdb" Checksum="yes" DiskId="5" />
         <File Id="_INTERNALSWIFTSYNTAXPARSER_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.pdb" Checksum="yes" DiskId="5" />
@@ -239,6 +276,33 @@
         <File Id="BLOCKSRUNTIME_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
         <File Id="DISPATCH_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="6" />
         <File Id="SOURCEKITDINPROC_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.pdb" Checksum="yes" DiskId="6" />
+
+        <!-- non-LLVM build components -->
+
+        <!-- llbuild -->
+        <File Id="LLBUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.pdb" Checksum="yes" DiskId="8" />
+        <File Id="LLBUILDSWIFT_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" DiskId="8" />
+
+        <File Id="SWIFT_BUILD_TOOL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" DiskId="8" />
+
+        <!-- swift-driver -->
+        <File Id="SWIFT_PDB" Name="swift.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-driver.pdb" Checksum="yes" DiskId="9" />
+        <File Id="SWIFT_OPTIONS_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" DiskId="9" />
+        <File Id="SWIFT_DRIVER_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" DiskId="9" />
+        <File Id="SWIFT_DRIVER_EXECUTION_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.pdb" Checksum="yes" DiskId="9" />
+
+        <!-- swift-argument-parser -->
+        <File Id="ARGUMENT_PARSER_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" DiskId="10" />
+        <File Id="ARGUMENT_PARSER_TOOL_INFO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.pdb" Checksum="yes" DiskId="10" />
+
+        <!-- tools-support-core -->
+        <File Id="TSC_BASIC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" DiskId="11" />
+        <File Id="TSC_LIBC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.pdb" Checksum="yes" DiskId="11" />
+        <File Id="TSC_UTILITY_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" DiskId="11" />
+
+        <!-- Yams -->
+        <File Id="CYAML_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CYaml.pdb" Checksum="yes" DiskId="12" />
+        <File Id="YAMS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" DiskId="12" />
       </Component>
       <?endif?>
     </DirectoryRef>


### PR DESCRIPTION
This shuffles the swift-driver from devtools to toolchain, replacing the
driver from the swift repository at packaging time.  This is required to
be this way to support bootstrapping and more importantly, to reduce the
overall build times for the toolchain (OSS builders are perilously close
to the time limit, and would fail to build with swift-driver in the same
build).  The toolchain MSI is meant to contain everything that is needed
for building a program manually with the compiler.  This should allow us
to migrate to swift-driver as the official Windows driver.