### PR TITLE
SwiftInstaller: update the default file list

### DIFF
--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
@@ -253,11 +253,15 @@ std::vector<std::filesystem::path> available_toolsets() noexcept {
       VCInstallDir.append("VC");
 
       std::string VCToolsVersion;
+
       // VSInstallDir\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt
-      // contains the default version of the v141 MSVC toolset.  Prefer to use
+      // contains the default version of the v141 MSVC toolset on VS2019. Prefer
+      // to use
       // VSInstallDir\VC\Auxiliary\Build\Microsoft.VCToolsVersion.v142.default.txt
-      // which contains the default v142 version of the toolset.
-      for (const auto &file : {"Microsoft.VCToolsVersion.v142.default.txt",
+      // which contains the default v142 version of the toolset on VS2019.
+      for (const auto &file : {"Microsoft.VCToolsVersion.v143.default.txt",
+                               "Microsoft.VCToolsVersion.v142.default.txt",
+                               "Microsoft.VCToolsVersion.v141.default.txt",
                                "Microsoft.VCToolsVersion.default.txt"}) {
         std::filesystem::path path{VCInstallDir};
         path.append("Auxiliary");


### PR DESCRIPTION
VS2022 adjusted the layout of the default toolset configuration.  Prefer
the versioned format over the unversioned format to retain compatibility
with VS2019.  This extends coverage for VS2022 and stays compatible with
VS2017, VS2019, and VS2022.