### PR TITLE
Rename _MatchingEngine to _RegexParser.

### DIFF
--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -36,7 +36,7 @@
         <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
         <File Id="swift_Differentiation.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
         <File Id="swiftDistributed.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.dll" Checksum="yes" />
-        <File Id="swift_MatchingEngine.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_MatchingEngine.dll" Checksum="yes" />
+        <File Id="swift_RegexParser.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.dll" Checksum="yes" />
         <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
@@ -61,7 +61,7 @@
         <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
         <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
         <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
-        <File Id="swift_MatchingEngine.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_MatchingEngine.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swift_RegexParser.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.pdb" Checksum="yes" DiskId="2" />
         <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
         <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -35,7 +35,7 @@
         <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
         <File Id="swift_Differentiation.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
         <File Id="swiftDistributed.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.dll" Checksum="yes" />
-        <File Id="swift_MatchingEngine.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_MatchingEngine.dll" Checksum="yes" />
+        <File Id="swift_RegexParser.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.dll" Checksum="yes" />
         <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
@@ -60,7 +60,7 @@
         <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
         <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
         <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
-        <File Id="swift_MatchingEngine.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_MatchingEngine.pdb" Checksum="yes" DiskId="2" />
+        <File Id="swift_RegexParser.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.pdb" Checksum="yes" DiskId="2" />
         <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
         <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -69,7 +69,7 @@
                               </Directory>
                               <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
                               </Directory>
-                              <Directory Id="_MatchingEngine.swiftmodule" Name="_MatchingEngine.swiftmodule">
+                              <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
                               </Directory>
                               <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
                               </Directory>
@@ -201,11 +201,11 @@
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="_MatchingEngine.swiftmodule">
-      <Component Id="_MatchingEngine.swiftmodule" Guid="44e30ebc-57c0-4531-9756-7d30583f5c11">
-        <File Id="_MatchingEngine.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_MatchingEngine.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_MatchingEngine.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_MatchingEngine.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_MatchingEngine.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_MatchingEngine.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="_RegexParser.swiftmodule">
+      <Component Id="_RegexParser.swiftmodule" Guid="44e30ebc-57c0-4531-9756-7d30583f5c11">
+        <File Id="_RegexParser.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="_RegexParser.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="_RegexParser.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
@@ -368,7 +368,7 @@
       <ComponentRef Id="_Concurrency.swiftmodule" />
       <ComponentRef Id="_Differentiation.swiftmodule" />
       <ComponentRef Id="Distributed.swiftmodule" />
-      <ComponentRef Id="_MatchingEngine.swiftmodule" />
+      <ComponentRef Id="_RegexParser.swiftmodule" />
       <ComponentRef Id="_StringProcessing.swiftmodule" />
       <ComponentRef Id="CRT.swiftmodule" />
       <ComponentRef Id="Dispatch.swiftmodule" />

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -69,7 +69,7 @@
                               </Directory>
                               <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
                               </Directory>
-                              <Directory Id="_MatchingEngine.swiftmodule" Name="_MatchingEngine.swiftmodule">
+                              <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
                               </Directory>
                               <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
                               </Directory>
@@ -201,11 +201,11 @@
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="_MatchingEngine.swiftmodule">
-      <Component Id="_MatchingEngine.swiftmodule" Guid="db814242-ca96-481d-9b5f-f2590e8a0c5b">
-        <File Id="_MatchingEngine.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_MatchingEngine.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_MatchingEngine.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_MatchingEngine.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_MatchingEngine.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_MatchingEngine.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+    <DirectoryRef Id="_RegexParser.swiftmodule">
+      <Component Id="_RegexParser.swiftmodule" Guid="db814242-ca96-481d-9b5f-f2590e8a0c5b">
+        <File Id="_RegexParser.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="_RegexParser.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="_RegexParser.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
@@ -362,7 +362,7 @@
       <ComponentRef Id="_Concurrency.swiftmodule" />
       <ComponentRef Id="_Differentiation.swiftmodule" />
       <ComponentRef Id="Distributed.swiftmodule" />
-      <ComponentRef Id="_MatchingEngine.swiftmodule" />
+      <ComponentRef Id="_RegexParser.swiftmodule" />
       <ComponentRef Id="_StringProcessing.swiftmodule" />
       <ComponentRef Id="CRT.swiftmodule" />
       <ComponentRef Id="Dispatch.swiftmodule" />


### PR DESCRIPTION
This change was introduced in apple/swift#42081.