### PR TITLE
WiX: move install location of runtime

### DIFF
--- a/platforms/Windows/icu-amd64.wxs
+++ b/platforms/Windows/icu-amd64.wxs
@@ -6,19 +6,15 @@
 
     <!-- Directory Structure -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="WINDOWSVOLUME">
-        <Directory Id="LIBRARY" Name="Library">
-          <Directory Id="ICU" Name="icu-$(var.ProductVersion)">
-            <Directory Id="ICU_USR" Name="usr">
-              <Directory Id="ICU_USR_BIN" Name="bin">
-              </Directory>
-            </Directory>
+      <Directory Id="ICU" Name="icu-$(var.ProductVersion)">
+        <Directory Id="ICU_USR" Name="usr">
+          <Directory Id="ICU_USR_BIN" Name="bin">
           </Directory>
         </Directory>
       </Directory>
     </Directory>
 
-    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <SetDirectory Id="TARGETDIR" Value="[ProgramFiles64Folder]swift" />
 
     <!-- Components -->
     <DirectoryRef Id="ICU_USR_BIN">
@@ -31,7 +27,7 @@
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="ENV_VARS" Guid="97fe0a23-32e0-481d-8827-215f4c74f03c">
-        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\icu-$(var.ProductVersion)\usr\bin" />
+        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[TARGETDIR]icu-$(var.ProductVersion)\usr\bin" />
       </Component>
     </DirectoryRef>
 

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -10,21 +10,19 @@
 
     <!-- Directory Structure -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="WINDOWSVOLUME">
-        <Directory Id="LIBRARY" Name="Library">
-          <!-- TODO(compnerd) use $(var.ProductVersion) -->
-          <Directory Id="SWIFT" Name="Swift-development">
-            <Directory Id="BIN" Name="bin">
-            </Directory>
+      <!-- TODO(compnerd) use $(var.ProductVersion) -->
+      <Directory Id="SWIFT" Name="runtime-development">
+        <Directory Id="SWIFT_USR" Name="usr">
+          <Directory Id="SWIFT_USR_BIN" Name="bin">
           </Directory>
         </Directory>
       </Directory>
     </Directory>
 
-    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <SetDirectory Id="TARGETDIR" Value="[ProgramFiles64Folder]swift" />
 
     <!-- Components -->
-    <DirectoryRef Id="BIN">
+    <DirectoryRef Id="SWIFT_USR_BIN">
       <Component Id="WINDOWS_SWIFT_RUNTIME" Guid="cd825076-16da-4530-84c8-810f3ae472a8">
         <File Id="BLOCKSRUNTIME_DLL" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
         <File Id="DISPATCH_DLL" Source="$(var.SDK_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
@@ -72,7 +70,7 @@
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="ENV_VARS" Guid="f249625e-aacd-4b17-a464-8f8df05ba5f3">
-        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\Swift-development\bin" />
+        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[TARGETDIR]runtime-development\usr\bin" />
       </Component>
     </DirectoryRef>
 


### PR DESCRIPTION
Re-home the runtime into a better default location on AMD64:
`%ProgramFiles%\swift\runtime-[VERSION]` from the previous
`%SystemDrive%\Library\Swift-[VERSION]`.  This will be required to
ensure that not only can we parallel install x86 and x64, but also
prepares the installers to accommodate alternate install locations.
Take the opportunity to restore the missing `usr` directory for the
runtime image.

Simultaneously, relocate ICU from `%SystemDrive%\icu-[VERSION]` to a new
peered location at `%ProgramFiles%\swift\icu-[VERSION]`.