### PR TITLE
update RPM specs dependencies

### DIFF
--- a/platforms/Linux/RPM/Amazonlinux/2/swiftlang.spec
+++ b/platforms/Linux/RPM/Amazonlinux/2/swiftlang.spec
@@ -68,12 +68,12 @@ Requires:       git
 Requires:       glibc-static
 Requires:       gzip
 Requires:       libbsd
-Requires:       libcurl
+Requires:       libcurl-devel
 Requires:       libedit
 Requires:       libicu
 Requires:       libstdc++-static
 Requires:       libuuid
-Requires:       libxml2
+Requires:       libxml2-devel
 Requires:       sqlite
 Requires:       tar
 Requires:       tzdata

--- a/platforms/Linux/RPM/Centos/7/swiftlang.spec
+++ b/platforms/Linux/RPM/Centos/7/swiftlang.spec
@@ -69,10 +69,12 @@ Requires:       gcc
 Requires:       git
 Requires:       glibc-static
 Requires:       libbsd-devel
+Requires:       libcurl-devel
 Requires:       libedit
 Requires:       libedit-devel
 Requires:       libicu-devel
 Requires:       libstdc++-static
+Requires:       libxml2-devel
 Requires:       pkgconfig
 Requires:       python3
 Requires:       sqlite

--- a/platforms/Linux/RPM/Centos/8/swiftlang.spec
+++ b/platforms/Linux/RPM/Centos/8/swiftlang.spec
@@ -68,10 +68,12 @@ Requires:       gcc
 Requires:       git
 Requires:       glibc-static
 Requires:       libbsd-devel
+Requires:       libcurl-devel
 Requires:       libedit
 Requires:       libedit-devel
 Requires:       libicu-devel
 Requires:       libstdc++-static
+Requires:       libxml2-devel
 Requires:       pkg-config
 Requires:       python3
 Requires:       sqlite


### PR DESCRIPTION
motivation: static linking required the development version of libxml2 and libcurl

changes: include libxml2-devel and libcurl-devel which are needed for static linking