### PR TITLE
WiX: correct naming for WiX rules

### DIFF
--- a/platforms/Windows/devtools.wxs
+++ b/platforms/Windows/devtools.wxs
@@ -2,28 +2,28 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Developer Tools for Windows x86_64" UpgradeCode="5778fa7a-f1a6-4133-b4e0-fc0d9caf4544" Version="$(var.ProductVersion)">
     <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Developer Tools for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
-    <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
 
+    <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="devtools_PDBs.cab" EmbedCab="yes" />
+    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
     <?endif?>
 
     <!-- Directory Structure -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="WINDOWSVOLUME">
-        <Directory Id="LIBRARY" Name="Library">
-          <Directory Id="DEVELOPER" Name="Developer">
-            <Directory Id="TOOLCHAINS" Name="Toolchains">
-              <Directory Id="UNKNOWN_ASSERTS_DEVELOPMENT_XCTOOLCHAIN" Name="unknown-Asserts-development.xctoolchain">
-                <Directory Id="USR" Name="usr">
-                  <Directory Id="USR_BIN" Name="bin">
-                  </Directory>
-                  <Directory Id="USR_LIB" Name="lib">
-                    <!-- FIXME(compnerd) should we include the SPM import libraries? -->
-                    <Directory Id="USR_LIB_SWIFT" Name="swift">
-                      <Directory Id="USR_LIB_SWIFT_PM" Name="pm">
-                        <Directory Id="USR_LIB_SWIFT_PM_MANIFEST_API" Name="ManifestAPI">
-                        </Directory>
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Toolchains" Name="Toolchains">
+            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+              <Directory Id="_usr" Name="usr">
+                <Directory Id="_usr_bin" Name="bin">
+                </Directory>
+                <Directory Id="_usr_lib" Name="lib">
+                  <!-- FIXME(compnerd) should we include the SPM import libraries? -->
+                  <Directory Id="_usr_lib_swift" Name="swift">
+                    <Directory Id="_usr_lib_swift_pm" Name="pm">
+                      <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
+                      </Directory>
+                      <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
                       </Directory>
                     </Directory>
                   </Directory>
@@ -35,142 +35,161 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
+      NOT INSTALLDIR
+    </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="USR_BIN">
+    <DirectoryRef Id="_usr_bin">
       <!-- IndexStoreDB -->
-      <Component Id="INDEXSTOREDB_BINS" Guid="cde37e2e-9f9d-4fc5-927b-55b9145c84cd">
-        <File Id="INDEXSTOREDB_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.dll" Checksum="yes" />
+      <Component Id="IndexStoreDB" Guid="cde37e2e-9f9d-4fc5-927b-55b9145c84cd">
+        <File Id="IndexStoreDB.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.dll" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="INDEXSTOREDB_DEBUGINFO" Guid="a0b6f544-c52a-4439-b646-474d43f8c7b4">
-        <File Id="INDEXSTOREDB_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.pdb" Checksum="yes" />
+      <Component Id="IndexStoreDBDebugInfo" Guid="a0b6f544-c52a-4439-b646-474d43f8c7b4">
+        <File Id="IndexStoreDB.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.pdb" Checksum="yes" />
       </Component>
       <?endif?>
 
       <!-- SourceKit-LSP -->
-      <Component Id="SOURCEKIT_LSP_BINS" Guid="5ca5d02f-76f3-4537-9dfb-a3fdb6381ac4">
-        <File Id="SOURCEKIT_LSP_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
+      <Component Id="SourceKitLSP" Guid="5ca5d02f-76f3-4537-9dfb-a3fdb6381ac4">
+        <File Id="sourcekit_lsp.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SOURCEKIT_LSP_DEBUGINFO" Guid="b4967969-ce4b-4d63-b2fd-0d8fc896cb28">
-        <File Id="SOURCEKIT_LSP_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.pdb" Checksum="yes" />
+      <Component Id="SourceKitLSPDebugInfo" Guid="b4967969-ce4b-4d63-b2fd-0d8fc896cb28">
+        <File Id="soucekit_lsp.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.pdb" Checksum="yes" />
       </Component>
       <?endif?>
 
       <!-- swift-crypto -->
-      <Component Id="SWIFT_CRYPTO_BINS" Guid="8f4fb997-7a41-4d37-a3d4-f5e006f5e3c4">
-        <File Id="CRYPTO_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
+      <Component Id="SwiftCrypto" Guid="8f4fb997-7a41-4d37-a3d4-f5e006f5e3c4">
+        <File Id="Crypto.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_CRYPTO_DEBUGINFO" Guid="0966d4bf-d9a6-46ed-9be2-5b165fff3d45">
-        <File Id="CRYPTO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
+      <Component Id="SwiftCryptoDebugInfo" Guid="0966d4bf-d9a6-46ed-9be2-5b165fff3d45">
+        <File Id="Crypto.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
       </Component>
       <?endif?>
 
       <!-- swift-collections -->
-      <Component Id="SWIFT_COLLECTIONS_BINS" Guid="f4634058-6477-4f8f-aa99-76a074056c2f">
-        <File Id="COLLECTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
-        <File Id="DEQUE_MODULE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.dll" Checksum="yes" />
-        <File Id="ORDERED_COLLECTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.dll" Checksum="yes" />
+      <Component Id="SwiftCollections" Guid="f4634058-6477-4f8f-aa99-76a074056c2f">
+        <File Id="Collections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
+        <File Id="DequeModule.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.dll" Checksum="yes" />
+        <File Id="OrderedCollections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.dll" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_COLLECTIONS_DEBUGINFO" Guid="3c709129-5383-47c8-a86a-38d44a575095">
-        <File Id="COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
-        <File Id="DEQUE_MODULE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
-        <File Id="ORDERED_COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
+      <Component Id="SwiftCollectionsDebugInfo" Guid="3c709129-5383-47c8-a86a-38d44a575095">
+        <File Id="Collections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
+        <File Id="DequeModule.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
+        <File Id="OrderedCollections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
       </Component>
       <?endif?>
 
       <!-- swift-package-manager -->
-      <Component Id="SWIFT_PACKAGE_MANAGER_BINS" Guid="1b6a0df3-9fd5-4262-8d90-55585f059d40">
-        <File Id="BASICS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.dll" Checksum="yes" />
-        <File Id="BUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.dll" Checksum="yes" />
-        <File Id="COMMANDS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
-        <File Id="PACKAGE_GRAPH_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
-        <File Id="PACKAGE_LOADING_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" Checksum="yes" />
-        <File Id="PACKAGE_MODEL_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" Checksum="yes" />
-        <File Id="SPMBUILD_CORE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" Checksum="yes" />
-        <File Id="WORKSPACE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.dll" Checksum="yes" />
+      <Component Id="SwiftPackageManager" Guid="1b6a0df3-9fd5-4262-8d90-55585f059d40">
+        <File Id="Basics.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.dll" Checksum="yes" />
+        <File Id="Build.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.dll" Checksum="yes" />
+        <File Id="Commands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
+        <File Id="PackageGraph.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
+        <File Id="PackageLoading.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" Checksum="yes" />
+        <File Id="PackageModel.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" Checksum="yes" />
+        <File Id="SPMBuildCore.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" Checksum="yes" />
+        <File Id="Workspace.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.dll" Checksum="yes" />
 
-        <File Id="SWIFT_BUILD_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.exe" Checksum="yes" />
-        <File Id="SWIFT_PACKAGE_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
-        <File Id="SWIFT_RUN_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.exe" Checksum="yes" />
-        <File Id="SWIFT_TEST_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.exe" Checksum="yes" />
+        <File Id="swift_build.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.exe" Checksum="yes" />
+        <File Id="swift_package.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
+        <File Id="swift_run.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.exe" Checksum="yes" />
+        <File Id="swift_test.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.exe" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_PACKAGE_MANAGER_DEBUGINFO" Guid="642629c0-be0d-4a8f-8e8e-375f4c6c5451">
-        <File Id="BASICS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
-        <File Id="BUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
-        <File Id="COMMANDS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
-        <File Id="PACKAGE_GRAPH_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
-        <File Id="PACKAGE_LOADING_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
-        <File Id="PACKAGE_MODEL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
-        <File Id="SPMBUILD_CORE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
-        <File Id="WORKSPACE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
+      <Component Id="SwiftPackageManagerDebugInfo" Guid="642629c0-be0d-4a8f-8e8e-375f4c6c5451">
+        <File Id="Basics.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
+        <File Id="Build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
+        <File Id="Commands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
+        <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
+        <File Id="PackageLoading.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
+        <File Id="PackageModel.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
+        <File Id="SPMBuildCore.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
+        <File Id="Workspace.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
 
-        <File Id="SWIFT_BUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
-        <File Id="SWIFT_PACKAGE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
-        <File Id="SWIFT_RUN_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />
-        <File Id="SWIFT_TEST_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.pdb" Checksum="yes" />
+        <File Id="swift_build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
+        <File Id="swift_package.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
+        <File Id="swift_run.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />
+        <File Id="swift_test.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.pdb" Checksum="yes" />
       </Component>
       <?endif?>
-      
+
       <!-- swift-system -->
-      <Component Id="SWIFT_SYSTEM_BINS" Guid="12bc7c44-ee92-4d7f-ad73-d33465707195">
-        <File Id="SWIFT_PACKAGE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.dll" Checksum="yes" />
+      <Component Id="SwiftSystem" Guid="12bc7c44-ee92-4d7f-ad73-d33465707195">
+        <File Id="SystemPackage.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.dll" Checksum="yes" />
       </Component>
-      
+
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_SYSTEM_DEBUGINFO" Guid="91a89290-7436-4b6e-925a-3e1d43304f20">
-        <File Id="SWIFT_PACKAGE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.pdb" Checksum="yes" />
+      <Component Id="SwiftSystemDebugInfo" Guid="91a89290-7436-4b6e-925a-3e1d43304f20">
+        <File Id="SystemPackage.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.pdb" Checksum="yes" />
       </Component>
       <?endif?>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_LIB_SWIFT_PM_MANIFEST_API">
-      <Component Id="MANIFEST_API" Guid="45a219f2-f92c-4644-99a0-33f55f35a43d">
-        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" Checksum="yes" />
-        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_LIB" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" Checksum="yes" />
-        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_SWIFTDOC" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftdoc" Checksum="yes" />
-        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_SWIFTMODULE" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="_usr_lib_swift_pm_ManifestAPI">
+      <Component Id="SwiftPackageManagerManifestAPI" Guid="45a219f2-f92c-4644-99a0-33f55f35a43d">
+        <File Id="PackageDescription.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" Checksum="yes" />
+        <File Id="PackageDescription.lib" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" Checksum="yes" />
+        <File Id="PackageDescription.swiftdoc" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftdoc" Checksum="yes" />
+        <File Id="PackageDescription.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO?>
-      <Component Id="MANIFEST_API_DEBUGINFO" Guid="c49ea278-c632-44de-8337-360f4759ac6b">
-        <File Id="MANIFESAT_API_PACKAGE_DESCRIPTION_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
+      <Component Id="SwiftPackageManagerManifestAPIDebugInfo" Guid="c49ea278-c632-44de-8337-360f4759ac6b">
+        <File Id="PackageDescription.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
       </Component>
       <?endif?>
     </DirectoryRef>
 
-    <Feature Id="DEVTOOLS" Level="1">
-      <ComponentRef Id="INDEXSTOREDB_BINS" />
-      <ComponentRef Id="SOURCEKIT_LSP_BINS" />
-      <ComponentRef Id="SWIFT_CRYPTO_BINS" />
-      <ComponentRef Id="SWIFT_COLLECTIONS_BINS" />
-      <ComponentRef Id="SWIFT_PACKAGE_MANAGER_BINS" />
-      <ComponentRef Id="SWIFT_SYSTEM_BINS" />
-      <ComponentRef Id="MANIFEST_API" />
-    </Feature>
+    <DirectoryRef Id="_usr_lib_swift_pm_PluginAPI">
+      <Component Id="SwiftPackageManagerPluginAPI" Guid="34eba1ba-c801-4449-9d97-bdaded0fad5f">
+        <File Id="PackagePlugin.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" Checksum="yes" />
+        <File Id="PackagePlugin.lib" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.lib" Checksum="yes" />
+        <File Id="PackagePlugin.swiftdoc" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftdoc" Checksum="yes" />
+        <File Id="PackagePlugin.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftmodule" Checksum="yes" />
+      </Component>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Feature Id="DEBUGINFO" Level="0">
-      <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-      <ComponentRef Id="INDEXSTOREDB_DEBUGINFO" />
-      <ComponentRef Id="SOURCEKIT_LSP_DEBUGINFO" />
-      <ComponentRef Id="SWIFT_CRYPTO_DEBUGINFO" />
-      <ComponentRef Id="SWIFT_COLLECTIONS_DEBUGINFO" />
-      <ComponentRef Id="SWIFT_PACKAGE_MANAGER_DEBUGINFO" />
-      <ComponentRef Id="SWIFT_SYSTEM_DEBUGINFO" />
-      <ComponentRef Id="MANIFEST_API_DEBUGINFO" />
+      <?ifdef INCLUDE_DEBUG_INFO?>
+      <Component Id="SwiftPackageManagerPluginAPIDebugInfo" Guid="af21f0c7-88c8-4e44-b662-5ea8a5c84ae7">
+        <File Id="PackagePlugin.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\pluginAPI\PackagePlugin.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+    </DirectoryRef>
+
+    <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows x86_64" Level="1" Title="Swift Developer Tools (Windows x86_64)">
+      <ComponentRef Id="IndexStoreDB" />
+      <ComponentRef Id="SourceKitLSP" />
+      <ComponentRef Id="SwiftCrypto" />
+      <ComponentRef Id="SwiftCollections" />
+      <ComponentRef Id="SwiftPackageManager" />
+      <ComponentRef Id="SwiftSystem" />
+      <ComponentRef Id="SwiftPackageManagerManifestAPI" />
+      <ComponentRef Id="SwiftPackageManagerPluginAPI" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows x86_64" Level="0" Title="Debug Info">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentRef Id="IndexStoreDBDebugInfo" />
+        <ComponentRef Id="SourceKitLSPDebugInfo" />
+        <ComponentRef Id="SwiftCryptoDebugInfo" />
+        <ComponentRef Id="SwiftCollectionsDebugInfo" />
+        <ComponentRef Id="SwiftPackageManagerDebugInfo" />
+        <ComponentRef Id="SwiftSystemDebugInfo" />
+        <ComponentRef Id="SwiftPackageManagerManifestAPIDebugInfo" />
+        <ComponentRef Id="SwiftPackageManagerPluginAPIDebugInfo" />
+      </Feature>
+      <?endif?>
     </Feature>
-    <?endif?>
 
     <!-- UI -->
     <UI />

--- a/platforms/Windows/icu-amd64.wxs
+++ b/platforms/Windows/icu-amd64.wxs
@@ -2,39 +2,61 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift ICU for Windows x86_64" UpgradeCode="4b3bfcaf-46b1-4940-b3e3-692ea4e78a09" Version="$(var.ProductVersion)">
     <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift ICU for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+
     <Media Id="1" Cabinet="icu.cab" EmbedCab="yes" />
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
+    <?endif?>
 
     <!-- Directory Structure -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ICU" Name="icu-$(var.ProductVersion)">
-        <Directory Id="ICU_USR" Name="usr">
-          <Directory Id="ICU_USR_BIN" Name="bin">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="_" Name="icu-$(var.ProductVersion)">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin">
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
     </Directory>
 
-    <SetDirectory Id="TARGETDIR" Value="[ProgramFiles64Folder]swift" />
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift">
+      NOT INSTALLDIR
+    </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="ICU_USR_BIN">
-      <Component Id="ICU_RUNTIME" Guid="77a97eb2-4a5c-4d85-9fb7-692fd37d9b68">
-        <File Id="ICUDT" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icudt$(var.ProductVersionMajor).dll" Checksum="yes" />
-        <File Id="ICUIN" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).dll" Checksum="yes" />
-        <File Id="ICUUC" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).dll" Checksum="yes" />
+    <DirectoryRef Id="_usr_bin">
+      <Component Id="ICURuntime" Guid="77a97eb2-4a5c-4d85-9fb7-692fd37d9b68">
+        <File Id="icudt.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icudt$(var.ProductVersionMajor).dll" Checksum="yes" />
+        <File Id="icuin.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).dll" Checksum="yes" />
+        <File Id="icuuc.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).dll" Checksum="yes" />
       </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="ICUDebugInfo" Guid="c4643ea4-e585-466d-a5ad-078ee75cee8c">
+        <File Id="icuin.pdb" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).pdb" Checksum="yes" DiskId="2" />
+        <File Id="icuuc.pdb" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <?endif ?>
     </DirectoryRef>
 
     <DirectoryRef Id="TARGETDIR">
-      <Component Id="ENV_VARS" Guid="97fe0a23-32e0-481d-8827-215f4c74f03c">
-        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[TARGETDIR]icu-$(var.ProductVersion)\usr\bin" />
+      <Component Id="EnvironmentVariables" Guid="97fe0a23-32e0-481d-8827-215f4c74f03c">
+        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]icu-$(var.ProductVersion)\usr\bin" />
       </Component>
     </DirectoryRef>
 
     <!-- Features -->
-    <Feature Id="RUNTIME" Level="1">
-      <ComponentRef Id="ICU_RUNTIME" />
-      <ComponentRef Id="ENV_VARS" />
+    <Feature Id="WinX64ICU" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift ICU for Windows x86_64" Level="1" Title="Swift ICU for Windows x86_64">
+      <ComponentRef Id="ICURuntime" />
+      <ComponentRef Id="EnvironmentVariables" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift ICU for Windows x86_64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentRef Id="ICUDebugInfo" />
+      </Feature>
+      <?endif ?>
     </Feature>
 
     <!-- UI -->

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -2,90 +2,109 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Runtime for Windows x86_64" UpgradeCode="850349e4-5a24-44eb-bded-f49a2709d26f" Version="$(var.ProductVersion)">
     <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Runtime for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
-    <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
 
+    <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="runtime_PDBs.cab" EmbedCab="yes" />
+    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
     <?endif?>
 
     <!-- Directory Structure -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <!-- TODO(compnerd) use $(var.ProductVersion) -->
-      <Directory Id="SWIFT" Name="runtime-development">
-        <Directory Id="SWIFT_USR" Name="usr">
-          <Directory Id="SWIFT_USR_BIN" Name="bin">
+      <Directory Id="INSTALLDIR">
+        <!-- TODO(compnerd) use $(var.ProductVersion) -->
+        <Directory Id="_" Name="runtime-development">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin">
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
     </Directory>
 
-    <SetDirectory Id="TARGETDIR" Value="[ProgramFiles64Folder]swift" />
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift">
+      NOT INSTALLDIR
+    </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="SWIFT_USR_BIN">
-      <Component Id="WINDOWS_SWIFT_RUNTIME" Guid="cd825076-16da-4530-84c8-810f3ae472a8">
-        <File Id="BLOCKSRUNTIME_DLL" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
-        <File Id="DISPATCH_DLL" Source="$(var.SDK_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
-        <File Id="FOUNDATION_DLL" Source="$(var.SDK_ROOT)\usr\bin\Foundation.dll" Checksum="yes" />
-        <File Id="FOUNDATION_NETWORKING_DLL" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.dll" Checksum="yes" />
-        <File Id="FOUNDATION_XML_DLL" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
-        <File Id="SWIFT_CONCURRENCY_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
-        <File Id="SWIFT_DIFFERENTIATION_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
-        <File Id="SWIFT_DISTRIBUTED_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.dll" Checksum="yes" />
-        <File Id="SWIFT_STRING_PROCESSING_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
-        <File Id="SWIFTCORE_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
-        <File Id="SWIFTDISPATCH_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
-        <!-- <File Id="SWIFTDEMANGLE_DLL" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" /> -->
-        <File Id="SWIFTCRT_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.dll" Checksum="yes" />
-        <File Id="SWIFTREMOTEMIRROR_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.dll" Checksum="yes" />
-        <File Id="SWIFTSWIFTONONESUPPORT_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.dll" Checksum="yes" />
-        <File Id="SWIFTWINSDK_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.dll" Checksum="yes" />
+    <DirectoryRef Id="_usr_bin">
+      <Component Id="SwiftRuntime" Guid="cd825076-16da-4530-84c8-810f3ae472a8">
+        <File Id="BlocksRuntime.dll" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
+        <File Id="dispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
+        <File Id="Foundation.dll" Source="$(var.SDK_ROOT)\usr\bin\Foundation.dll" Checksum="yes" />
+        <File Id="FoundationNetworking.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.dll" Checksum="yes" />
+        <File Id="FoundationXML.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
+        <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
+        <File Id="swift_Differentiation.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
+        <File Id="swiftDistributed.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.dll" Checksum="yes" />
+        <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
+        <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
+        <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
+        <!-- <File Id="swiftDemangle.dll" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" /> -->
+        <File Id="swiftCRT.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.dll" Checksum="yes" />
+        <File Id="swiftRemoteMirror.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.dll" Checksum="yes" />
+        <File Id="swiftSwiftOnoneSupport.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.dll" Checksum="yes" />
+        <File Id="swiftWinSDK.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.dll" Checksum="yes" />
+      </Component>
 
-        <File Id="PLUTIL_EXE" Source="$(var.SDK_ROOT)\usr\bin\plutil.exe" Checksum="yes" />
+      <Component Id="SwiftUtilities" Guid="a5126e94-79df-455c-83de-04e064ad586b">
+        <File Id="plutil.exe" Source="$(var.SDK_ROOT)\usr\bin\plutil.exe" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="WINDOWS_SWIFT_RUNTIME_DEBUGINFO" Guid="b61b71f4-8387-4be1-a756-1d06e796003c">
-        <File Id="BLOCKSRUNTIME_PDB" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
-        <File Id="DISPATCH_PDB" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
-        <File Id="FOUNDATION_PDB" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
-        <File Id="FOUNDATION_NETWORKING_PDB" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
-        <File Id="FOUNDATION_XML_PDB" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFT_CONCURRENCY_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFT_DIFFERENTIATION_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFT_DISTRIBUTED_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFT_STRING_PROCESSING_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFTCORE_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFTDISPATCH_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
-        <!-- <File Id="SWIFTDEMANGLE_PDB" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" /> -->
-        <File Id="SWIFTCRT_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFTREMOTEMIRROR_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFTSWIFTONONESUPPORT_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFTWINSDK_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
+      <Component Id="SwiftRuntimeDebugInfo" Guid="b61b71f4-8387-4be1-a756-1d06e796003c">
+        <File Id="BlocksRuntime.pdb" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
+        <File Id="dispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
+        <File Id="Foundation.pdb" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
+        <File Id="FoundationNetworking.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
+        <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
+        <!-- <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" /> -->
+        <File Id="swiftCRT.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swiftRemoteMirror.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swiftSwiftOnoneSupport.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swiftWinSDK.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
+      </Component>
 
-        <File Id="PLUTIL_PDB" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
+      <Component Id="SwiftUtilitiesDebugInfo" Guid="b76da977-e914-46b7-98bc-7d8b033bf4ae">
+        <File Id="plutil.pdb" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
       </Component>
       <?endif ?>
     </DirectoryRef>
 
     <DirectoryRef Id="TARGETDIR">
-      <Component Id="ENV_VARS" Guid="f249625e-aacd-4b17-a464-8f8df05ba5f3">
-        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[TARGETDIR]runtime-development\usr\bin" />
+      <Component Id="EnvironmentVariables" Guid="f249625e-aacd-4b17-a464-8f8df05ba5f3">
+        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
       </Component>
     </DirectoryRef>
 
     <!-- Feature -->
-    <Feature Id="RUNTIME" Level="1">
-      <ComponentRef Id="WINDOWS_SWIFT_RUNTIME" />
-      <ComponentRef Id="ENV_VARS" />
+    <Feature Id="WinX64SwiftRuntime" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows x86_64" Level="1" Title="Swift Runtime for Windows x86_64">
+      <ComponentRef Id="SwiftRuntime" />
+      <ComponentRef Id="EnvironmentVariables" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows x86_64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentRef Id="SwiftRuntimeDebugInfo" />
+      </Feature>
+      <?endif?>
     </Feature>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Feature Id="DEBUGINFO" Level="0">
-      <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-      <ComponentRef Id="WINDOWS_SWIFT_RUNTIME_DEBUGINFO" />
+    <Feature Id="WinX64SwiftUtilities" Absent="allow" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows x86_64" Level="1" Title="Swift Utilities for Windows x86_64">
+      <ComponentRef Id="SwiftUtilities" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows x86_64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentRef Id="SwiftUtilitiesDebugInfo" />
+      </Feature>
+      <?endif?>
     </Feature>
-    <?endif ?>
 
     <!-- UI -->
     <UI />

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -2,33 +2,35 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift SDK for Windows x86_64" UpgradeCode="83af0249-2b57-4ce1-8121-c29c6c555225" Version="$(var.ProductVersion)">
     <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift SDK for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
+    <?endif?>
 
     <!-- Directory Structure -->
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="INSTALLDIR">
-        <Directory Id="LIBRARY" Name="Library">
-          <Directory Id="LIBRARY_DEVELOPER" Name="Developer">
-            <Directory Id="LIBRARY_DEVELOPER_PLATFORMS" Name="Platforms">
-              <Directory Id="LIBRARY_DEVELOPER_PLATFORMS_WINDOWS_PLATFORM" Name="Windows.platform">
-                <Directory Id="LIBRARY_DEVELOPER_PLATFORMS_WINDOWS_PLATFORM_DEVELOPER" Name="Developer">
-                  <Directory Id="LIBRARY_DEVELOPER_PLATFORMS_WINDOWS_PLATFORM_DEVELOPER_LIBRARY" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="DeveloperPlatforms" Name="Platforms">
+            <Directory Id="WindowsPlatform" Name="Windows.platform">
+              <Directory Id="WindowsPlatform_Developer" Name="Developer">
+                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                    <!-- XCTest -->
-                    <!--
-                      FIXME(compnerd) this should actually be the proper version
-                      of XCTest, and needs to be reflected in the plist as well.
-                    -->
-                    <Directory Id="LIBRARY_DEVELOPER_PLATFORMS_WINDOWS_PLATFORM_DEVELOPER_LIBRARY_XCTEST" Name="XCTest-development">
-                      <Directory Id="XCTEST_USR" Name="usr">
-                        <Directory Id="XCTEST_USR_BIN64" Name="bin64">
-                        </Directory>
-                        <Directory Id="XCTEST_USR_LIB" Name="lib">
-                          <Directory Id="XCTEST_USR_LIB_SWIFT" Name="swift">
-                            <Directory Id="XCTEST_USR_LIB_SWIFT_WINDOWS" Name="windows">
-                              <Directory Id="XCTEST_USR_LIB_SWIFT_WINDOWS_X86_64" Name="x86_64">
-                                <Directory Id="XCTEST_USR_LIB_SWIFT_WINDOWS_XCTEST_SWIFTMODULE" Name="XCTest.swiftmodule">
-                                </Directory>
+                  <!-- XCTest -->
+                  <!--
+                    FIXME(compnerd) this should actually be the proper version
+                    of XCTest, and needs to be reflected in the plist as well.
+                  -->
+                  <Directory Id="XCTest" Name="XCTest-development">
+                    <Directory Id="XCTest_usr" Name="usr">
+                      <Directory Id="XCTest_usr_bin64" Name="bin64">
+                      </Directory>
+                      <Directory Id="XCTest_usr_lib" Name="lib">
+                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="XCTest_usr_lib_swift_windows_x86_64" Name="x86_64">
+                              <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
                               </Directory>
                             </Directory>
                           </Directory>
@@ -36,60 +38,60 @@
                       </Directory>
                     </Directory>
                   </Directory>
+                </Directory>
 
-                  <Directory Id="LIBRARY_DEVELOPER_PLATFORMS_WINDOWS_PLATFORM_DEVELOPER_SDKS" Name="SDKs">
+                <Directory Id="SDKs" Name="SDKs">
 
-                    <!-- Windows.sdk -->
-                    <Directory Id="LIBRARY_DEVELOPER_PLATFORMS_WINDOWS_PLATFORM_DEVELOPER_SDKS_WINDOWS_SDK" Name="Windows.sdk">
-                      <Directory Id="WINDOWS_SDK_USR" Name="usr">
-                        <Directory Id="WINDOWS_SDK_USR_INCLUDE" Name="include">
-                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_BLOCK" Name="Block">
-                          </Directory>
-                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_DISPATCH" Name="dispatch">
-                          </Directory>
-                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_OS" Name="os">
-                          </Directory>
-                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_SWIFT" Name="swift">
-                            <Directory Id="WINDOWS_SDK_USR_INCLUDE_SWIFT_SWIFT_REMOTE_MIRROR" Name="SwiftRemoteMirror">
-                            </Directory>
+                  <!-- Windows.sdk -->
+                  <Directory Id="WindowsSDK" Name="Windows.sdk">
+                    <Directory Id="WindowsSDK_usr" Name="usr">
+                      <Directory Id="WindowsSDK_usr_include" Name="include">
+                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                           </Directory>
                         </Directory>
-                        <Directory Id="WINDOWS_SDK_USR_LIB" Name="lib">
-                          <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT" Name="swift">
-                            <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_SHIMS" Name="shims">
-                            </Directory>
-                            <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS" Name="windows">
-                              <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64" Name="x86_64">
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__CONCURRENCY_SWIFTMODULE" Name="_Concurrency.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__DIFFERENTIATION_SWIFTMODULE" Name="_Differentiation.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__DISTRIBUTED_SWIFTMODULE" Name="Distributed.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__STRING_PROCESSING_SWIFTMODULE" Name="_StringProcessing.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_CRT_SWIFTMODULE" Name="CRT.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_DISPATCH_SWIFTMODULE" Name="dispatch.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_FOUNDATION_SWIFTMODULE" Name="Foundation.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_FOUNDATION_NETWORKING_SWIFTMODULE" Name="FoundationNetworking.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_FOUNDATION_XML_SWIFTMODULE" Name="FoundationXML.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_SWIFT_SWIFTMODULE" Name="Swift.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_SWIFTONONESUPPORT_SWIFTMODULE" Name="SwiftOnoneSupport.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_WINSDK_SWIFTMODULE" Name="WinSDK.swiftmodule">
-                                </Directory>
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
+                              <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                              </Directory>
+                              <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                              </Directory>
+                              <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                              </Directory>
+                              <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                              </Directory>
+                              <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                              </Directory>
+                              <Directory Id="dispatch.swiftmodule" Name="dispatch.swiftmodule">
+                              </Directory>
+                              <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                              </Directory>
+                              <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                              </Directory>
+                              <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                              </Directory>
+                              <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                              </Directory>
+                              <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                              </Directory>
+                              <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
                               </Directory>
                             </Directory>
                           </Directory>
                         </Directory>
-                        <Directory Id="WINDOWS_SDK_USR_SHARE" Name="share">
-                        </Directory>
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_share" Name="share">
                       </Directory>
                     </Directory>
                   </Directory>
@@ -101,298 +103,298 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]">
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
       NOT INSTALLDIR
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="XCTEST_USR_BIN64">
-      <Component Id="XCTEST_RUNTIME" Guid="3d49884d-1ff2-4f2f-bdb1-5dacba74e256">
-        <File Id="XCTEST_DLL" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
+    <DirectoryRef Id="XCTest_usr_bin64">
+      <Component Id="XCTestRuntime" Guid="3d49884d-1ff2-4f2f-bdb1-5dacba74e256">
+        <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="XCTestRuntimeDebugInfo" Guid="a967ad27-bf6b-496b-9529-435f8a85ad21">
+        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <?endif?>
+    </DirectoryRef>
+
+    <DirectoryRef Id="XCTest_usr_lib_swift_windows_x86_64">
+      <Component Id="XCTestLibraries" Guid="3602ef83-8da8-47d3-b3ec-942e916c420b">
+        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="XCTEST_USR_LIB_SWIFT_WINDOWS_X86_64">
-      <Component Id="XCTEST_IMPORT_LIBS" Guid="3602ef83-8da8-47d3-b3ec-942e916c420b">
-        <File Id="XCTEST_LIB" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
+    <DirectoryRef Id="XCTest.swiftmodule">
+      <Component Id="XCTestSwiftModule" Guid="a52d9a17-c0e2-47f1-be01-4d47692423e3">
+        <File Id="XCTest.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftdoc" Checksum="yes" />
+        <File Id="XCTest.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="XCTEST_USR_LIB_SWIFT_WINDOWS_XCTEST_SWIFTMODULE">
-      <Component Id="XCTEST_SWIFT_MODULES" Guid="a52d9a17-c0e2-47f1-be01-4d47692423e3">
-        <File Id="X86_64_UNKNOWN_WINDOWS_SWIFTDOC" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftdoc" Checksum="yes" />
-        <File Id="X86_64_UNKNOWN_WINDOWS_SWIFTMODULE" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror">
+      <Component Id="SwiftRemoteMirrorHeaders" Guid="1653308a-60bc-4771-9635-8b3e67ba46c5">
+        <File Id="MemoryReaderInterface.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\MemoryReaderInterface.h" Checksum="yes" />
+        <File Id="Platform.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\Platform.h" Checksum="yes" />
+        <File Id="SwiftRemoteMirror.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirror.h" Checksum="yes" />
+        <File Id="SwiftRemoteMirrorTypes.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_SWIFT_SWIFT_REMOTE_MIRROR">
-      <Component Id="SWIFT_REMOTE_MIRROR_HEADERS" Guid="1653308a-60bc-4771-9635-8b3e67ba46c5">
-        <File Id="MEMORY_READER_INTERFACE_H" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\MemoryReaderInterface.h" Checksum="yes" />
-        <File Id="PLATFORM_H" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\Platform.h" Checksum="yes" />
-        <File Id="SWIFT_REMOTE_MIRROR_H" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirror.h" Checksum="yes" />
-        <File Id="SWIFT_REMOTE_MIRROR_TYPES_H" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" Checksum="yes" />
+    <DirectoryRef Id="WindowsSDK_usr_include_Block">
+      <Component Id="BlocksRuntimeHeaders" Guid="56ef7e66-3a7b-41a3-967c-1c9247183bb6">
+        <File Id="BlocksRuntime_Block.h" Source="$(var.SDK_ROOT)\usr\lib\swift\Block\Block.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_BLOCK">
-      <Component Id="BLOCKS_RUNTIME_HEADERS" Guid="56ef7e66-3a7b-41a3-967c-1c9247183bb6">
-        <File Id="BLOCK_H" Source="$(var.SDK_ROOT)\usr\lib\swift\Block\Block.h" Checksum="yes" />
+    <DirectoryRef Id="WindowsSDK_usr_include_dispatch">
+      <Component Id="DispatchHeaders" Guid="7d683f4f-7a40-4ef9-821f-12ca867edb7b">
+        <File Id="base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\base.h" Checksum="yes" />
+        <File Id="dispatch_block.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\block.h" Checksum="yes" />
+        <File Id="data.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\data.h" Checksum="yes" />
+        <File Id="dispatch.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" Checksum="yes" />
+        <File Id="group.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\group.h" Checksum="yes" />
+        <File Id="introspection.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" Checksum="yes" />
+        <File Id="io.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\io.h" Checksum="yes" />
+        <File Id="dispatch.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" Checksum="yes" />
+        <File Id="dispatch_object.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\object.h" Checksum="yes" />
+        <File Id="once.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\once.h" Checksum="yes" />
+        <File Id="queue.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\queue.h" Checksum="yes" />
+        <File Id="semaphore.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" Checksum="yes" />
+        <File Id="source.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\source.h" Checksum="yes" />
+        <File Id="time.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\time.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_DISPATCH">
-      <Component Id="DISPATCH_DISPATCH_HEADERS" Guid="7d683f4f-7a40-4ef9-821f-12ca867edb7b">
-        <File Id="BASE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\base.h" Checksum="yes" />
-        <File Id="DISPATCH_BLOCK_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\block.h" Checksum="yes" />
-        <File Id="DATA_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\data.h" Checksum="yes" />
-        <File Id="DISPATCH_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" Checksum="yes" />
-        <File Id="GROUP_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\group.h" Checksum="yes" />
-        <File Id="INTROSPECTION_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" Checksum="yes" />
-        <File Id="IO_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\io.h" Checksum="yes" />
-        <File Id="DISPATCH_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" Checksum="yes" />
-        <File Id="DISPATCH_OBJECT_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\object.h" Checksum="yes" />
-        <File Id="ONCE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\once.h" Checksum="yes" />
-        <File Id="QUEUE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\queue.h" Checksum="yes" />
-        <File Id="SEMAPHORE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" Checksum="yes" />
-        <File Id="SOURCE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\source.h" Checksum="yes" />
-        <File Id="TIME_H" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\time.h" Checksum="yes" />
+    <DirectoryRef Id="WindowsSDK_usr_include_os">
+      <Component Id="DispatchOSHeaders" Guid="0caaa892-0d73-44eb-af99-e42ba5a0f928">
+        <File Id="generic_unix_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_unix_base.h" Checksum="yes" />
+        <File Id="generic_win_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_win_base.h" Checksum="yes" />
+        <File Id="os_object.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\object.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_OS">
-      <Component Id="DISPATCH_OS_HEADERS" Guid="0caaa892-0d73-44eb-af99-e42ba5a0f928">
-        <File Id="GENERIC_UNIX_BASE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_unix_base.h" Checksum="yes" />
-        <File Id="GENERIC_WIN_BASE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_win_base.h" Checksum="yes" />
-        <File Id="OS_OBJECT_H" Source="$(var.SDK_ROOT)\usr\lib\swift\os\object.h" Checksum="yes" />
+    <DirectoryRef Id="_Concurrency.swiftmodule">
+      <Component Id="_Concurrency.swiftmodule" Guid="c9ff4b16-0ca1-4be9-8d53-fff74bac18ca">
+        <File Id="_Concurrency.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="_Concurrency.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="_Concurrency.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__CONCURRENCY_SWIFTMODULE">
-      <Component Id="_CONCURRENCY_SWIFTMODULE" Guid="c9ff4b16-0ca1-4be9-8d53-fff74bac18ca">
-        <File Id="_CONCURRENCY_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_CONCURRENCY_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_CONCURRENCY_SWIFTMODULE_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="_Differentiation.swiftmodule">
+      <Component Id="_Differentiation.swiftmodule" Guid="e033eda9-3d7b-4cc6-9493-bd5ee2993235">
+        <File Id="_Differentiation.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="_Differentiation.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="_Differentiation.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__DIFFERENTIATION_SWIFTMODULE">
-      <Component Id="_DIFFERENTIATION_SWIFTMODULE" Guid="e033eda9-3d7b-4cc6-9493-bd5ee2993235">
-        <File Id="_DIFFERENTIATION_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_DIFFERENTIATION_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_DIFFERENTIATION_SWIFTMODULE_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="Distributed.swiftmodule">
+      <Component Id="Distributed.swiftmodule" Guid="63ea424f-ae9f-4e47-b5d4-cdd04ebc5fdd">
+        <File Id="Distributed.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="Distributed.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="Distributed.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__DISTRIBUTED_SWIFTMODULE">
-      <Component Id="DISTRIBUTED_SWIFTMODULE" Guid="63ea424f-ae9f-4e47-b5d4-cdd04ebc5fdd">
-        <File Id="DISTRIBUTED_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="DISTRIBUTED_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="DISTRIBUTED_SWIFTMODULE_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="_StringProcessing.swiftmodule">
+      <Component Id="_StringProcessing.swiftmodule" Guid="6baa3833-10a9-4df3-a568-241791d13449">
+        <File Id="_StringProcessing.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="_StringProcessing.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="_StringProcessing.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__STRING_PROCESSING_SWIFTMODULE">
-      <Component Id="_STRING_PROCESSING_SWIFTMODULE" Guid="6baa3833-10a9-4df3-a568-241791d13449">
-        <File Id="_STRING_PROCESSING_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_STRING_PROCESSING_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_STRING_PROCESSING_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="CRT.swiftmodule">
+      <Component Id="CRT.swiftmodule" Guid="fef33579-241c-44a6-b772-cfdc5721fcc7">
+        <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="CRT.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="CRT.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_CRT_SWIFTMODULE">
-      <Component Id="CRT_SWIFTMODULE" Guid="fef33579-241c-44a6-b772-cfdc5721fcc7">
-        <File Id="CRT_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="CRT_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="CRT_SWIFTMODULE_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="dispatch.swiftmodule">
+      <Component Id="Dispatch.swiftmodule" Guid="0bb44335-c778-4e57-b072-6370b6b71d23">
+        <File Id="Dispatch.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftdoc" Checksum="yes" />
+        <File Id="Dispatch.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_DISPATCH_SWIFTMODULE">
-      <Component Id="DISPATCH_SWIFTMODULE" Guid="0bb44335-c778-4e57-b072-6370b6b71d23">
-        <File Id="DISPATCH_SWIFTMODULE_SWIFTDOC" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftdoc" Checksum="yes" />
-        <File Id="DISPASTCH_SWIFTMODULE_SWIFTMODULE" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="Foundation.swiftmodule">
+      <Component Id="Foundation.swiftmodule" Guid="08d334bb-9dd3-478a-907e-c515e0d87c0d">
+        <File Id="Foundation.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftdoc" Checksum="yes" />
+        <File Id="Foundation.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_FOUNDATION_SWIFTMODULE">
-      <Component Id="FOUNDATION_SWIFTMODULE" Guid="08d334bb-9dd3-478a-907e-c515e0d87c0d">
-        <File Id="FOUNDATION_SWIFTMODULE_SWIFTDOC" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftdoc" Checksum="yes" />
-        <File Id="FOUNDATION_SWIFTMODULE_SWIFTMODULE" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="FoundationNetworking.swiftmodule">
+      <Component Id="FoundationNetworking.swiftmodule" Guid="8037da71-8bd2-479c-a1b2-421df3423284">
+        <File Id="FoundationNetworking.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftdoc" Checksum="yes" />
+        <File Id="FoundationNetworking.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_FOUNDATION_NETWORKING_SWIFTMODULE">
-      <Component Id="FOUNDATION_NETWORKING_SWIFTMODULE" Guid="8037da71-8bd2-479c-a1b2-421df3423284">
-        <File Id="FOUNDATION_NETWORKING_SWIFTMODULE_SWIFTDOC" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftdoc" Checksum="yes" />
-        <File Id="FOUNDATION_NETWORKING_SWIFTMODULE_SWIFTMODULE" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="FoundationXML.swiftmodule">
+      <Component Id="FoundationXML.swiftmodule" Guid="7e405291-54db-4a8f-bcc7-d016aa2418d6">
+        <File Id="FoundationXML.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftdoc" Checksum="yes" />
+        <File Id="FoundationXML.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_FOUNDATION_XML_SWIFTMODULE">
-      <Component Id="FOUNDATION_XML_SWIFTMODULE" Guid="7e405291-54db-4a8f-bcc7-d016aa2418d6">
-        <File Id="FOUNDATION_XML_SWIFTMODULE_SWIFTDOC" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftdoc" Checksum="yes" />
-        <File Id="FOUNDATION_XML_SWIFTMODULE_SWIFTMODULE" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="Swift.swiftmodule">
+      <Component Id="Swift.swiftmodule" Guid="a0676bb0-ae06-402d-b442-ad6eabede927">
+        <File Id="Swift.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="Swift.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="Swift.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_SWIFT_SWIFTMODULE">
-      <Component Id="SWIFT_SWIFTMODULE" Guid="a0676bb0-ae06-402d-b442-ad6eabede927">
-        <File Id="SWIFT_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="SWIFT_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="SWIFT_SWIFTMODULE_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="SwiftOnoneSupport.swiftmodule">
+      <Component Id="SwiftOnoneSupport.swiftmodule" Guid="c4950dc9-b0d2-48c9-8f8d-426e6d3c6c78">
+        <File Id="SwiftOnoneSupport.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="SwiftOnoneSupport.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="SwiftOnoneSupport.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_SWIFTONONESUPPORT_SWIFTMODULE">
-      <Component Id="SWIFT_ONONE_SUPPORT_SWIFTMODULE" Guid="c4950dc9-b0d2-48c9-8f8d-426e6d3c6c78">
-        <File Id="SWIFT_ONONE_SUPPORT_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="SWIFT_ONONE_SUPPORT_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="SWIFT_ONONE_SUPPORT_SWIFTMODULE_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="WinSDK.swiftmodule">
+      <Component Id="WinSDK.swiftmodule" Guid="9fb3ebfa-da7d-4fb8-a3ec-ebc0aa6b7814">
+        <File Id="WinSDK.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="WinSDK.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="WinSDK.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_WINSDK_SWIFTMODULE">
-      <Component Id="WINSDK_SWIFTMODULE" Guid="9fb3ebfa-da7d-4fb8-a3ec-ebc0aa6b7814">
-        <File Id="WINSDK_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="WINSDK_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="WINSDK_SWIFTMODULE_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="WindowsSDK_usr_lib_swift_windows_x86_64">
+      <Component Id="Registrar" Guid="7c968f4a-c039-4605-8a96-2670284e1993">
+        <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftrt.obj" Checksum="yes" />
+      </Component>
+
+      <Component Id="_ConcurrencyLibraries" Guid="6188de52-0a9b-4a62-bfde-f115a6b76cf7">
+        <File Id="swift_Concurrency.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Concurrency.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="_DifferentiationLibraries" Guid="a240db64-c797-4e43-9c52-ec5e16a36bf9">
+        <File Id="swift_Differentiation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Differentiation.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="_DistributedLibraries" Guid="c3d65ddc-89e9-4ff9-bf1f-ef91bc0b1009">
+        <File Id="swiftDistributed.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftDistributed.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="BlocksRuntimeLibraries" Guid="c521f7e9-179a-49ed-a643-035d8a96be56">
+        <File Id="BlocksRuntime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="DispatchLibraries" Guid="6bd9a2cd-9ba8-499d-884b-22aa5156b5bc">
+        <File Id="dispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
+        <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="FoundationLibraries" Guid="44c3e8a3-3cf4-485a-a01f-52bbad5cbe20">
+        <File Id="Foundation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
+        <File Id="FoundationNetworking.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
+        <File Id="FoundationXML.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="SwiftLibraries" Guid="a9288d7e-c197-4cab-938f-5926be290a71">
+        <File Id="swiftCore.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCore.lib" Checksum="yes" />
+        <File Id="swiftSwiftOnoneSupport.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftSwiftOnoneSupport.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="SwiftSDKOverlayLibraries" Guid="03f5b5bc-ab5a-4287-818e-c164dcfbef1a">
+        <File Id="swiftCRT.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCRT.lib" Checksum="yes" />
+        <File Id="swiftWinSDK.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftWinSDK.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="SwiftRemoteMirrorLibraries" Guid="36e05640-2023-47fa-a81c-ad3f15eae659">
+        <File Id="swiftRemoteMirror.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64">
-      <Component Id="REGISTRAR" Guid="7c968f4a-c039-4605-8a96-2670284e1993">
-        <File Id="SWIFTRT_OBJ" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftrt.obj" Checksum="yes" />
-      </Component>
-
-      <Component Id="_CONCURRENCY_IMPORT_LIBS" Guid="6188de52-0a9b-4a62-bfde-f115a6b76cf7">
-        <File Id="SWIFT_CONCURRENCY_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Concurrency.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="_DIFFERENTIATION_IMPORT_LIBS" Guid="a240db64-c797-4e43-9c52-ec5e16a36bf9">
-        <File Id="SWIFT_DIFFERENTIATION_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Differentiation.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="_DISTRIBUTED_IMPORT_LIBS" Guid="c3d65ddc-89e9-4ff9-bf1f-ef91bc0b1009">
-        <File Id="SWIFT_DISTRIBUTED_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftDistributed.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="BLOCKS_RUNTIME_IMPORT_LIBS" Guid="c521f7e9-179a-49ed-a643-035d8a96be56">
-        <File Id="BLOCKS_RUNTIME_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="DISPATCH_IMPORT_LIBS" Guid="6bd9a2cd-9ba8-499d-884b-22aa5156b5bc">
-        <File Id="DISPATCH_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
-        <File Id="SWIFT_DISPATCH_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="FOUNDATION_IMPORT_LIBS" Guid="44c3e8a3-3cf4-485a-a01f-52bbad5cbe20">
-        <File Id="FOUNDATION_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
-        <File Id="FOUNDATION_NETWORKING_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
-        <File Id="FOUNDATION_XML_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SWIFT_IMPORT_LIBS" Guid="a9288d7e-c197-4cab-938f-5926be290a71">
-        <File Id="SWIFT_CORE_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCore.lib" Checksum="yes" />
-        <File Id="SWIFT_SWIFT_ONONE_SUPPORT_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftSwiftOnoneSupport.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SDK_OVERLAY_IMPORT_LIBS" Guid="03f5b5bc-ab5a-4287-818e-c164dcfbef1a">
-        <File Id="SWIFT_CRT_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCRT.lib" Checksum="yes" />
-        <File Id="SWIFT_WINSDK_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftWinSDK.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SWIFT_REMOTE_MIRROR_IMPORT_LIBS" Guid="36e05640-2023-47fa-a81c-ad3f15eae659">
-        <File Id="SWIFT_REMOTE_MIRROR_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib" Checksum="yes" />
+    <DirectoryRef Id="WindowsSDK_usr_share">
+      <Component Id="SupportFiles" Guid="2be1e214-512b-4895-9aef-93c8e263a698">
+        <File Id="ucrt.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\ucrt.modulemap" Checksum="yes" />
+        <File Id="winsdk.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\winsdk.modulemap" Checksum="yes" />
+        <File Id="visualc.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.modulemap" Checksum="yes" />
+        <File Id="visualc.apinotes" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.apinotes" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_SHARE">
-      <Component Id="WINDOWS_SDK_SUPPORT_FILES" Guid="2be1e214-512b-4895-9aef-93c8e263a698">
-        <File Id="UCRT_MODULEMAP" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\ucrt.modulemap" Checksum="yes" />
-        <File Id="WINSDK_MODULEMAP" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\winsdk.modulemap" Checksum="yes" />
-        <File Id="VISUALC_MODULEMAP" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.modulemap" Checksum="yes" />
-        <File Id="VISUALC_APINOTES" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.apinotes" Checksum="yes" />
+    <DirectoryRef Id="WindowsPlatform">
+      <Component Id="Info.plist" Guid="03130625-9732-4c44-ae81-eddfd97cbe6c">
+        <File Id="Info.plist" Source="$(var.PLATFORM_ROOT)\Info.plist" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="LIBRARY_DEVELOPER_PLATFORMS_WINDOWS_PLATFORM">
-      <Component Id="PLATFORM_INFO_PLIST" Guid="03130625-9732-4c44-ae81-eddfd97cbe6c">
-        <File Id="INFO_PLIST" Source="$(var.PLATFORM_ROOT)\Info.plist" Checksum="yes" />
+    <DirectoryRef Id="WindowsSDK">
+      <Component Id="SDKSettings.plist" Guid="1562926d-6c1d-4cc1-9ab2-42effae919d2">
+        <File Id="SDKSettings.plist" Source="$(var.SDK_ROOT)\SDKSettings.plist" Checksum="yes" />
       </Component>
     </DirectoryRef>
-
-    <DirectoryRef Id="LIBRARY_DEVELOPER_PLATFORMS_WINDOWS_PLATFORM_DEVELOPER_SDKS_WINDOWS_SDK">
-      <Component Id="SDK_SDKSETTINGS_PLIST" Guid="1562926d-6c1d-4cc1-9ab2-42effae919d2">
-        <File Id="SDKSETTINGS_PLIST" Source="$(var.SDK_ROOT)\SDKSettings.plist" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <ComponentGroup Id="DISPATCH_HEADERS">
-      <ComponentRef Id="DISPATCH_DISPATCH_HEADERS" />
-      <ComponentRef Id="DISPATCH_OS_HEADERS" />
-    </ComponentGroup>
-
-    <ComponentGroup Id="PLISTS">
-      <ComponentRef Id="PLATFORM_INFO_PLIST" />
-      <ComponentRef Id="SDK_SDKSETTINGS_PLIST" />
-    </ComponentGroup>
 
     <DirectoryRef Id="TARGETDIR">
-      <Component Id="ENV_VARS" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
+      <Component Id="EnvironmentVariables" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
         <!-- <Condition> %PROCESSOR_ARCHITECTURE~="amd64" </Condition> -->
-        <Environment Id="SDKROOT" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
+        <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
       </Component>
     </DirectoryRef>
 
     <!-- Features -->
-    <Feature Id="SDK" ConfigurableDirectory="INSTALLDIR" Level="1">
-      <ComponentRef Id="XCTEST_RUNTIME" />
-      <ComponentRef Id="XCTEST_IMPORT_LIBS" />
-      <ComponentRef Id="XCTEST_SWIFT_MODULES" />
+    <Feature Id="WinX64SDK" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows x86_64" Level="1" Title="Swift SDK for Windows x86_64">
+      <ComponentRef Id="XCTestRuntime" />
+      <ComponentRef Id="XCTestLibraries" />
+      <ComponentRef Id="XCTestSwiftModule" />
 
-      <ComponentRef Id="BLOCKS_RUNTIME_HEADERS" />
-      <ComponentRef Id="BLOCKS_RUNTIME_IMPORT_LIBS" />
+      <ComponentRef Id="BlocksRuntimeHeaders" />
+      <ComponentRef Id="BlocksRuntimeLibraries" />
 
-      <ComponentGroupRef Id="DISPATCH_HEADERS" />
-      <ComponentRef Id="DISPATCH_IMPORT_LIBS" />
+      <ComponentRef Id="DispatchHeaders" />
+      <ComponentRef Id="DispatchOSHeaders" />
+      <ComponentRef Id="DispatchLibraries" />
 
-      <ComponentRef Id="_CONCURRENCY_SWIFTMODULE" />
-      <ComponentRef Id="_DIFFERENTIATION_SWIFTMODULE" />
-      <ComponentRef Id="DISTRIBUTED_SWIFTMODULE" />
-      <ComponentRef Id="_STRING_PROCESSING_SWIFTMODULE" />
-      <ComponentRef Id="CRT_SWIFTMODULE" />
-      <ComponentRef Id="DISPATCH_SWIFTMODULE" />
-      <ComponentRef Id="FOUNDATION_SWIFTMODULE" />
-      <ComponentRef Id="FOUNDATION_NETWORKING_SWIFTMODULE" />
-      <ComponentRef Id="FOUNDATION_XML_SWIFTMODULE"/>
-      <ComponentRef Id="SWIFT_SWIFTMODULE" />
-      <ComponentRef Id="SWIFT_ONONE_SUPPORT_SWIFTMODULE" />
-      <ComponentRef Id="WINSDK_SWIFTMODULE" />
+      <ComponentRef Id="_Concurrency.swiftmodule" />
+      <ComponentRef Id="_Differentiation.swiftmodule" />
+      <ComponentRef Id="Distributed.swiftmodule" />
+      <ComponentRef Id="_StringProcessing.swiftmodule" />
+      <ComponentRef Id="CRT.swiftmodule" />
+      <ComponentRef Id="Dispatch.swiftmodule" />
+      <ComponentRef Id="Foundation.swiftmodule" />
+      <ComponentRef Id="FoundationNetworking.swiftmodule" />
+      <ComponentRef Id="FoundationXML.swiftmodule"/>
+      <ComponentRef Id="Swift.swiftmodule" />
+      <ComponentRef Id="SwiftOnoneSupport.swiftmodule" />
+      <ComponentRef Id="WinSDK.swiftmodule" />
 
-      <ComponentRef Id="_CONCURRENCY_IMPORT_LIBS" />
-      <ComponentRef Id="_DIFFERENTIATION_IMPORT_LIBS" />
-      <ComponentRef Id="_DISTRIBUTED_IMPORT_LIBS" />
-      <!-- <ComponentRef Id="CRT_IMPORT_LIBS" /> -->
-      <!-- <ComponentRef Id="DISPATCH_IMPORT_LIBS" /> -->
-      <ComponentRef Id="FOUNDATION_IMPORT_LIBS" />
-      <!-- <ComponentRef Id="FOUNDATION_NETWORKING_IMPORT_LIBS" /> -->
-      <!-- <ComponentRef Id="FOUNDATION_XML_IMPORT_LIBS" /> -->
-      <ComponentRef Id="SWIFT_IMPORT_LIBS" />
-      <!-- <ComponentRef Id="SWIFT_ONONE_SUPPORT_IMPORT_LIBS" /> -->
-      <!-- <ComponentRef Id="WINSDK_IMPORT_LIBS" /> -->
-      <ComponentRef Id="SDK_OVERLAY_IMPORT_LIBS" />
+      <ComponentRef Id="_ConcurrencyLibraries" />
+      <ComponentRef Id="_DifferentiationLibraries" />
+      <ComponentRef Id="_DistributedLibraries" />
+      <ComponentRef Id="FoundationLibraries" />
+      <ComponentRef Id="SwiftLibraries" />
+      <ComponentRef Id="SwiftSDKOverlayLibraries" />
 
-      <ComponentRef Id="SWIFT_REMOTE_MIRROR_HEADERS" />
-      <ComponentRef Id="SWIFT_REMOTE_MIRROR_IMPORT_LIBS" />
+      <ComponentRef Id="SwiftRemoteMirrorHeaders" />
+      <ComponentRef Id="SwiftRemoteMirrorLibraries" />
 
-      <ComponentGroupRef Id="SWIFT_SHIMS" />
+      <ComponentGroupRef Id="SwiftShims" />
 
-      <ComponentRef Id="REGISTRAR" />
+      <ComponentRef Id="Registrar" />
 
-      <ComponentRef Id="WINDOWS_SDK_SUPPORT_FILES" />
+      <ComponentRef Id="SupportFiles" />
 
-      <ComponentRef Id="ENV_VARS" />
-      <ComponentGroupRef Id="PLISTS" />
+      <ComponentRef Id="Info.plist" />
+      <ComponentRef Id="SDKSettings.plist" />
+
+      <ComponentRef Id="EnvironmentVariables" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows x86_64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentRef Id="XCTestRuntimeDebugInfo" />
+      </Feature>
+      <?endif ?>
     </Feature>
 
     <!-- UI -->
@@ -410,7 +412,7 @@
                   Return="check" />
     <CustomAction Id="SwiftInstaller_InstallAuxiliaryFiles.SetProperty"
                   Property="SwiftInstaller_InstallAuxiliaryFiles"
-                  Value="[INSTALLDIR]Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"
+                  Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"
                   Return="check" />
 
     <!-- Hooks -->

--- a/platforms/Windows/sdk.wixproj
+++ b/platforms/Windows/sdk.wixproj
@@ -28,7 +28,7 @@
   <Import Project="$(WixTargetsPath)" />
 
   <PropertyGroup>
-    <DefineConstants>ProductVersion=$(ProductVersion);PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);SWIFT_SOURCE_DIR=$(SWIFT_SOURCE_DIR);SDK_ROOT_USR_LIB_SWIFT_SHIMS=$(SDK_ROOT)\usr\lib\swift\shims;</DefineConstants>
+    <DefineConstants>ProductVersion=$(ProductVersion);PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);SWIFT_SOURCE_DIR=$(SWIFT_SOURCE_DIR);SwiftShimsPath=$(SDK_ROOT)\usr\lib\swift\shims;</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
     <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>
@@ -48,9 +48,9 @@
   <Target Name="BeforeBuild">
     <ItemGroup>
       <HarvestDirectory Include="$(SDK_ROOT)\usr\lib\swift\shims">
-        <ComponentGroupName>SWIFT_SHIMS</ComponentGroupName>
-        <DirectoryRefId>WINDOWS_SDK_USR_LIB_SWIFT_SHIMS</DirectoryRefId>
-        <PreprocessorVariable>var.SDK_ROOT_USR_LIB_SWIFT_SHIMS</PreprocessorVariable>
+        <ComponentGroupName>SwiftShims</ComponentGroupName>
+        <DirectoryRefId>WindowsSDK_usr_lib_swift_shims</DirectoryRefId>
+        <PreprocessorVariable>var.SwiftShimsPath</PreprocessorVariable>
       </HarvestDirectory>
     </ItemGroup>
   </Target>

--- a/platforms/Windows/toolchain.wixproj
+++ b/platforms/Windows/toolchain.wixproj
@@ -36,13 +36,13 @@
     <ItemGroup>
       <!-- FIXME(compnerd): include the shims in the toolchain instead of the SDK?
       <HarvestDirectory Include="$(TOOLCHAIN_ROOT)\usr\lib\swift\shims">
-        <ComponentGroupName>SWIFT_SHIMS</ComponentGroupName>
-        <DirectoryRefId>USR_LIB_SWIFT_SHIMS</DirectoryRefId>
+        <ComponentGroupName>SwiftShims</ComponentGroupName>
+        <DirectoryRefId>_usr_lib_swift_shims</DirectoryRefId>
       </HarvestDirectory>
       -->
       <HarvestDirectory Include="$(TOOLCHAIN_ROOT)\usr\lib\clang">
-        <ComponentGroupName>CLANG_RESOURCES</ComponentGroupName>
-        <DirectoryRefId>USR_LIB_CLANG</DirectoryRefId>
+        <ComponentGroupName>ClangResources</ComponentGroupName>
+        <DirectoryRefId>_usr_lib_clang</DirectoryRefId>
         <PreprocessorVariable>var.TOOLCHAIN_ROOT_USR_LIB_CLANG</PreprocessorVariable>
       </HarvestDirectory>
     </ItemGroup>

--- a/platforms/Windows/toolchain.wxs
+++ b/platforms/Windows/toolchain.wxs
@@ -14,83 +14,81 @@
     <Media Id="1" Cabinet="toolchain.cab" EmbedCab="yes" CompressionLevel="high" />
 
     <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="clang_PDBs.cab" />
-    <Media Id="3" Cabinet="LLDB_PDBs.cab" />
-    <Media Id="4" Cabinet="LLVM_PDBs.cab" />
-    <Media Id="5" Cabinet="Swift_PDBs.cab" />
-    <Media Id="6" Cabinet="SourceKit_PDBs.cab" />
-    <Media Id="7" Cabinet="LLD_PDBs.cab" />
-    <Media Id="8" Cabinet="LLBuild_PDBs.cab" />
-    <Media Id="9" Cabinet="SwiftDriver_PDBs.cab" />
-    <Media Id="10" Cabinet="ArgumentParser_PDBs.cab" />
-    <Media Id="11" Cabinet="ToolsSupportCore_PDBs.cab" />
-    <Media Id="12" Cabinet="Yams_PDBs.cab" />
+    <Media Id="2" Cabinet="PDBs.clang.cab" />
+    <Media Id="3" Cabinet="PDBs.lldb.cab" />
+    <Media Id="4" Cabinet="PDBs.llvm.cab" />
+    <Media Id="5" Cabinet="PDBs.swift.cab" />
+    <Media Id="6" Cabinet="PDBs.SourceKit.cab" />
+    <Media Id="7" Cabinet="PDBs.lld.cab" />
+    <Media Id="8" Cabinet="PDBs.llbuild.cab" />
+    <Media Id="9" Cabinet="PDBs.swift-driver.cab" />
+    <Media Id="10" Cabinet="PDBs.ArgumentParser.cab" />
+    <Media Id="11" Cabinet="PDBs.ToolsSupportCore.cab" />
+    <Media Id="12" Cabinet="PDBs.Yams.cab" />
     <?endif?>
 
     <!-- Directory Structure -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="WINDOWSVOLUME">
-        <Directory Id="LIBRARY" Name="Library">
-          <Directory Id="DEVELOPER" Name="Developer">
-            <Directory Id="TOOLCHAINS" Name="Toolchains">
-              <!-- TODO(compnerd):
-                This really should be
-                unknown-Asserts-$(var.ProductVersion).xctoolchain,
-                though before changing, we should setup a
-                `unknown-Asserts-current.xctoolchain`
-                symlink. Additionally, beware that the environment chagnes
-                below will need to be updated to reflect this change. Ideally,
-                we would have as part of this a tool to select the different
-                toolchain versions.
-              -->
-              <Directory Id="UNKNOWN_ASSERTS_DEVELOPMENT_XCTOOLCHAIN" Name="unknown-Asserts-development.xctoolchain">
-                <Directory Id="USR" Name="usr">
-                  <Directory Id="USR_BIN" Name="bin">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Toolchains" Name="Toolchains">
+            <!-- TODO(compnerd):
+              This really should be
+              unknown-Asserts-$(var.ProductVersion).xctoolchain,
+              though before changing, we should setup a
+              `unknown-Asserts-current.xctoolchain`
+              symlink. Additionally, beware that the environment chagnes
+              below will need to be updated to reflect this change. Ideally,
+              we would have as part of this a tool to select the different
+              toolchain versions.
+            -->
+            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+              <Directory Id="_usr" Name="usr">
+                <Directory Id="_usr_bin" Name="bin">
+                </Directory>
+                <Directory Id="_usr_include" Name="include">
+                  <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
                   </Directory>
-                  <Directory Id="USR_INCLUDE" Name="include">
-                    <Directory Id="USR_INCLUDE__INTERNALSWIFTSCAN" Name="_InternalSwiftScan">
-                    </Directory>
-                    <Directory Id="USR_INCLUDE__INTERNALSWIFTSYNTAXPARSER" Name="_InternalSwiftSyntaxParser">
-                    </Directory>
-                    <Directory Id="USR_INCLUDE_CLANG_C" Name="clang-c">
-                    </Directory>
-                    <Directory Id="USR_INCLUDE_DISPATCH" Name="dispatch">
-                    </Directory>
-                    <Directory Id="USR_INCLUDE_INDEXSTORE" Name="indexstore">
-                    </Directory>
-                    <Directory Id="USR_INCLUDE_LLDB" Name="lldb">
-                    </Directory>
-                    <Directory Id="USR_INCLUDE_LLVM_C" Name="llvm-c">
-                    </Directory>
-                    <Directory Id="USR_INCLUDE_OS" Name="os">
-                    </Directory>
-                    <Directory Id="USR_INCLUDE_SOURCEKIT" Name="SourceKit">
-                    </Directory>
+                  <Directory Id="_usr_include__InternalSwiftSyntaxParser" Name="_InternalSwiftSyntaxParser">
                   </Directory>
-                  <Directory Id="USR_LIB" Name="lib">
-                    <Directory Id="USR_LIB_CLANG" Name="clang">
-                    </Directory>
-                    <Directory Id="USR_LIB_SITE_PACKAGES" Name="site-packages">
-                      <Directory Id="USR_LIB_SITE_PACKAGES_LLDB" Name="lldb">
-                        <Directory Id="USR_LIB_SITE_PACKAGES_LLDB_FORMATTERS" Name="formatters">
-                          <Directory Id="USR_LIB_SITE_PACKAGES_LLDB_FORMATTERS_CPP" Name="cpp">
-                          </Directory>
-                        </Directory>
-                        <Directory Id="USR_LIB_SITE_PACKAGES_LLDB_UTILS" Name="utils">
+                  <Directory Id="_usr_include_clang_c" Name="clang-c">
+                  </Directory>
+                  <Directory Id="_usr_include_dispatch" Name="dispatch">
+                  </Directory>
+                  <Directory Id="_usr_include_indexstore" Name="indexstore">
+                  </Directory>
+                  <Directory Id="_usr_include_lldb" Name="lldb">
+                  </Directory>
+                  <Directory Id="_usr_include_llvm_c" Name="llvm-c">
+                  </Directory>
+                  <Directory Id="_usr_include_os" Name="os">
+                  </Directory>
+                  <Directory Id="_usr_include_SourceKit" Name="SourceKit">
+                  </Directory>
+                </Directory>
+                <Directory Id="_usr_lib" Name="lib">
+                  <Directory Id="_usr_lib_clang" Name="clang">
+                  </Directory>
+                  <Directory Id="_usr_lib_site_packages" Name="site-packages">
+                    <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
+                      <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
+                        <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
                         </Directory>
                       </Directory>
-                    </Directory>
-                    <Directory Id="USR_LIB_SWIFT" Name="swift">
-                      <Directory Id="USR_LIB_SWIFT_MIGRATOR" Name="migrator">
-                      </Directory>
-                      <Directory Id="USR_LIB_SWIFT_SHIMS" Name="shims">
+                      <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
                       </Directory>
                     </Directory>
                   </Directory>
-                  <Directory Id="USR_LIBEXEC" Name="libexec">
+                  <Directory Id="_usr_lib_swift" Name="swift">
+                    <Directory Id="_usr_lib_swift_migrator" Name="migrator">
+                    </Directory>
+                    <Directory Id="_usr_lib_swift_shims" Name="shims">
+                    </Directory>
                   </Directory>
-                  <Directory Id="USR_SHARE" Name="share">
-                  </Directory>
+                </Directory>
+                <Directory Id="_usr_libexec" Name="libexec">
+                </Directory>
+                <Directory Id="_usr_share" Name="share">
                 </Directory>
               </Directory>
             </Directory>
@@ -99,407 +97,410 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
+      NOT INSTALLDIR
+    </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="USR_BIN">
-      <Component Id="TOOLCHAIN_BINS" Guid="d150bdb3-d0f4-4a12-bacf-4dc0b1724d9e">
+    <DirectoryRef Id="_usr_bin">
+      <Component Id="Toolchain" Guid="d150bdb3-d0f4-4a12-bacf-4dc0b1724d9e">
         <!-- clang -->
 
         <!-- symlinks -->
-        <File Id="CLANG_CL_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cl.exe" Checksum="yes" />
-        <File Id="CLANG_CPP_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cpp.exe" Checksum="yes" />
-        <File Id="CLANG____EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang++.exe" Checksum="yes" />
+        <File Id="clang_cl.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cl.exe" Checksum="yes" />
+        <File Id="clang_cpp.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cpp.exe" Checksum="yes" />
+        <File Id="clang__.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang++.exe" Checksum="yes" />
         <!-- /symlinks -->
 
-        <File Id="CLANG_FORMAT_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.exe" Checksum="yes" />
-        <File Id="CLANG_TIDY_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.exe" Checksum="yes" />
-        <File Id="CLANG_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.exe" Checksum="yes" />
-        <File Id="LIBCLANG_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.dll" Checksum="yes" />
-        <File Id="LIBINDEXSTORE_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.dll" Checksum="yes" />
+        <File Id="clang_format.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.exe" Checksum="yes" />
+        <File Id="clang_tidy.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.exe" Checksum="yes" />
+        <File Id="clang.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.exe" Checksum="yes" />
+        <File Id="libclang.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.dll" Checksum="yes" />
+        <File Id="libIndexStore.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.dll" Checksum="yes" />
         <!-- clang-offload-bundler.exe, clang-refactor.exe, clang-rename.exe, optremarks.dll, scan-build, scan-view -->
 
         <!-- lld -->
 
         <!-- symlinks -->
-        <File Id="LD_LLD_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld.lld.exe" Checksum="yes" />
-        <File Id="LD64_LLD_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld64.lld.exe" Checksum="yes" />
-        <File Id="LLD_LINK_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld-link.exe" Checksum="yes" />
-        <File Id="WASM_LD_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\wasm-ld.exe" Checksum="yes" />
+        <File Id="ld.lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld.lld.exe" Checksum="yes" />
+        <File Id="ld64.lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld64.lld.exe" Checksum="yes" />
+        <File Id="lld_link.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld-link.exe" Checksum="yes" />
+        <File Id="wasm_ld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\wasm-ld.exe" Checksum="yes" />
         <!-- /symlinks -->
 
-        <File Id="LLD_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.exe" Checksum="yes" />
+        <File Id="lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.exe" Checksum="yes" />
 
         <!-- lldb -->
-        <File Id="LLDB_SERVER_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.exe" Checksum="yes" />
-        <File Id="LLDB_VSCODE_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.exe" Checksum="yes" />
-        <File Id="LLDB_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.exe" Checksum="yes" />
-        <File Id="LIBLLDB_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.dll" Checksum="yes" />
-        <File Id="REPL_SWIFT_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\repl_swift.exe" Checksum="yes" />
+        <File Id="lldb_server.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.exe" Checksum="yes" />
+        <File Id="lldb_vscode.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.exe" Checksum="yes" />
+        <File Id="lldb.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.exe" Checksum="yes" />
+        <File Id="liblldb.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.dll" Checksum="yes" />
+        <File Id="repl_swift.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\repl_swift.exe" Checksum="yes" />
         <!-- lldb-argdumper.exe -->
 
         <!-- llvm -->
 
         <!-- symlinks -->
         <!-- addr2line.exe, ar.exe, c++filt.exe, dwp.exe, nm.exe, objcopy.exe, objdump.exe, ranlib.exe, readelf.exe, size.exe, strings.exe -->
-        <File Id="LLVM_DLLTOOL_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dlltool.exe" Checksum="yes" />
-        <File Id="LLVM_LIB_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lib.exe" Checksum="yes" />
-        <File Id="LLVM_RANLIB_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ranlib.exe" Checksum="yes" />
-        <File Id="LLVM_READELF_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readelf.exe" Checksum="yes" />
-        <File Id="LLVM_STRIP_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strip.exe" Checksum="yes" />
+        <File Id="llvm_dlltool.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dlltool.exe" Checksum="yes" />
+        <File Id="llvm_lib.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lib.exe" Checksum="yes" />
+        <File Id="lldb_ranlib.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ranlib.exe" Checksum="yes" />
+        <File Id="llvm_readelf.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readelf.exe" Checksum="yes" />
+        <File Id="llvm_strip.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strip.exe" Checksum="yes" />
         <!-- /symlinks -->
 
-        <File Id="DSYMUTIL_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.exe" Checksum="yes" />
-        <File Id="LLVM_AR_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.exe" Checksum="yes" />
-        <File Id="LLVM_COV_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.exe" Checksum="yes" />
-        <File Id="LLVM_CVTRES_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.exe" Checksum="yes" />
-        <File Id="LLVM_CXXFILT_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.exe" Checksum="yes" />
-        <File Id="LLVM_DWARFDUMP_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.exe" Checksum="yes" />
-        <File Id="LLVM_DWP_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.exe" Checksum="yes" />
-        <File Id="LLVM_LIPO_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.exe" Checksum="yes" />
-        <File Id="LLVM_MT_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.exe" Checksum="yes" />
-        <File Id="LLVM_NM_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.exe" Checksum="yes" />
-        <File Id="LLVM_OBJCOPY_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.exe" Checksum="yes" />
-        <File Id="LLVM_OBJDUMP_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.exe" Checksum="yes" />
-        <File Id="LLVM_PDBUTIL_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.exe" Checksum="yes" />
-        <File Id="LLVM_PROFDATA_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.exe" Checksum="yes" />
-        <File Id="LLVM_RC_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.exe" Checksum="yes" />
-        <File Id="LLVM_READOBJ_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.exe" Checksum="yes" />
-        <File Id="LLVM_SIZE_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.exe" Checksum="yes" />
-        <File Id="LLVM_STRINGS_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.exe" Checksum="yes" />
-        <File Id="LLVM_SYMBOLIZER_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.exe" Checksum="yes" />
-        <File Id="LLVM_UNDNAME_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.exe" Checksum="yes" />
-        <File Id="LTO_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.dll" Checksum="yes" />
+        <File Id="dsymutil.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.exe" Checksum="yes" />
+        <File Id="llvm_ar.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.exe" Checksum="yes" />
+        <File Id="llvm_cov.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.exe" Checksum="yes" />
+        <File Id="llvm_cvtres.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.exe" Checksum="yes" />
+        <File Id="llvm_cxxfilt.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.exe" Checksum="yes" />
+        <File Id="llvm_dwarfdump.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.exe" Checksum="yes" />
+        <File Id="llvm_dwp.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.exe" Checksum="yes" />
+        <File Id="llvm_lipo.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.exe" Checksum="yes" />
+        <File Id="llvm_mt.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.exe" Checksum="yes" />
+        <File Id="llvm_nm.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.exe" Checksum="yes" />
+        <File Id="llvm_objcopy.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.exe" Checksum="yes" />
+        <File Id="llvm_objdump.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.exe" Checksum="yes" />
+        <File Id="llvm_pdbutil.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.exe" Checksum="yes" />
+        <File Id="llvm_profdata.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.exe" Checksum="yes" />
+        <File Id="llvm_rc.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.exe" Checksum="yes" />
+        <File Id="llvm_readobj.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.exe" Checksum="yes" />
+        <File Id="llvm_size.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.exe" Checksum="yes" />
+        <File Id="llvm_strings.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.exe" Checksum="yes" />
+        <File Id="llvm_symbolizer.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.exe" Checksum="yes" />
+        <File Id="llvm_undname.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.exe" Checksum="yes" />
+        <File Id="LTO.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.dll" Checksum="yes" />
 
         <!-- swift -->
 
         <!-- symlinks -->
-        <File Id="SWIFT_AUTOLINK_EXTRACT_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-autolink-extract.exe" Checksum="yes" />
+        <File Id="swift_autolink_extract.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-autolink-extract.exe" Checksum="yes" />
         <!-- /symlinks -->
 
-        <File Id="SWIFT_DEMANGLE_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.exe" Checksum="yes" />
-        <File Id="SWIFT_FRONTEND_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.exe" Checksum="yes" />
-        <File Id="SWIFT_REFACTOR_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-refactor.exe" Checksum="yes" />
-        <File Id="SWIFTDEMANGLE_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.dll" Checksum="yes" />
-        <File Id="_INTERNALSWIFTSCAN_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.dll" Checksum="yes" />
-        <File Id="_INTERNALSWIFTSYNTAXPARSER_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.dll" Checksum="yes" />
+        <File Id="swift_demangle.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.exe" Checksum="yes" />
+        <File Id="swift_frontend.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.exe" Checksum="yes" />
+        <File Id="swiftDemangle.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.dll" Checksum="yes" />
+        <File Id="_InternalSwiftScan.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.dll" Checksum="yes" />
+        <File Id="_InternalSwiftSyntaxParser.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.dll" Checksum="yes" />
 
         <!-- sourcekit -->
-        <File Id="BLOCKSRUNTIME_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
-        <File Id="DISPATCH_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
-        <File Id="SOURCEKITDINPROC_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.dll" Checksum="yes" />
+        <File Id="BlocksRuntime.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
+        <File Id="dispatch.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
+        <File Id="sourcekitdInProc.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.dll" Checksum="yes" />
 
         <!-- non-LLVM build components -->
 
         <!-- llbuild -->
-        <File Id="LLBUILD_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.dll" Checksum="yes" />
-        <File Id="LLBUILDSWIFT_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" Checksum="yes" />
+        <File Id="llbuild.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.dll" Checksum="yes" />
+        <File Id="llbuildSwift.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" Checksum="yes" />
 
-        <File Id="SWIFT_BUILD_TOOL_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
+        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
 
         <!-- swift-driver -->
         <!-- symlinks -->
-        <File Id="SWIFTC_EXE" Name="swiftc.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
+        <File Id="swiftc.exe" Name="swiftc.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
         <!-- /symlinks -->
 
-        <File Id="SWIFT_EXE" Name="swift.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
-        <File Id="SWIFT_HELP_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-help.exe" Checksum="yes" />
-        <File Id="SWIFT_BUILD_SDK_INTERFACES_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-sdk-interfaces.exe" Checksum="yes" />
-        <File Id="SWIFT_OPTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" Checksum="yes" />
-        <File Id="SWIFT_DRIVER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
-        <File Id="SWIFT_DRIVER_EXECUTION_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriverExecution.dll" Checksum="yes" />
+        <File Id="swift.exe" Name="swift.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
+        <File Id="swift_help.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-help.exe" Checksum="yes" />
+        <File Id="swift_build_sdk_interfaces.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-sdk-interfaces.exe" Checksum="yes" />
+        <File Id="SwiftOptions.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" Checksum="yes" />
+        <File Id="SwiftDriver.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
+        <File Id="SwiftDriverExecution.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriverExecution.dll" Checksum="yes" />
 
         <!-- swift-argument-parser -->
-        <File Id="ARGUMENT_PARSER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
-        <File Id="ARGUMENT_PARSER_TOOL_INFO_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.dll" Checksum="yes" />
+        <File Id="ArgumentParser.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
+        <File Id="ArgumentParserToolInfo.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.dll" Checksum="yes" />
 
         <!-- tools-support-core -->
-        <File Id="TSC_BASIC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" Checksum="yes" />
-        <File Id="TSC_LIBC_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.dll" Checksum="yes" />
-        <File Id="TSC_UTILITY_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
+        <File Id="TSCBasic.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" Checksum="yes" />
+        <File Id="TSCLibc.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.dll" Checksum="yes" />
+        <File Id="TSCUtility.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
 
         <!-- Yams -->
-        <File Id="YAMS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
+        <File Id="Yams.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="TOOLCHAIN_DEBUGINFO" Guid="b8eab90b-cf24-48c2-b727-e90231ad87be">
+      <Component Id="ToolchainDebugInfo" Guid="b8eab90b-cf24-48c2-b727-e90231ad87be">
         <!-- clang -->
-        <File Id="CLANG_FORMAT_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.pdb" Checksum="yes" DiskId="2" />
-        <File Id="CLANG_TIDY_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.pdb" Checksum="yes" />
-        <File Id="CLANG_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.pdb" Checksum="yes" DiskId="2" />
-        <File Id="LIBCLANG_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.pdb" Checksum="yes" DiskId="2" />
-        <File Id="LIBINDEXSTORE_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.pdb" Checksum="yes" DiskId="2" />
+        <File Id="clang_format.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.pdb" Checksum="yes" DiskId="2" />
+        <File Id="clang_tidy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.pdb" Checksum="yes" />
+        <File Id="clang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.pdb" Checksum="yes" DiskId="2" />
+        <File Id="libclang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.pdb" Checksum="yes" DiskId="2" />
+        <File Id="libIndexStore.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.pdb" Checksum="yes" DiskId="2" />
 
         <!-- lld -->
-        <File Id="LLD_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.pdb" Checksum="yes" DiskId="7" />
+        <File Id="lld.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.pdb" Checksum="yes" DiskId="7" />
 
         <!-- lldb -->
-        <File Id="LLDB_SERVER_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.pdb" Checksum="yes" DiskId="3" />
-        <File Id="LLDB_VSCODE_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.pdb" Checksum="yes" DiskId="3" />
-        <File Id="LLDB_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.pdb" Checksum="yes" DiskId="3" />
-        <File Id="LIBLLDB_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.pdb" Checksum="yes" DiskId="3" />
+        <File Id="lldb_server.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.pdb" Checksum="yes" DiskId="3" />
+        <File Id="lldb_vscode.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.pdb" Checksum="yes" DiskId="3" />
+        <File Id="lldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.pdb" Checksum="yes" DiskId="3" />
+        <File Id="liblldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.pdb" Checksum="yes" DiskId="3" />
 
         <!-- llvm -->
-        <File Id="DSYMUTIL_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_AR_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_COV_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_CVTRES_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_CXXFILT_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_DWARFDUMP_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_DWP_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_LIPO_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_MT_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_NM_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_OBJCOPY_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_OBJDUMP_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_PDBUTIL_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_PROFDATA_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_RC_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_READOBJ_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_SIZE_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_STRINGS_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_SYMBOLIZER_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LLVM_UNDNAME_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LTO_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.pdb" Checksum="yes" DiskId="4" />
+        <File Id="dsymutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_ar.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_cov.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_cvtres.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_cxxfilt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_dwarfdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_dwp.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_lipo.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_mt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_nm.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_objcopy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_objdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_pdbutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_profdata.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_rc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_readobj.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_size.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_strings.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_symbolizer.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.pdb" Checksum="yes" DiskId="4" />
+        <File Id="llvm_undname.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.pdb" Checksum="yes" DiskId="4" />
+        <File Id="LTO.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.pdb" Checksum="yes" DiskId="4" />
 
         <!-- swift -->
-        <File Id="SWIFT_DEMANGLE_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.pdb" Checksum="yes" DiskId="5" />
-        <File Id="SWIFT_FRONTEND_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.pdb" Checksum="yes" DiskId="5" />
-        <File Id="SWIFT_REFACTOR_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-refactor.pdb" Checksum="yes" DiskId="5" />
-        <File Id="SWIFTDEMANGLE_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="5" />
-        <File Id="_INTERNALSWIFTCAN_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.pdb" Checksum="yes" DiskId="5" />
-        <File Id="_INTERNALSWIFTSYNTAXPARSER_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.pdb" Checksum="yes" DiskId="5" />
+        <File Id="swift_demangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.pdb" Checksum="yes" DiskId="5" />
+        <File Id="swift_frontend.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.pdb" Checksum="yes" DiskId="5" />
+        <File Id="swiftDemangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="5" />
+        <File Id="_InternalSwiftScan.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.pdb" Checksum="yes" DiskId="5" />
+        <File Id="_InternalSwiftSyntaxParser.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.pdb" Checksum="yes" DiskId="5" />
 
         <!-- sourcekit -->
-        <File Id="BLOCKSRUNTIME_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
-        <File Id="DISPATCH_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="6" />
-        <File Id="SOURCEKITDINPROC_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.pdb" Checksum="yes" DiskId="6" />
+        <File Id="BlocksRuntime.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
+        <File Id="dispatch.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="6" />
+        <File Id="sourcekitdInProc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.pdb" Checksum="yes" DiskId="6" />
 
         <!-- non-LLVM build components -->
 
         <!-- llbuild -->
-        <File Id="LLBUILD_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.pdb" Checksum="yes" DiskId="8" />
-        <File Id="LLBUILDSWIFT_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" DiskId="8" />
+        <File Id="llbuild.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.pdb" Checksum="yes" DiskId="8" />
+        <File Id="llbuildSwift.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" DiskId="8" />
 
-        <File Id="SWIFT_BUILD_TOOL_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" DiskId="8" />
+        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" DiskId="8" />
 
         <!-- swift-driver -->
-        <File Id="SWIFT_PDB" Name="swift.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-driver.pdb" Checksum="yes" DiskId="9" />
-        <File Id="SWIFT_OPTIONS_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" DiskId="9" />
-        <File Id="SWIFT_DRIVER_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" DiskId="9" />
-        <File Id="SWIFT_DRIVER_EXECUTION_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.pdb" Checksum="yes" DiskId="9" />
+        <File Id="swift.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.pdb" Checksum="yes" DiskId="9" />
+        <File Id="swift_help.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-help.pdb" Checksum="yes" DiskId="9" />
+        <File Id="swift_build_sdk_interfaces.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-build-sdk-interfaces.pdb" Checksum="yes" DiskId="9" />
+        <File Id="SwiftOptions.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" DiskId="9" />
+        <File Id="SwiftDriver.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" DiskId="9" />
+        <File Id="SwiftDriverExecution.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.pdb" Checksum="yes" DiskId="9" />
 
         <!-- swift-argument-parser -->
-        <File Id="ARGUMENT_PARSER_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" DiskId="10" />
-        <File Id="ARGUMENT_PARSER_TOOL_INFO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.pdb" Checksum="yes" DiskId="10" />
+        <File Id="ArgumentParser.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" DiskId="10" />
+        <File Id="ArgumentParserToolInfo.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.pdb" Checksum="yes" DiskId="10" />
 
         <!-- tools-support-core -->
-        <File Id="TSC_BASIC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" DiskId="11" />
-        <File Id="TSC_LIBC_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.pdb" Checksum="yes" DiskId="11" />
-        <File Id="TSC_UTILITY_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" DiskId="11" />
+        <File Id="TSCBasic.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" DiskId="11" />
+        <File Id="TSCLibc.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.pdb" Checksum="yes" DiskId="11" />
+        <File Id="TSCUtility.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" DiskId="11" />
 
         <!-- Yams -->
-        <File Id="YAMS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" DiskId="12" />
+        <File Id="Yams.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" DiskId="12" />
       </Component>
       <?endif?>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_LIB">
-      <Component Id="TOOLCHAIN_IMPLIBS" Guid="c8c86ead-78b5-49be-815b-7e7d12ba1582">
-        <File Id="BLOCKSRUNTIME_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\BlocksRuntime.lib" Checksum="yes" />
-        <File Id="DISPATCH_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\dispatch.lib" Checksum="yes" />
-        <File Id="LIBCLANG_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libclang.lib" Checksum="yes" />
-        <File Id="LIBINDEXSTORE_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libIndexStore.lib" Checksum="yes" />
-        <File Id="LIBLLDB_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\liblldb.lib" Checksum="yes" />
-        <File Id="LTO_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\LTO.lib" Checksum="yes" />
-        <File Id="SOURCEKITD_IN_PROC_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\sourcekitdInProc.lib" Checksum="yes" />
-        <File Id="SWIFTDEMANGLE_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swiftDemangle.lib" Checksum="yes" />
-        <File Id="_INTERNALSWIFTSCAN_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftScan.lib" Checksum="yes" />
-        <File Id="_INTERNALSWIFTSYNTAXPARSER_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftSyntaxParser.lib" Checksum="yes" />
+    <DirectoryRef Id="_usr_lib">
+      <Component Id="ToolchainLibraries" Guid="c8c86ead-78b5-49be-815b-7e7d12ba1582">
+        <File Id="BlocksRuntime.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\BlocksRuntime.lib" Checksum="yes" />
+        <File Id="dispatch.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\dispatch.lib" Checksum="yes" />
+        <File Id="libclang.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libclang.lib" Checksum="yes" />
+        <File Id="libIndexStore.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libIndexStore.lib" Checksum="yes" />
+        <File Id="liblldb.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\liblldb.lib" Checksum="yes" />
+        <File Id="LTO.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\LTO.lib" Checksum="yes" />
+        <File Id="sourcekitdInProc.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\sourcekitdInProc.lib" Checksum="yes" />
+        <File Id="swiftDemangle.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swiftDemangle.lib" Checksum="yes" />
+        <File Id="_InternalSwiftScan.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftScan.lib" Checksum="yes" />
+        <File Id="_InternalSwiftSyntaxParser.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftSyntaxParser.lib" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_LIB_SITE_PACKAGES_LLDB">
-      <Component Id="LLDB_PYTHON_SCRIPTS" Guid="ab01c50e-3e1f-48d2-ac47-e07978a98aa3">
-        <File Id="LLDB___INIT___PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\__init__.py" Checksum="yes" />
-        <File Id="LLDB__LLDB_PYD" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\_lldb.pyd" Checksum="yes" />
-        <File Id="LLDB_EMBEDDED_INTERPRETER_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\embedded_interpreter.py" Checksum="yes" />
-        <File Id="LLDB_LLDB_ARGDUMPER_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\lldb-argdumper.exe" Checksum="yes" />
+    <DirectoryRef Id="_usr_lib_site_packages_lldb">
+      <Component Id="LLDBPythonScripts" Guid="ab01c50e-3e1f-48d2-ac47-e07978a98aa3">
+        <File Id="LLDB___init__.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\__init__.py" Checksum="yes" />
+        <File Id="_lldb.pyd" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\_lldb.pyd" Checksum="yes" />
+        <File Id="embedded_interpreter.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\embedded_interpreter.py" Checksum="yes" />
+        <File Id="lldb_argdumper.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\lldb-argdumper.exe" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_LIB_SITE_PACKAGES_LLDB_FORMATTERS">
-      <Component Id="LLDB_PYTHON_SCRIPTS_FORMATTERS" Guid="f8fdf112-c3f1-4e0d-814f-6128c9375869">
-        <File Id="LLDB_FORMATTER_LOGGER_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\Logger.py" Checksum="yes" />
-        <File Id="LLDB_FORMATTER___INIT___PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\__init__.py" Checksum="yes" />
-        <File Id="LLDB_FORMATTER_ATTRIB_FROMDICT_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\attrib_fromdict.py" Checksum="yes" />
-        <File Id="LLDB_FORMATTER_CACHE_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cache.py" Checksum="yes" />
-        <File Id="LLDB_FORMATTER_METRICS_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\metrics.py" Checksum="yes" />
-        <File Id="LLDB_FORMATTER_SYNTH_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\synth.py" Checksum="yes" />
+    <DirectoryRef Id="_usr_lib_site_packages_lldb_formatters">
+      <Component Id="LLDBFormatters" Guid="f8fdf112-c3f1-4e0d-814f-6128c9375869">
+        <File Id="logger.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\Logger.py" Checksum="yes" />
+        <File Id="LLDBFormatters___init__.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\__init__.py" Checksum="yes" />
+        <File Id="attrib_fromdict.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\attrib_fromdict.py" Checksum="yes" />
+        <File Id="cache.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cache.py" Checksum="yes" />
+        <File Id="metrics.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\metrics.py" Checksum="yes" />
+        <File Id="synth.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\synth.py" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_LIB_SITE_PACKAGES_LLDB_FORMATTERS_CPP">
-      <Component Id="LLDB_PYTHON_SCRIPTS_FORMATTERS_CPP" Guid="68217602-585a-4bfc-8c39-41c4bc1f3969">
-        <File Id="LLDB_FORMATTER_CPP___INIT___PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\__init__.py" Checksum="yes" />
-        <File Id="LLDB_FORMATTER_CPP__GNU_LIBSTDCPP_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\gnu_libstdcpp.py" Checksum="yes" />
-        <File Id="LLDB_FORMATTER_CPP_LIBCXX_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\libcxx.py" Checksum="yes" />
+    <DirectoryRef Id="_usr_lib_site_packages_lldb_formatters_cpp">
+      <Component Id="LLDBFormattersCPP" Guid="68217602-585a-4bfc-8c39-41c4bc1f3969">
+        <File Id="LLDBFormattersCPP___init__.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\__init__.py" Checksum="yes" />
+        <File Id="gnu_libstdcpp.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\gnu_libstdcpp.py" Checksum="yes" />
+        <File Id="libcxx.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\libcxx.py" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_LIB_SITE_PACKAGES_LLDB_UTILS">
-      <Component Id="LLDB_PYTHON_SCRIPTS_UTILS" Guid="f1402112-72fd-450a-962c-a0a29ec23278">
-        <File Id="LLDB_UTILS___INIT___PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\__init__.py" Checksum="yes" />
-        <File Id="LLDB_UTILS_IN_CALL_STACK_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\in_call_stack.py" Checksum="yes" />
-        <File Id="LLDB_UTILS_SYMBOLICATION_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\symbolication.py" Checksum="yes" />
+    <DirectoryRef Id="_usr_lib_site_packages_lldb_utils">
+      <Component Id="LLDBUtils" Guid="f1402112-72fd-450a-962c-a0a29ec23278">
+        <File Id="LLDBUtils___init__.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\__init__.py" Checksum="yes" />
+        <File Id="in_call_stack.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\in_call_stack.py" Checksum="yes" />
+        <File Id="symbolication.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\symbolication.py" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
     <!-- TODO(compnerd): install the block headers from Swift -->
     <!--
-    <DirectoryRef Id="USR_INCLUDE">
-      <Component Id="BLOCK_HEADERS" Guid="87f18903-e252-41c4-ade9-aeb4819eeebe">
-        <File Id="BLOCK_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\Block.h" Checksum="yes" />
+    <DirectoryRef Id="_usr_include">
+      <Component Id="BlockRuntimeHeaders" Guid="87f18903-e252-41c4-ade9-aeb4819eeebe">
+      <File Id="BlocskRuntimeBlock.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\Block.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
     -->
 
-    <DirectoryRef Id="USR_INCLUDE__INTERNALSWIFTSCAN">
-      <Component Id="_INTERNALSWIFTSCAN_HEADERS" Guid="d680187a-4f9e-4008-ab79-ab5eeb13fd50">
-        <File Id="DEPENDENCYSCAN_H" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScan.h" Checksum="yes" />
-        <File Id="DEPENDENCYSCANMACROS_H" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScanMacros.h" Checksum="yes" />
-        <File Id="_INTERNALSWIFTSCAN_MODULE_MODULEMAP" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\module.modulemap" Checksum="yes" />
+    <DirectoryRef Id="_usr_include__InternalSwiftScan">
+      <Component Id="_InternalSwiftScanHeaders" Guid="d680187a-4f9e-4008-ab79-ab5eeb13fd50">
+        <File Id="DependencyScan.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScan.h" Checksum="yes" />
+        <File Id="DependencyScanMacros.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScanMacros.h" Checksum="yes" />
+        <File Id="_InternalSwiftScan.modulemap" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\module.modulemap" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_INCLUDE__INTERNALSWIFTSYNTAXPARSER">
-      <Component Id="_INTERNALSWIFTSYNTAXPARSER_HEADERS" Guid="81ae1aef-7471-4637-b0a2-86b6f9def568">
-        <File Id="SWIFTSYNTAXPARSER_H" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxParser.h" Checksum="yes" />
-        <File Id="SWIFTSYNTAXCDATATYPES_H" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxCDataTypes.h" Checksum="yes" />
-        <File Id="_INTERNALSWIFTSYNTAXPARSER_MODULE_MODULEMAP" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\module.modulemap" Checksum="yes" />
+    <DirectoryRef Id="_usr_include__InternalSwiftSyntaxParser">
+      <Component Id="_InternalSwiftSyntaxParserHeaders" Guid="81ae1aef-7471-4637-b0a2-86b6f9def568">
+        <File Id="SwiftSyntaxParser.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxParser.h" Checksum="yes" />
+        <File Id="SwiftSyntaxCDataTypes.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxCDataTypes.h" Checksum="yes" />
+        <File Id="_InternalSwiftSyntaxParser.modulemap" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\module.modulemap" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_INCLUDE_CLANG_C">
-      <Component Id="LIBCLANG_HEADERS" Guid="3bd9acb2-6d90-4197-afb7-ebec49c4aa75">
-        <File Id="BUILDSYSTEM_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\BuildSystem.h" Checksum="yes" />
-        <File Id="CXCOMPILATIONDATABASE_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXCompilationDatabase.h" Checksum="yes" />
-        <File Id="CXERRORCODE_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXErrorCode.h" Checksum="yes" />
-        <File Id="CXSTRING_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXString.h" Checksum="yes" />
-        <File Id="DOCUMENTATION_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Documentation.h" Checksum="yes" />
-        <File Id="FATALERRORHANDLER_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\FatalErrorHandler.h" Checksum="yes" />
-        <File Id="INDEX_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Index.h" Checksum="yes" />
-        <File Id="PLATFORM_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Platform.h" Checksum="yes" />
-        <File Id="REFACTOR_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Refactor.h" Checksum="yes" />
+    <DirectoryRef Id="_usr_include_clang_c">
+      <Component Id="libclangHeader" Guid="3bd9acb2-6d90-4197-afb7-ebec49c4aa75">
+        <File Id="BuildSystem.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\BuildSystem.h" Checksum="yes" />
+        <File Id="CXCompilationDatabase.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXCompilationDatabase.h" Checksum="yes" />
+        <File Id="CXErrorCode.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXErrorCode.h" Checksum="yes" />
+        <File Id="CXString.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXString.h" Checksum="yes" />
+        <File Id="Documentation.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Documentation.h" Checksum="yes" />
+        <File Id="FatalErrorHandler.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\FatalErrorHandler.h" Checksum="yes" />
+        <File Id="Index.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Index.h" Checksum="yes" />
+        <File Id="Platform.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Platform.h" Checksum="yes" />
+        <File Id="Refactor.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Refactor.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_INCLUDE_INDEXSTORE">
-      <Component Id="INDEXSTORE_HEADERS" Guid="a9555162-c45d-404f-aec2-44f7a82ca4fe">
-        <File Id="INDEXSTORE_H" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\indexstore.h" Checksum="yes" />
-        <File Id="INDEXSTORECXX_H" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\IndexStoreCXX.h" Checksum="yes" />
+    <DirectoryRef Id="_usr_include_indexstore">
+      <Component Id="IndexStoreHeaders" Guid="a9555162-c45d-404f-aec2-44f7a82ca4fe">
+        <File Id="indexstore.h" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\indexstore.h" Checksum="yes" />
+        <File Id="IndexStoreCXX.h" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\IndexStoreCXX.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_INCLUDE_LLVM_C">
-      <Component Id="LTO_HEADERS" Guid="dd5ced9e-e3d5-4bf3-9f47-de0c8ca20720">
-        <File Id="LTO_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\llvm-c\lto.h" Checksum="yes" />
+    <DirectoryRef Id="_usr_include_llvm_c">
+      <Component Id="LTOHeaders" Guid="dd5ced9e-e3d5-4bf3-9f47-de0c8ca20720">
+        <File Id="lto.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\llvm-c\lto.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
     <!-- TODO(compnerd): install the dispatch headers from swift -->
     <!--
-    <DirectoryRef Id="USR_INCLUDE_DISPATCH">
-      <Component Id="DISPATCH_HEADERS" Guid="4f9607c6-e517-40a4-9c66-4f76411582ff">
-        <File Id="DISPATCH_BASE_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\base.h" Checksum="yes" />
-        <File Id="DISPATCH_BLOCK_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\block.h" Checksum="yes" />
-        <File Id="DISPATCH_DATA_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\data.h" Checksum="yes" />
-        <File Id="DISPATCH_DISPATCH_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\dispatch.h" Checksum="yes" />
-        <File Id="DISPATCH_GROUP_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\group.h" Checksum="yes" />
-        <File Id="DISPATCH_INTROSPECTION_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\introspection.h" Checksum="yes" />
-        <File Id="DISPATCH_IO_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\io.h" Checksum="yes" />
-        <File Id="DISPATCH_OBJECT_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\object.h" Checksum="yes" />
-        <File Id="DISPATCH_ONCE_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\once.h" Checksum="yes" />
-        <File Id="DISPATCH_QUEUE_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\queue.h" Checksum="yes" />
-        <File Id="DISPATCH_SEMAPHORE_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\semaphore.h" Checksum="yes" />
-        <File Id="DISPATCH_SOURCE_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\source.h" Checksum="yes" />
-        <File Id="DISPATCH_TIME_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\time.h" Checksum="yes" />
+    <DirectoryRef Id="_usr_include_dispatch">
+      <Component Id="DispatchHeaders" Guid="4f9607c6-e517-40a4-9c66-4f76411582ff">
+        <File Id="base.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\base.h" Checksum="yes" />
+        <File Id="dispatch_block.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\block.h" Checksum="yes" />
+        <File Id="data.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\data.h" Checksum="yes" />
+        <File Id="dispatch.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\dispatch.h" Checksum="yes" />
+        <File Id="group.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\group.h" Checksum="yes" />
+        <File Id="introspection.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\introspection.h" Checksum="yes" />
+        <File Id="io.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\io.h" Checksum="yes" />
+        <File Id="dispatch.modulemap" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\dispatch.modulemap" Checksum="yes" />
+        <File Id="dispatch_object.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\object.h" Checksum="yes" />
+        <File Id="once.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\once.h" Checksum="yes" />
+        <File Id="queue.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\queue.h" Checksum="yes" />
+        <File Id="semaphore.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\semaphore.h" Checksum="yes" />
+        <File Id="source.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\source.h" Checksum="yes" />
+        <File Id="time.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\time.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_INCLUDE_OS">
-      <Component Id="OS_HEADERS" Guid="7b2d5d0e-f4eb-4562-a739-095715347718">
-        <File Id="OS_OBJECT_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\object.h" Checksum="yes" />
-        <File Id="OS_GENERIC_UNIX_BASE_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\generic_unix_base.h" Checksum="yes" />
-        <File Id="OS_GENERIC_WIN_BASE_H" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\generic_win_base.h" Checksum="yes" />
+    <DirectoryRef Id="_usr_include_os">
+      <Component Id="DispatchOSHeaders" Guid="7b2d5d0e-f4eb-4562-a739-095715347718">
+        <File Id="generic_unix_base.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\generic_unix_base.h" Checksum="yes" />
+        <File Id="generic_win_base.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\generic_win_base.h" Checksum="yes" />
+        <File Id="os_object.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\object.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
     -->
 
-    <DirectoryRef Id="USR_INCLUDE_SOURCEKIT">
-      <Component Id="SOURCEKIT_HEADERS" Guid="758c7e7c-9214-4fff-bfb6-56cb1aa42e2b">
-        <File Id="SOURCEKITD_H" Source="$(var.TOOLCHAIN_ROOT)\usr\include\SourceKit\sourcekitd.h" Checksum="yes" />
+    <DirectoryRef Id="_usr_include_SourceKit">
+      <Component Id="SourceKitHeaders" Guid="758c7e7c-9214-4fff-bfb6-56cb1aa42e2b">
+        <File Id="sourcekitd.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\SourceKit\sourcekitd.h" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="USR_LIB_SWIFT_MIGRATOR">
-      <Component Id="SWIFT_MIGRATOR_DATA" Guid="0d2c2da1-0634-4b6b-9f15-29f11995cb31">
-        <File Id="IOS4_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\ios4.json" Checksum="yes" />
-        <File Id="IOS42_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\ios42.json" Checksum="yes" />
-        <File Id="MACOS4_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\macos4.json" Checksum="yes" />
-        <File Id="MACOS42_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\macos42.json" Checksum="yes" />
-        <File Id="OVERLAY4_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay4.json" Checksum="yes" />
-        <File Id="OVERLAY42_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay42.json" Checksum="yes" />
-        <File Id="TVOS4_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\tvos4.json" Checksum="yes" />
-        <File Id="TVOS42_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\tvos42.json" Checksum="yes" />
-        <File Id="WATCHOS4_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos4.json" Checksum="yes" />
-        <File Id="WATCHOS42_JSON" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos42.json" Checksum="yes" />
+    <DirectoryRef Id="_usr_lib_swift_migrator">
+      <Component Id="SwiftMigratorData" Guid="0d2c2da1-0634-4b6b-9f15-29f11995cb31">
+        <File Id="ios4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\ios4.json" Checksum="yes" />
+        <File Id="ios42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\ios42.json" Checksum="yes" />
+        <File Id="macos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\macos4.json" Checksum="yes" />
+        <File Id="macos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\macos42.json" Checksum="yes" />
+        <File Id="overlay4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay4.json" Checksum="yes" />
+        <File Id="overlay42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay42.json" Checksum="yes" />
+        <File Id="tvos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\tvos4.json" Checksum="yes" />
+        <File Id="tvos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\tvos42.json" Checksum="yes" />
+        <File Id="watchos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos4.json" Checksum="yes" />
+        <File Id="watchos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos42.json" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
     <DirectoryRef Id="TARGETDIR">
-      <Component Id="ENV_VARS" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
-        <Environment Id="DEVELOPER_DIR" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[WindowsVolume]Library\Developer" />
-        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
+      <Component Id="EnvironmentVariables" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
+        <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer" />
+        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
       </Component>
     </DirectoryRef>
 
-    <Feature Id="TOOLCHAIN" Level="1">
-      <ComponentRef Id="TOOLCHAIN_BINS" />
-      <ComponentRef Id="TOOLCHAIN_IMPLIBS" />
+    <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows x86_64" Level="1" Title="Swift Toolchain for Windows x86_64">
+      <ComponentRef Id="Toolchain" />
+      <ComponentRef Id="ToolchainLibraries" />
       <!--
-      <ComponentRef Id="BLOCK_HEADERS" />
+      <ComponentRef Id="BlockRuntimeHeaders" />
       -->
-      <ComponentRef Id="_INTERNALSWIFTSYNTAXPARSER_HEADERS" />
-      <ComponentRef Id="_INTERNALSWIFTSCAN_HEADERS" />
-      <ComponentRef Id="INDEXSTORE_HEADERS" />
-      <ComponentRef Id="LIBCLANG_HEADERS" />
-      <ComponentRef Id="LTO_HEADERS" />
+      <ComponentRef Id="_InternalSwiftSyntaxParserHeaders" />
+      <ComponentRef Id="_InternalSwiftScanHeaders" />
+      <ComponentRef Id="IndexStoreHeaders" />
+      <ComponentRef Id="libclangHeader" />
+      <ComponentRef Id="LTOHeaders" />
       <!--
-      <ComponentRef Id="DISPATCH_HEADERS" />
-      <ComponentRef Id="OS_HEADERS" />
+      <ComponentRef Id="DispatchHeaders" />
+      <ComponentRef Id="DispatchOSHeaders" />
       -->
-      <ComponentRef Id="SOURCEKIT_HEADERS" />
-      <ComponentRef Id="SWIFT_MIGRATOR_DATA" />
-      <ComponentGroupRef Id="CLANG_RESOURCES" />
+      <ComponentRef Id="SourceKitHeaders" />
+      <ComponentRef Id="SwiftMigratorData" />
+      <ComponentGroupRef Id="ClangResources" />
       <!--
-      <ComponentGroupRef Id="SWIFT_SHIMS" />
+      <ComponentGroupRef Id="SwiftShims" />
       -->
-      <ComponentRef Id="LLDB_PYTHON_SCRIPTS" />
-      <ComponentRef Id="LLDB_PYTHON_SCRIPTS_FORMATTERS" />
-      <ComponentRef Id="LLDB_PYTHON_SCRIPTS_FORMATTERS_CPP" />
-      <ComponentRef Id="LLDB_PYTHON_SCRIPTS_UTILS" />
+      <ComponentRef Id="LLDBPythonScripts" />
+      <ComponentRef Id="LLDBFormatters" />
+      <ComponentRef Id="LLDBFormattersCPP" />
+      <ComponentRef Id="LLDBUtils" />
 
-      <ComponentRef Id="ENV_VARS" />
-    </Feature>
+      <ComponentRef Id="EnvironmentVariables" />
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Feature Id="DEBUGINFO" Level="0">
-      <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-      <ComponentRef Id="TOOLCHAIN_DEBUGINFO" />
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows x86_64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentRef Id="ToolchainDebugInfo" />
+      </Feature>
+      <?endif?>
     </Feature>
-    <?endif?>
 
     <!-- UI -->
     <UI />


### PR DESCRIPTION
The previous names created an unnecessary number of variables.  This
cleans up the variables in the hopes that we can star exposing features
into the installer.  Take the opportunity to homogenise the manifests,
using similar names for cabinets, naming patterns, and make install
roots configurable even though that is not exposed via a UI.

Additionally add missing files for Swift Package Manager while
restructuring the MSI packages.  Furthermore, mark Debug Information
features as sub-features as they do not make sense as standalone
features.