### PR TITLE
WiX: move `DEVELOPER_DIR` to be setup by the toolchain MSI

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -340,7 +340,6 @@
     <DirectoryRef Id="TARGETDIR">
       <Component Id="ENV_VARS" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
         <!-- <Condition> %PROCESSOR_ARCHITECTURE~="amd64" </Condition> -->
-        <Environment Id="DEVELOPER_DIR" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer" />
         <Environment Id="SDKROOT" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
       </Component>
     </DirectoryRef>

--- a/platforms/Windows/toolchain.wxs
+++ b/platforms/Windows/toolchain.wxs
@@ -460,6 +460,7 @@
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="ENV_VARS" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
+        <Environment Id="DEVELOPER_DIR" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[WindowsVolume]Library\Developer" />
         <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
       </Component>
     </DirectoryRef>


### PR DESCRIPTION
This variable is more about where the toolchain is located rather than
the SDK.  It was previously setup by the SDK MSI as the variable really
is currently only used for locating XCTest.  However, it is possible to
locate XCTest via the SDKROOT path which is likely better in any case.
This will allow us to now conditionalise the "installation" of the
SDKROOT variable to the case where the SDK matches the host.  In
particular, only two hosts will ever be permitted to set this variable:
x64 and ARM64 and only when the native SDK is installed.  For any other
case, the user is responsible for setting SDKROOT or passing `-sdk` as
it implies cross-compilation.