### PR TITLE
improve RPM spec formatting

### DIFF
--- a/platforms/Linux/RPM/Centos/7/swiftlang.spec
+++ b/platforms/Linux/RPM/Centos/7/swiftlang.spec
@@ -44,7 +44,6 @@ Source31:       https://github.com/apple/swift-format/archive/swift-%{swift_vers
 Source32:       https://github.com/apple/swift-lmdb/archive/swift-%{swift_version}.tar.gz#/swift-lmdb.tar.gz
 Source33:       https://github.com/apple/swift-markdown/archive/swift-%{swift_version}.tar.gz#/swift-markdown.tar.gz
 
-
 Patch0:         patches/hwasan_symbolize.patch
 
 BuildRequires:  autoconf
@@ -64,9 +63,9 @@ BuildRequires:  ninja-build
 BuildRequires:  openssl-devel
 BuildRequires:  pexpect
 BuildRequires:  python-devel
-BuildRequires:  python3-devel
 BuildRequires:  python-pygments
 BuildRequires:  python-six
+BuildRequires:  python3-devel
 BuildRequires:  python36-pexpect
 BuildRequires:  python36-six
 BuildRequires:  PyYAML

--- a/platforms/Linux/RPM/Centos/8/swiftlang.spec
+++ b/platforms/Linux/RPM/Centos/8/swiftlang.spec
@@ -62,16 +62,16 @@ BuildRequires:  libxml2-devel
 BuildRequires:  make
 BuildRequires:  ncurses-devel
 BuildRequires:  pcre-devel
+BuildRequires:  platform-python-devel
 BuildRequires:  python2
 BuildRequires:  python2-devel
 BuildRequires:  python2-six
 BuildRequires:  python3
-BuildRequires:  python3-six
 BuildRequires:  python3-pexpect
-BuildRequires:  platform-python-devel
+BuildRequires:  python3-six
+BuildRequires:  rsync
 BuildRequires:  sqlite-devel
 BuildRequires:  swig
-BuildRequires:  rsync
 BuildRequires:  tar
 BuildRequires:  which
 

--- a/platforms/Linux/RPM/Fedora/34/swiftlang.spec
+++ b/platforms/Linux/RPM/Fedora/34/swiftlang.spec
@@ -59,99 +59,91 @@ Source32:       https://github.com/apple/swift-lmdb/archive/swift-%{swift_versio
 Source33:       https://github.com/apple/swift-markdown/archive/swift-%{swift_version}.tar.gz#/swift-markdown.tar.gz
 
 Patch0:         nocyclades.patch
-Patch1:			unusedvariable.patch
- 
+Patch1:         unusedvariable.patch
+
 BuildRequires:  clang
-BuildRequires:  swig
-BuildRequires:  rsync
-BuildRequires:  python3
-BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-distro
 BuildRequires:  libbsd-devel
-BuildRequires:  libxml2-devel
-BuildRequires:  libsqlite3x-devel
-BuildRequires:  libdispatch-devel
 BuildRequires:  libcurl-devel
-BuildRequires:  libuuid-devel
+BuildRequires:  libdispatch-devel
 BuildRequires:  libedit-devel
 BuildRequires:  libicu-devel
+BuildRequires:  libsqlite3x-devel
+BuildRequires:  libuuid-devel
+BuildRequires:  libxml2-devel
 BuildRequires:  perl-podlators
+BuildRequires:  python3
+BuildRequires:  python3-devel
+BuildRequires:  python3-distro
+BuildRequires:  python3-setuptools
 BuildRequires:  python3-six
-BuildRequires:  /usr/bin/pathfix.py
-BuildRequires:  cmake
+BuildRequires:  rsync
+BuildRequires:  swig
 %if ! 0%{?el8}
 BuildRequires:	python-unversioned-command
 %endif
+BuildRequires:  /usr/bin/pathfix.py
 
-Requires:       glibc-devel
 Requires:       binutils-gold
 Requires:       gcc
-Requires:       ncurses-devel
+Requires:       glibc-devel
 Requires:       ncurses-compat-libs
+Requires:       ncurses-devel
 
-ExclusiveArch:  x86_64 aarch64 
+ExclusiveArch:  x86_64 aarch64
 
 Provides: 	swiftlang = %{version}-%{release}
 
 %description
-Swift is a general-purpose programming language built using 
-a modern approach to safety, performance, and software design 
+Swift is a general-purpose programming language built using
+a modern approach to safety, performance, and software design
 patterns.
 
-The goal of the Swift project is to create the best available 
-language for uses ranging from systems programming, to mobile 
-and desktop apps, scaling up to cloud services. Most 
-importantly, Swift is designed to make writing and maintaining 
-correct programs easier for the developer. 
-
+The goal of the Swift project is to create the best available
+language for uses ranging from systems programming, to mobile
+and desktop apps, scaling up to cloud services. Most
+importantly, Swift is designed to make writing and maintaining
+correct programs easier for the developer.
 
 %prep
 %setup -q -c -n %{swift_source_location} -a 0 -a 1 -a 2 -a 3 -a 4 -a 5 -a 6 -a 7 -a 8 -a 9 -a 10 -a 11 -a 12 -a 13 -a 14 -a 15 -a 16 -a 17 -a 18 -a 19 -a 20 -a 21 -a 22 -a 23 -a 24 -a 25 -a 26 -a 27 -a 28 -a 29 -a 30 -a 31 -a 32 -a 33
 # The Swift build script requires directories to be named
 # in a specific way so renaming the source directories is
 # necessary
+mv CMake-%{cmake_version} cmake
+mv icu-release-%{icu_version} icu
+mv indexstore-db-swift-%{swift_version} indexstore-db
+mv llvm-project-swift-%{swift_version} llvm-project
+mv ninja-%{ninja_version} ninja
+mv ninja-%{ninja_version} ninja
+mv sourcekit-lsp-swift-%{swift_version} sourcekit-lsp
+mv swift-argument-parser-%{swift_argument_parser_version} swift-argument-parser
+mv swift-atomics-%{swift_atomics_version} swift-atomics
 mv swift-cmark-swift-%{swift_version} cmark
+mv swift-cmark-swift-%{swift_version}-gfm swift-cmark-gfm
+mv swift-collections-%{swift_collections_version} swift-collections
 mv swift-corelibs-foundation-swift-%{swift_version} swift-corelibs-foundation
 mv swift-corelibs-libdispatch-swift-%{swift_version} swift-corelibs-libdispatch
 mv swift-corelibs-xctest-swift-%{swift_version} swift-corelibs-xctest
+mv swift-crypto-%{swift_crypto_version} swift-crypto
+mv swift-docc-render-artifact-swift-%{swift_version} swift-docc-render-artifact
+mv swift-docc-swift-%{swift_version} swift-docc
+mv swift-docc-symbolkit-swift-%{swift_version} swift-docc-symbolkit
+mv swift-driver-swift-%{swift_version} swift-driver
+mv swift-format-swift-%{swift_version} swift-format
 mv swift-integration-tests-swift-%{swift_version} swift-integration-tests
 mv swift-llbuild-swift-%{swift_version} llbuild
-mv swift-package-manager-swift-%{swift_version} swiftpm
-mv swift-swift-%{swift_version} swift
-mv swift-xcode-playground-support-swift-%{swift_version} swift-xcode-playground-support
-mv sourcekit-lsp-swift-%{swift_version} sourcekit-lsp
-mv indexstore-db-swift-%{swift_version} indexstore-db
-mv llvm-project-swift-%{swift_version} llvm-project
-mv swift-syntax-swift-%{swift_version} swift-syntax
-mv swift-tools-support-core-swift-%{swift_version} swift-tools-support-core
-mv swift-argument-parser-%{swift_argument_parser_version} swift-argument-parser
-mv swift-driver-swift-%{swift_version} swift-driver
-mv swift-crypto-%{swift_crypto_version} swift-crypto
-mv ninja-%{ninja_version} ninja
-mv CMake-%{cmake_version} cmake
-mv swift-atomics-%{swift_atomics_version} swift-atomics
-mv swift-cmark-swift-%{swift_version}-gfm swift-cmark-gfm
-mv swift-docc-swift-%{swift_version} swift-docc
-mv swift-docc-render-artifact-swift-%{swift_version} swift-docc-render-artifact
-mv swift-docc-symbolkit-swift-%{swift_version} swift-docc-symbolkit
-mv swift-collections-%{swift_collections_version} swift-collections
-mv swift-numerics-%{swift_numerics_version} swift-numerics
-mv swift-system-%{swift_system_version} swift-system
-mv swift-nio-%{swift_nio_version} swift-nio
-mv swift-nio-ssl-%{swift_nio_ssl_version} swift-nio-ssl
-mv swift-format-swift-%{swift_version} swift-format
 mv swift-lmdb-swift-%{swift_version} swift-lmdb
 mv swift-markdown-swift-%{swift_version} swift-markdown
-
-# ICU 
-mv icu-release-%{icu_version} icu
-
-# Yams
+mv swift-nio-%{swift_nio_version} swift-nio
+mv swift-nio-ssl-%{swift_nio_ssl_version} swift-nio-ssl
+mv swift-numerics-%{swift_numerics_version} swift-numerics
+mv swift-package-manager-swift-%{swift_version} swiftpm
+mv swift-swift-%{swift_version} swift
+mv swift-syntax-swift-%{swift_version} swift-syntax
+mv swift-system-%{swift_system_version} swift-system
+mv swift-tools-support-core-swift-%{swift_version} swift-tools-support-core
+mv swift-xcode-playground-support-swift-%{swift_version} swift-xcode-playground-support
 mv Yams-%{yams_version} yams
-
-# Ninja
-mv ninja-%{ninja_version} ninja
 
 # Remove Cyclades as it has been removed from the Linux kernel
 %patch0 -p0
@@ -159,14 +151,13 @@ mv ninja-%{ninja_version} ninja
 # Temp patch to test libdispatch issue with clang 13
 %patch1 -p0
 
-# Fix python to python3 
+# Fix python to python3
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" swift/utils/api_checker/swift-api-checker.py
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" llvm-project/compiler-rt/lib/hwasan/scripts/hwasan_symbolize
 
-
 %build
 export VERBOSE=1
-# Before Fedora 34, we may not have /usr/bin/python, so we 
+# Before Fedora 34, we may not have /usr/bin/python, so we
 # roll our own because the build script expects there to be one.
 %if 0%{?fedora} < 34 || 0%{?el8}
 mkdir $PWD/binforpython
@@ -176,7 +167,6 @@ export PATH=$PWD/binforpython:$PATH
 
 # Here we go!
 swift/utils/build-script --preset=buildbot_linux,no_assertions,no_test install_destdir=%{_builddir} installable_package=%{_builddir}/swift-%{version}-%{linux_version}.tar.gz
-
 
 %install
 mkdir -p %{buildroot}%{_libexecdir}/swift/%{package_version}
@@ -192,7 +182,6 @@ cp %{_builddir}/usr/share/man/man1/swift.1 %{buildroot}%{_mandir}/man1/swift.1
 # how the Swift binaries use RPATH
 export QA_SKIP_RPATHS=1
 
-
 %files
 %license swift/LICENSE.txt
 %{_bindir}/swift
@@ -201,9 +190,7 @@ export QA_SKIP_RPATHS=1
 %{_mandir}/man1/swift.1.gz
 %{_libexecdir}/swift/
 
-
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
-
 
 %changelog

--- a/platforms/Linux/RPM/Fedora/35/swiftlang.spec
+++ b/platforms/Linux/RPM/Fedora/35/swiftlang.spec
@@ -60,51 +60,50 @@ Source32:       https://github.com/apple/swift-lmdb/archive/swift-%{swift_versio
 Source33:       https://github.com/apple/swift-markdown/archive/swift-%{swift_version}.tar.gz#/swift-markdown.tar.gz
 
 Patch0:         nocyclades.patch
-Patch1:			unusedvariable.patch
- 
+Patch1:         unusedvariable.patch
+
 BuildRequires:  clang
-BuildRequires:  swig
-BuildRequires:  rsync
-BuildRequires:  python3
-BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-distro
 BuildRequires:  libbsd-devel
-BuildRequires:  libxml2-devel
-BuildRequires:  libsqlite3x-devel
-BuildRequires:  libdispatch-devel
 BuildRequires:  libcurl-devel
-BuildRequires:  libuuid-devel
+BuildRequires:  libdispatch-devel
 BuildRequires:  libedit-devel
 BuildRequires:  libicu-devel
+BuildRequires:  libsqlite3x-devel
+BuildRequires:  libuuid-devel
+BuildRequires:  libxml2-devel
 BuildRequires:  perl-podlators
+BuildRequires:  python3
+BuildRequires:  python3-devel
+BuildRequires:  python3-distro
+BuildRequires:  python3-setuptools
 BuildRequires:  python3-six
-BuildRequires:  /usr/bin/pathfix.py
-BuildRequires:  cmake
+BuildRequires:  rsync
+BuildRequires:  swig
 %if ! 0%{?el8}
 BuildRequires:	python-unversioned-command
 %endif
+BuildRequires:  /usr/bin/pathfix.py
 
-Requires:       glibc-devel
 Requires:       binutils-gold
 Requires:       gcc
-Requires:       ncurses-devel
+Requires:       glibc-devel
 Requires:       ncurses-compat-libs
+Requires:       ncurses-devel
 
-ExclusiveArch:  x86_64 aarch64 
+ExclusiveArch:  x86_64 aarch64
 
 Provides: 	swiftlang = %{version}-%{release}
 
 %description
-Swift is a general-purpose programming language built using 
-a modern approach to safety, performance, and software design 
+Swift is a general-purpose programming language built using
+a modern approach to safety, performance, and software design
 patterns.
 
-The goal of the Swift project is to create the best available 
-language for uses ranging from systems programming, to mobile 
-and desktop apps, scaling up to cloud services. Most 
-importantly, Swift is designed to make writing and maintaining 
-correct programs easier for the developer. 
+The goal of the Swift project is to create the best available
+language for uses ranging from systems programming, to mobile
+and desktop apps, scaling up to cloud services. Most
+importantly, Swift is designed to make writing and maintaining
+correct programs easier for the developer.
 
 
 %prep
@@ -112,47 +111,41 @@ correct programs easier for the developer.
 # The Swift build script requires directories to be named
 # in a specific way so renaming the source directories is
 # necessary
+mv CMake-%{cmake_version} cmake
+mv icu-release-%{icu_version} icu
+mv indexstore-db-swift-%{swift_version} indexstore-db
+mv llvm-project-swift-%{swift_version} llvm-project
+mv ninja-%{ninja_version} ninja
+mv ninja-%{ninja_version} ninja
+mv sourcekit-lsp-swift-%{swift_version} sourcekit-lsp
+mv swift-argument-parser-%{swift_argument_parser_version} swift-argument-parser
+mv swift-atomics-%{swift_atomics_version} swift-atomics
 mv swift-cmark-swift-%{swift_version} cmark
+mv swift-cmark-swift-%{swift_version}-gfm swift-cmark-gfm
+mv swift-collections-%{swift_collections_version} swift-collections
 mv swift-corelibs-foundation-swift-%{swift_version} swift-corelibs-foundation
 mv swift-corelibs-libdispatch-swift-%{swift_version} swift-corelibs-libdispatch
 mv swift-corelibs-xctest-swift-%{swift_version} swift-corelibs-xctest
+mv swift-crypto-%{swift_crypto_version} swift-crypto
+mv swift-docc-render-artifact-swift-%{swift_version} swift-docc-render-artifact
+mv swift-docc-swift-%{swift_version} swift-docc
+mv swift-docc-symbolkit-swift-%{swift_version} swift-docc-symbolkit
+mv swift-driver-swift-%{swift_version} swift-driver
+mv swift-format-swift-%{swift_version} swift-format
 mv swift-integration-tests-swift-%{swift_version} swift-integration-tests
 mv swift-llbuild-swift-%{swift_version} llbuild
-mv swift-package-manager-swift-%{swift_version} swiftpm
-mv swift-swift-%{swift_version} swift
-mv swift-xcode-playground-support-swift-%{swift_version} swift-xcode-playground-support
-mv sourcekit-lsp-swift-%{swift_version} sourcekit-lsp
-mv indexstore-db-swift-%{swift_version} indexstore-db
-mv llvm-project-swift-%{swift_version} llvm-project
-mv swift-syntax-swift-%{swift_version} swift-syntax
-mv swift-tools-support-core-swift-%{swift_version} swift-tools-support-core
-mv swift-argument-parser-%{swift_argument_parser_version} swift-argument-parser
-mv swift-driver-swift-%{swift_version} swift-driver
-mv swift-crypto-%{swift_crypto_version} swift-crypto
-mv ninja-%{ninja_version} ninja
-mv CMake-%{cmake_version} cmake
-mv swift-atomics-%{swift_atomics_version} swift-atomics
-mv swift-cmark-swift-%{swift_version}-gfm swift-cmark-gfm
-mv swift-docc-swift-%{swift_version} swift-docc
-mv swift-docc-render-artifact-swift-%{swift_version} swift-docc-render-artifact
-mv swift-docc-symbolkit-swift-%{swift_version} swift-docc-symbolkit
-mv swift-collections-%{swift_collections_version} swift-collections
-mv swift-numerics-%{swift_numerics_version} swift-numerics
-mv swift-system-%{swift_system_version} swift-system
-mv swift-nio-%{swift_nio_version} swift-nio
-mv swift-nio-ssl-%{swift_nio_ssl_version} swift-nio-ssl
-mv swift-format-swift-%{swift_version} swift-format
 mv swift-lmdb-swift-%{swift_version} swift-lmdb
 mv swift-markdown-swift-%{swift_version} swift-markdown
-
-# ICU 
-mv icu-release-%{icu_version} icu
-
-# Yams
+mv swift-nio-%{swift_nio_version} swift-nio
+mv swift-nio-ssl-%{swift_nio_ssl_version} swift-nio-ssl
+mv swift-numerics-%{swift_numerics_version} swift-numerics
+mv swift-package-manager-swift-%{swift_version} swiftpm
+mv swift-swift-%{swift_version} swift
+mv swift-syntax-swift-%{swift_version} swift-syntax
+mv swift-system-%{swift_system_version} swift-system
+mv swift-tools-support-core-swift-%{swift_version} swift-tools-support-core
+mv swift-xcode-playground-support-swift-%{swift_version} swift-xcode-playground-support
 mv Yams-%{yams_version} yams
-
-# Ninja
-mv ninja-%{ninja_version} ninja
 
 # Remove Cyclades as it has been removed from the Linux kernel
 %patch0 -p0
@@ -160,14 +153,13 @@ mv ninja-%{ninja_version} ninja
 # Temp patch to test libdispatch issue with clang 13
 %patch1 -p0
 
-# Fix python to python3 
+# Fix python to python3
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" swift/utils/api_checker/swift-api-checker.py
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" llvm-project/compiler-rt/lib/hwasan/scripts/hwasan_symbolize
 
-
 %build
 export VERBOSE=1
-# Before Fedora 34, we may not have /usr/bin/python, so we 
+# Before Fedora 34, we may not have /usr/bin/python, so we
 # roll our own because the build script expects there to be one.
 %if 0%{?fedora} < 34 || 0%{?el8}
 mkdir $PWD/binforpython
@@ -177,7 +169,6 @@ export PATH=$PWD/binforpython:$PATH
 
 # Here we go!
 swift/utils/build-script --preset=buildbot_linux,no_assertions,no_test install_destdir=%{_builddir} installable_package=%{_builddir}/swift-%{version}-%{linux_version}.tar.gz
-
 
 %install
 mkdir -p %{buildroot}%{_libexecdir}/swift/%{package_version}
@@ -193,7 +184,6 @@ cp %{_builddir}/usr/share/man/man1/swift.1 %{buildroot}%{_mandir}/man1/swift.1
 # how the Swift binaries use RPATH
 export QA_SKIP_RPATHS=1
 
-
 %files
 %license swift/LICENSE.txt
 %{_bindir}/swift
@@ -202,9 +192,7 @@ export QA_SKIP_RPATHS=1
 %{_mandir}/man1/swift.1.gz
 %{_libexecdir}/swift/
 
-
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
-
 
 %changelog

--- a/platforms/Linux/RPM/Fedora/rawhide/swiftlang.spec
+++ b/platforms/Linux/RPM/Fedora/rawhide/swiftlang.spec
@@ -61,98 +61,90 @@ Source33:       https://github.com/apple/swift-markdown/archive/swift-%{swift_ve
 
 Patch0:         nocyclades.patch
 Patch1:			unusedvariable.patch
- 
+
 BuildRequires:  clang
-BuildRequires:  swig
-BuildRequires:  rsync
-BuildRequires:  python3
-BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-distro
 BuildRequires:  libbsd-devel
-BuildRequires:  libxml2-devel
-BuildRequires:  libsqlite3x-devel
-BuildRequires:  libdispatch-devel
 BuildRequires:  libcurl-devel
-BuildRequires:  libuuid-devel
+BuildRequires:  libdispatch-devel
 BuildRequires:  libedit-devel
 BuildRequires:  libicu-devel
+BuildRequires:  libsqlite3x-devel
+BuildRequires:  libuuid-devel
+BuildRequires:  libxml2-devel
 BuildRequires:  perl-podlators
+BuildRequires:  python3
+BuildRequires:  python3-devel
+BuildRequires:  python3-distro
+BuildRequires:  python3-setuptools
 BuildRequires:  python3-six
-BuildRequires:  /usr/bin/pathfix.py
-BuildRequires:  cmake
+BuildRequires:  rsync
+BuildRequires:  swig
 %if ! 0%{?el8}
 BuildRequires:	python-unversioned-command
 %endif
+BuildRequires:  /usr/bin/pathfix.py
 
-Requires:       glibc-devel
 Requires:       binutils-gold
 Requires:       gcc
-Requires:       ncurses-devel
+Requires:       glibc-devel
 Requires:       ncurses-compat-libs
+Requires:       ncurses-devel
 
-ExclusiveArch:  x86_64 aarch64 
+ExclusiveArch:  x86_64 aarch64
 
 Provides: 	swiftlang = %{version}-%{release}
 
 %description
-Swift is a general-purpose programming language built using 
-a modern approach to safety, performance, and software design 
+Swift is a general-purpose programming language built using
+a modern approach to safety, performance, and software design
 patterns.
 
-The goal of the Swift project is to create the best available 
-language for uses ranging from systems programming, to mobile 
-and desktop apps, scaling up to cloud services. Most 
-importantly, Swift is designed to make writing and maintaining 
-correct programs easier for the developer. 
-
+The goal of the Swift project is to create the best available
+language for uses ranging from systems programming, to mobile
+and desktop apps, scaling up to cloud services. Most
+importantly, Swift is designed to make writing and maintaining
+correct programs easier for the developer.
 
 %prep
 %setup -q -c -n %{swift_source_location} -a 0 -a 1 -a 2 -a 3 -a 4 -a 5 -a 6 -a 7 -a 8 -a 9 -a 10 -a 11 -a 12 -a 13 -a 14 -a 15 -a 16 -a 17 -a 18 -a 19 -a 20 -a 21 -a 22 -a 23 -a 24 -a 25 -a 26 -a 27 -a 28 -a 29 -a 30 -a 31 -a 32 -a 33
 # The Swift build script requires directories to be named
 # in a specific way so renaming the source directories is
 # necessary
+mv CMake-%{cmake_version} cmake
+mv icu-release-%{icu_version} icu
+mv indexstore-db-swift-%{swift_version} indexstore-db
+mv llvm-project-swift-%{swift_version} llvm-project
+mv ninja-%{ninja_version} ninja
+mv ninja-%{ninja_version} ninja
+mv sourcekit-lsp-swift-%{swift_version} sourcekit-lsp
+mv swift-argument-parser-%{swift_argument_parser_version} swift-argument-parser
+mv swift-atomics-%{swift_atomics_version} swift-atomics
 mv swift-cmark-swift-%{swift_version} cmark
+mv swift-cmark-swift-%{swift_version}-gfm swift-cmark-gfm
+mv swift-collections-%{swift_collections_version} swift-collections
 mv swift-corelibs-foundation-swift-%{swift_version} swift-corelibs-foundation
 mv swift-corelibs-libdispatch-swift-%{swift_version} swift-corelibs-libdispatch
 mv swift-corelibs-xctest-swift-%{swift_version} swift-corelibs-xctest
+mv swift-crypto-%{swift_crypto_version} swift-crypto
+mv swift-docc-render-artifact-swift-%{swift_version} swift-docc-render-artifact
+mv swift-docc-swift-%{swift_version} swift-docc
+mv swift-docc-symbolkit-swift-%{swift_version} swift-docc-symbolkit
+mv swift-driver-swift-%{swift_version} swift-driver
+mv swift-format-swift-%{swift_version} swift-format
 mv swift-integration-tests-swift-%{swift_version} swift-integration-tests
 mv swift-llbuild-swift-%{swift_version} llbuild
-mv swift-package-manager-swift-%{swift_version} swiftpm
-mv swift-swift-%{swift_version} swift
-mv swift-xcode-playground-support-swift-%{swift_version} swift-xcode-playground-support
-mv sourcekit-lsp-swift-%{swift_version} sourcekit-lsp
-mv indexstore-db-swift-%{swift_version} indexstore-db
-mv llvm-project-swift-%{swift_version} llvm-project
-mv swift-syntax-swift-%{swift_version} swift-syntax
-mv swift-tools-support-core-swift-%{swift_version} swift-tools-support-core
-mv swift-argument-parser-%{swift_argument_parser_version} swift-argument-parser
-mv swift-driver-swift-%{swift_version} swift-driver
-mv swift-crypto-%{swift_crypto_version} swift-crypto
-mv ninja-%{ninja_version} ninja
-mv CMake-%{cmake_version} cmake
-mv swift-atomics-%{swift_atomics_version} swift-atomics
-mv swift-cmark-swift-%{swift_version}-gfm swift-cmark-gfm
-mv swift-docc-swift-%{swift_version} swift-docc
-mv swift-docc-render-artifact-swift-%{swift_version} swift-docc-render-artifact
-mv swift-docc-symbolkit-swift-%{swift_version} swift-docc-symbolkit
-mv swift-collections-%{swift_collections_version} swift-collections
-mv swift-numerics-%{swift_numerics_version} swift-numerics
-mv swift-system-%{swift_system_version} swift-system
-mv swift-nio-%{swift_nio_version} swift-nio
-mv swift-nio-ssl-%{swift_nio_ssl_version} swift-nio-ssl
-mv swift-format-swift-%{swift_version} swift-format
 mv swift-lmdb-swift-%{swift_version} swift-lmdb
 mv swift-markdown-swift-%{swift_version} swift-markdown
-
-# ICU 
-mv icu-release-%{icu_version} icu
-
-# Yams
+mv swift-nio-%{swift_nio_version} swift-nio
+mv swift-nio-ssl-%{swift_nio_ssl_version} swift-nio-ssl
+mv swift-numerics-%{swift_numerics_version} swift-numerics
+mv swift-package-manager-swift-%{swift_version} swiftpm
+mv swift-swift-%{swift_version} swift
+mv swift-syntax-swift-%{swift_version} swift-syntax
+mv swift-system-%{swift_system_version} swift-system
+mv swift-tools-support-core-swift-%{swift_version} swift-tools-support-core
+mv swift-xcode-playground-support-swift-%{swift_version} swift-xcode-playground-support
 mv Yams-%{yams_version} yams
-
-# Ninja
-mv ninja-%{ninja_version} ninja
 
 # Remove Cyclades as it has been removed from the Linux kernel
 %patch0 -p0
@@ -160,14 +152,13 @@ mv ninja-%{ninja_version} ninja
 # Temp patch to test libdispatch issue with clang 13
 %patch1 -p0
 
-# Fix python to python3 
+# Fix python to python3
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" swift/utils/api_checker/swift-api-checker.py
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" llvm-project/compiler-rt/lib/hwasan/scripts/hwasan_symbolize
 
-
 %build
 export VERBOSE=1
-# Before Fedora 34, we may not have /usr/bin/python, so we 
+# Before Fedora 34, we may not have /usr/bin/python, so we
 # roll our own because the build script expects there to be one.
 %if 0%{?fedora} < 34 || 0%{?el8}
 mkdir $PWD/binforpython
@@ -178,21 +169,19 @@ export PATH=$PWD/binforpython:$PATH
 # Here we go!
 swift/utils/build-script --preset=buildbot_linux,no_assertions,no_test install_destdir=%{_builddir} installable_package=%{_builddir}/swift-%{version}-%{linux_version}.tar.gz
 
-
 %install
-mkdir -p %{buildroot}%{_libexecdir}/swift/
-cp -r %{_builddir}/usr/* %{buildroot}%{_libexecdir}/swift
+mkdir -p %{buildroot}%{_libexecdir}/swift/%{package_version}
+cp -r %{_builddir}/usr/* %{buildroot}%{_libexecdir}/swift/%{package_version}
 mkdir -p %{buildroot}%{_bindir}
-ln -fs %{_libexecdir}/swift/bin/swift %{buildroot}%{_bindir}/swift 
-ln -fs %{_libexecdir}/swift/bin/swiftc %{buildroot}%{_bindir}/swiftc
-ln -fs %{_libexecdir}/swift/bin/sourcekit-lsp %{buildroot}%{_bindir}/sourcekit-lsp
+ln -fs %{_libexecdir}/swift/%{package_version}/bin/swift %{buildroot}%{_bindir}/swift
+ln -fs %{_libexecdir}/swift/%{package_version}/bin/swiftc %{buildroot}%{_bindir}/swiftc
+ln -fs %{_libexecdir}/swift/%{package_version}/bin/sourcekit-lsp %{buildroot}%{_bindir}/sourcekit-lsp
 mkdir -p %{buildroot}%{_mandir}/man1
 cp %{_builddir}/usr/share/man/man1/swift.1 %{buildroot}%{_mandir}/man1/swift.1
 
 # This is to fix an issue with check-rpaths complaining about
 # how the Swift binaries use RPATH
 export QA_SKIP_RPATHS=1
-
 
 %files
 %license swift/LICENSE.txt
@@ -202,9 +191,7 @@ export QA_SKIP_RPATHS=1
 %{_mandir}/man1/swift.1.gz
 %{_libexecdir}/swift/
 
-
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
-
 
 %changelog


### PR DESCRIPTION
motivation: easier to maintain code

changes:
* sort BuildRequires, Requires and move secions alphabetically
* other small formatting fixes like whitespace, etc
* remove cmake from fedora BuildRequires since we are builfing it from source
* update fedora rawhide path to be more consistent with other fedora locations and rpm builders