### PR TITLE
WiX: make SDK/runtime manifests multi-use

### DIFF
--- a/platforms/Windows/devtools.wixproj
+++ b/platforms/Windows/devtools.wixproj
@@ -9,6 +9,9 @@
     <OutputType>Package</OutputType>
     <ProjectGuid>0a266072-af7c-43f2-b192-dd86995c2e82</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
     <ProductVersion>0.0.0</ProductVersion>
   </PropertyGroup>

--- a/platforms/Windows/devtools.wxs
+++ b/platforms/Windows/devtools.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Developer Tools for Windows x86_64" UpgradeCode="5778fa7a-f1a6-4133-b4e0-fc0d9caf4544" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift Developer Tools for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Developer Tools for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
     <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
 
     <?ifdef INCLUDE_DEBUG_INFO ?>

--- a/platforms/Windows/devtools.wxs
+++ b/platforms/Windows/devtools.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Developer Tools" UpgradeCode="5778fa7a-f1a6-4133-b4e0-fc0d9caf4544" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Developer Tools" InstallScope="perMachine" Manufacturer="swift.org" />
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Developer Tools for Windows x86_64" UpgradeCode="5778fa7a-f1a6-4133-b4e0-fc0d9caf4544" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift Developer Tools for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
     <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
 
     <?ifdef INCLUDE_DEBUG_INFO ?>

--- a/platforms/Windows/icu-amd64.wxs
+++ b/platforms/Windows/icu-amd64.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift ICU for Windows x86_64" UpgradeCode="4b3bfcaf-46b1-4940-b3e3-692ea4e78a09" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift ICU for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift ICU for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
     <Media Id="1" Cabinet="icu.cab" EmbedCab="yes" />
 
     <!-- Directory Structure -->

--- a/platforms/Windows/icu-amd64.wxs
+++ b/platforms/Windows/icu-amd64.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="ICU" UpgradeCode="4b3bfcaf-46b1-4940-b3e3-692ea4e78a09" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="ICU" InstallScope="perMachine" Manufacturer="swift.org" />
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift ICU for Windows x86_64" UpgradeCode="4b3bfcaf-46b1-4940-b3e3-692ea4e78a09" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift ICU for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
     <Media Id="1" Cabinet="icu.cab" EmbedCab="yes" />
 
     <!-- Directory Structure -->

--- a/platforms/Windows/icu.wixproj
+++ b/platforms/Windows/icu.wixproj
@@ -9,6 +9,12 @@
     <OutputType>Package</OutputType>
     <ProjectGuid>07dd2e66-b7f5-40a7-bed1-b3dd2a187c00</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProductArchitecture Condition=" '$(ProductArchitecture)' == '' ">amd64</ProductArchitecture>
+    <ProductArchitecture>$(ProductArchitecture)</ProductArchitecture>
+
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
     <ProductVersion>$(ProductVersion)</ProductVersion>
   </PropertyGroup>
@@ -25,7 +31,22 @@
     <DefineConstants>ProductVersion=$(ProductVersion);ProductVersionMajor=$(ProductVersionMajor);ICU_ROOT=$(ICU_ROOT)</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">
+    <InstallerPlatform>x64</InstallerPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm64' ">
+    <InstallerPlatform>arm64</InstallerPlatform>
+    <InstallerVersion>500</InstallerVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm' ">
+    <InstallerPlatform>arm</InstallerPlatform>
+    <InstallerVersion>500</InstallerVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'x86' ">
+    <InstallerPlatform>x86</InstallerPlatform>
+  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Include="icu.wxs" />
+    <Compile Include="icu-$(ProductArchitecture).wxs" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/installer.wixproj
+++ b/platforms/Windows/installer.wixproj
@@ -9,6 +9,9 @@
     <OutputType>Bundle</OutputType>
     <ProjectGuid>8ae3ad4d-2df4-42b7-890e-decdd5cead0b</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
     <ProductVersion>$(ProductVersion)</ProductVersion>
   </PropertyGroup>

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Runtime for Windows x86_64" UpgradeCode="850349e4-5a24-44eb-bded-f49a2709d26f" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift Runtime for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Runtime for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
 
     <?ifdef INCLUDE_DEBUG_INFO ?>

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Windows Swift Runtime for x86_64" UpgradeCode="850349e4-5a24-44eb-bded-f49a2709d26f" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Windows Swift Runtime for x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Runtime for Windows x86_64" UpgradeCode="850349e4-5a24-44eb-bded-f49a2709d26f" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift Runtime for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
 
     <?ifdef INCLUDE_DEBUG_INFO ?>

--- a/platforms/Windows/runtime.wixproj
+++ b/platforms/Windows/runtime.wixproj
@@ -9,6 +9,12 @@
     <OutputType>Package</OutputType>
     <ProjectGuid></ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProductArchitecture Condition=" '$(ProductArchitecture)' == '' ">amd64</ProductArchitecture>
+    <ProductArchitecture>$(ProductArchitecture)</ProductArchitecture>
+
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
     <ProductVersion>$(ProductVersion)</ProductVersion>
   </PropertyGroup>
@@ -25,7 +31,22 @@
     <DefineConstants>ProductVersion=$(ProductVersion);SDK_ROOT=$(SDK_ROOT);$(INCLUDE_DEBUG_INFO)</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">
+    <InstallerPlatform>x64</InstallerPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm64' ">
+    <InstallerPlatform>arm64</InstallerPlatform>
+    <InstallerVersion>500</InstallerVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm' ">
+    <InstallerPlatform>arm</InstallerPlatform>
+    <InstallerVersion>500</InstallerVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'x86' ">
+    <InstallerPlatform>x86</InstallerPlatform>
+  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Include="runtime.wxs" />
+    <Compile Include="runtime-$(ProductArchitecture).wxs" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Windows Swift SDK for x86_64" UpgradeCode="83af0249-2b57-4ce1-8121-c29c6c555225" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Windows Swift SDK for x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift SDK for Windows x86_64" UpgradeCode="83af0249-2b57-4ce1-8121-c29c6c555225" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift SDK for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
 
     <!-- Directory Structure -->

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift SDK for Windows x86_64" UpgradeCode="83af0249-2b57-4ce1-8121-c29c6c555225" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift SDK for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift SDK for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
 
     <!-- Directory Structure -->

--- a/platforms/Windows/sdk.wixproj
+++ b/platforms/Windows/sdk.wixproj
@@ -9,6 +9,12 @@
     <OutputType>Package</OutputType>
     <ProjectGuid>39170311-3634-4a14-9546-7e4825e7dcd8</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProductArchitecture Condition=" '$(ProductArchitecture)' == '' ">amd64</ProductArchitecture>
+    <ProductArchitecture>$(ProductArchitecture)</ProductArchitecture>
+
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
     <ProductVersion>$(ProductVersion)</ProductVersion>
   </PropertyGroup>
@@ -50,6 +56,6 @@
   </Target>
 
   <ItemGroup>
-    <Compile Include="sdk.wxs" />
+    <Compile Include="sdk-$(ProductArchitecture).wxs" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/toolchain.wxs
+++ b/platforms/Windows/toolchain.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Toolchain for Windows x86_64" UpgradeCode="9871289b-f9cb-4b39-8122-2c7ec1ab24d5" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift Toolchain for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Toolchain for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
 
     <!--
       NOTE(compnerd) Use high compression as this is an extrodinarily large

--- a/platforms/Windows/toolchain.wxs
+++ b/platforms/Windows/toolchain.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Toolchain" UpgradeCode="9871289b-f9cb-4b39-8122-2c7ec1ab24d5" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Toolchain" InstallScope="perMachine" Manufacturer="swift.org" />
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Toolchain for Windows x86_64" UpgradeCode="9871289b-f9cb-4b39-8122-2c7ec1ab24d5" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021 Swift Open Source Project" Compressed="yes" Description="Swift Toolchain for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
 
     <!--
       NOTE(compnerd) Use high compression as this is an extrodinarily large


### PR DESCRIPTION
This renames the files to allow for extending the SDK/runtime packaging
for additional architectures, which enables packaging the SDK/runtime
for x86 and ARM64.  Update the other wixproj files to maintain
similarity in property group setup.