### PR TITLE
Windows: update packaging manifest for apple/swift-package-manager#4182

### DIFF
--- a/platforms/Windows/devtools.wxs
+++ b/platforms/Windows/devtools.wxs
@@ -127,21 +127,11 @@
         <File Id="BASICS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.dll" Checksum="yes" />
         <File Id="BUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.dll" Checksum="yes" />
         <File Id="COMMANDS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
-        <File Id="LLBUILD_MANIFEST_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LLBuildManifest.dll" Checksum="yes" />
         <File Id="PACKAGE_GRAPH_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
         <File Id="PACKAGE_LOADING_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" Checksum="yes" />
         <File Id="PACKAGE_MODEL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" Checksum="yes" />
-        <File Id="SOURCE_CONTROL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SourceControl.dll" Checksum="yes" />
         <File Id="SPMBUILD_CORE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" Checksum="yes" />
-        <File Id="SPMLLBUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMLLBuild.dll" Checksum="yes" />
         <File Id="WORKSPACE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.dll" Checksum="yes" />
-        <File Id="XCBUILD_SUPPORT_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\XCBuildSupport.dll" Checksum="yes" />
-        <File Id="XCODEPROJ_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Xcodeproj.dll" Checksum="yes" />
-        <File Id="PACKAGE_COLLECTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollections.dll" Checksum="yes" />
-        <File Id="PACKAGE_COLLECTIONS_MODEL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollectionsModel.dll" Checksum="yes" />
-        <File Id="PACKAGE_COLLECTIONS_SIGNING_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollectionsSigning.dll" Checksum="yes" />
-        <File Id="PACKAGE_FINGERPRINT_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageFingerprint.dll" Checksum="yes" />
-        <File Id="PACKAGE_REGISTRY_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageRegistry.dll" Checksum="yes" />
 
         <File Id="SWIFT_BUILD_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.exe" Checksum="yes" />
         <File Id="SWIFT_PACKAGE_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
@@ -154,21 +144,11 @@
         <File Id="BASICS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
         <File Id="BUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
         <File Id="COMMANDS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
-        <File Id="LLBUILD_MANIFEST_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\LLBuildManifest.pdb" Checksum="yes" />
         <File Id="PACKAGE_GRAPH_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
         <File Id="PACKAGE_LOADING_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
         <File Id="PACKAGE_MODEL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
-        <File Id="SOURCE_CONTROL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SourceControl.pdb" Checksum="yes" />
         <File Id="SPMBUILD_CORE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
-        <File Id="SPMLLBUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMLLBuild.pdb" Checksum="yes" />
         <File Id="WORKSPACE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
-        <File Id="XCBUILD_SUPPORT_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\XCBuildSupport.pdb" Checksum="yes" />
-        <File Id="XCODEPROJ_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Xcodeproj.pdb" Checksum="yes" />
-        <File Id="PACKAGE_COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollections.pdb" Checksum="yes" />
-        <File Id="PACKAGE_COLLECTIONS_MODEL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollectionsModel.pdb" Checksum="yes" />
-        <File Id="PACKAGE_COLLECTIONS_SIGNING_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollectionsSigning.pdb" Checksum="yes" />
-        <File Id="PACKAGE_FINGERPRINT_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageFingerprint.pdb" Checksum="yes" />
-        <File Id="PACKAGE_REGISTRY_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageRegistry.pdb" Checksum="yes" />
 
         <File Id="SWIFT_BUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
         <File Id="SWIFT_PACKAGE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />


### PR DESCRIPTION
Update the packaging manifest for partially statically linking the
swift-package-manager libraries.  This reduces the number of distributed
libraries and the overall size of the toolchain by a minuscule amount.