### PR TITLE
WiX: add some more control over the MSI chain

### DIFF
--- a/platforms/Windows/installer.wixproj
+++ b/platforms/Windows/installer.wixproj
@@ -14,6 +14,11 @@
   <PropertyGroup>
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
     <ProductVersion>$(ProductVersion)</ProductVersion>
+
+    <RequiredChain Condition=" '$(RequiredChain)' == '' ">icu.msi;runtime.msi;toolchain.msi;devtools.msi;sdk.msi</RequiredChain>
+    <RequiredChain>$(RequiredChain)</RequiredChain>
+
+    <OptionalChain>$(OptionalChain)</OptionalChain>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,7 +30,7 @@
   <Import Project="$(WixTargetsPath)" />
 
   <PropertyGroup>
-    <DefineConstants>ProductVersion=$(ProductVersion);MSI_LOCATION=$(MSI_LOCATION);</DefineConstants>
+    <DefineConstants>ProductVersion=$(ProductVersion);RequiredChain=$(RequiredChain);OptionalChain=$(OptionalChain);MSI_LOCATION=$(MSI_LOCATION);</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/platforms/Windows/installer.wxs
+++ b/platforms/Windows/installer.wxs
@@ -1,18 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
-  <Bundle Name="Swift" Version="$(var.ProductVersion)" Manufacturer="swift.org" UpgradeCode="8c75f32a-7bdf-4c61-abf6-c7e1c4b8fbf6">
+  <Bundle Name="Swift Developer Package for Windows x86_64" Version="$(var.ProductVersion)" Manufacturer="swift.org" UpgradeCode="8c75f32a-7bdf-4c61-abf6-c7e1c4b8fbf6">
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
       <bal:WixStandardBootstrapperApplication LicenseUrl="" LogoFile="Resources/swift.png" SuppressOptionsUI="yes" SuppressRepair="no" />
     </BootstrapperApplicationRef>
 
     <Chain>
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\toolchain.msi" Compressed="yes">
+      <?if $(var.RequiredChain) != "" ?>
+      <?foreach MSI in $(var.RequiredChain) ?>
+      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes">
         <MsiProperty Name="INSTALL_DEBUGINFO" Value="[INSTALL_DEBUGINFO]" />
       </MsiPackage>
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\sdk.msi" Compressed="yes" />
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\devtools.msi" Compressed="yes" />
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\runtime.msi" Compressed="yes" />
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\icu.msi" Compressed="yes" />
+      <?endforeach?>
+      <?endif?>
+
+      <?if $(var.OptionalChain) != "" ?>
+      <?foreach MSI in $(var.OptionalChain) ?>
+      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes" Visible="yes">
+        <MsiProperty Name="INSTALL_DEBUGINFO" Value="[INSTALL_DEBUGINFO]" />
+      </MsiPackage>
+      <?endforeach?>
+      <?endif?>
     </Chain>
   </Bundle>
 </Wix>


### PR DESCRIPTION
This adds the ability to include "optional" MSIs to the chain.  Optional
MSIs are currently always installed as we do not have the UI for feature
selection in the boot-strapper, but can be subsequently removed from the
"Add Remove Programs" control panel.  This will enable the distribution
of the x86 SDK and runtime.