### PR TITLE
Update swift_installer.cc

### DIFF
--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
@@ -338,7 +338,7 @@ bool replace_file(const std::filesystem::path &source,
   }
 
   std::filesystem::path temp =
-      std::filesystem::path(source)
+      std::filesystem::path(destination)
           .replace_filename(std::wstring(reinterpret_cast<LPCWSTR>(id)));
 
   RpcStringFreeW(&id);


### PR DESCRIPTION
Correct the location of the temporary file creation.  We would previously overwrite the source rather than the destination.