### PR TITLE
5.7 updates

### DIFF
--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
@@ -348,7 +348,9 @@ bool replace_file(const std::filesystem::path &source,
 
   // Rename file.
   HANDLE hFile = CreateFileW(temp.wstring().c_str(),
-                             GENERIC_READ | GENERIC_WRITE | DELETE, 0, nullptr,
+                             GENERIC_READ | DELETE,
+                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                             nullptr,
                              OPEN_EXISTING,
                              FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_POSIX_SEMANTICS,
                              nullptr);
@@ -359,7 +361,7 @@ bool replace_file(const std::filesystem::path &source,
 
   windows::raii::handle handle(hFile);
 
-  std::wstring path = temp.wstring();
+  std::wstring path = destination.wstring();
   std::vector<char> buffer(sizeof(FILE_RENAME_INFO) - sizeof(wchar_t) +
                            (path.size() * sizeof(std::wstring::value_type)));
   FILE_RENAME_INFO &rename_info =

--- a/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
+++ b/platforms/Windows/CustomActions/SwiftInstaller/Sources/swift_installer.cc
@@ -338,7 +338,7 @@ bool replace_file(const std::filesystem::path &source,
   }
 
   std::filesystem::path temp =
-      std::filesystem::path(source)
+      std::filesystem::path(destination)
           .replace_filename(std::wstring(reinterpret_cast<LPCWSTR>(id)));
 
   RpcStringFreeW(&id);

--- a/platforms/Windows/devtools.wxs
+++ b/platforms/Windows/devtools.wxs
@@ -40,153 +40,221 @@
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="_usr_bin">
-      <!-- IndexStoreDB -->
-      <Component Id="IndexStoreDB" Guid="cde37e2e-9f9d-4fc5-927b-55b9145c84cd">
-        <File Id="IndexStoreDB.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.dll" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="IndexStoreDBDebugInfo" Guid="a0b6f544-c52a-4439-b646-474d43f8c7b4">
-        <File Id="IndexStoreDB.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-
-      <!-- SourceKit-LSP -->
-      <Component Id="SourceKitLSP" Guid="5ca5d02f-76f3-4537-9dfb-a3fdb6381ac4">
-        <File Id="sourcekit_lsp.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SourceKitLSPDebugInfo" Guid="b4967969-ce4b-4d63-b2fd-0d8fc896cb28">
-        <File Id="soucekit_lsp.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-
-      <!-- swift-crypto -->
-      <Component Id="SwiftCrypto" Guid="8f4fb997-7a41-4d37-a3d4-f5e006f5e3c4">
+    <ComponentGroup Id="SwiftCrypto">
+      <Component Id="Crypto.dll" Directory="_usr_bin" Guid="da28dfe3-2af0-45fb-b877-a5ef37da48cd">
         <File Id="Crypto.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SwiftCryptoDebugInfo" Guid="0966d4bf-d9a6-46ed-9be2-5b165fff3d45">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftCryptoDebugInfo">
+      <Component Id="Crypto.pdb" Directory="_usr_bin" Guid="e977250f-2ed1-4fd5-adb0-e4d7c0a9fbfd">
         <File Id="Crypto.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
       </Component>
-      <?endif?>
+    </ComponentGroup>
+    <?endif?>
 
-      <!-- swift-collections -->
-      <Component Id="SwiftCollections" Guid="f4634058-6477-4f8f-aa99-76a074056c2f">
+    <ComponentGroup Id="SwiftCollections">
+      <Component Id="Collections.dll" Directory="_usr_bin" Guid="fd0862f1-2e80-4040-8736-b73fc9c4230d">
         <File Id="Collections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
+      </Component>
+      <Component Id="DequeModule.dll" Directory="_usr_bin" Guid="c365ca88-b4d7-4257-bd91-47b50d18a02f">
         <File Id="DequeModule.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.dll" Checksum="yes" />
+      </Component>
+      <Component Id="OrderedCollections.dll" Directory="_usr_bin" Guid="626e8064-dc13-45b3-a7e0-dada2939b786">
         <File Id="OrderedCollections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.dll" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SwiftCollectionsDebugInfo" Guid="3c709129-5383-47c8-a86a-38d44a575095">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftCollectionsDebugInfo">
+      <Component Id="Collections.pdb" Directory="_usr_bin" Guid="be44261f-8aa1-484b-87a1-d2b1a697a2ca">
         <File Id="Collections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="DequeModule.pdb" Directory="_usr_bin" Guid="702354af-089c-4180-86a4-6b427305c1bb">
         <File Id="DequeModule.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="OrderedCollections.pdb" Directory="_usr_bin" Guid="e88ac571-94a9-43e0-b8ea-72c555a67023">
         <File Id="OrderedCollections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
       </Component>
-      <?endif?>
+    </ComponentGroup>
+    <?endif?>
 
-      <!-- swift-package-manager -->
-      <Component Id="SwiftPackageManager" Guid="1b6a0df3-9fd5-4262-8d90-55585f059d40">
+    <ComponentGroup Id="SwiftSystem">
+      <Component Id="SystemPackage.dll" Directory="_usr_bin" Guid="16215499-75a2-49b2-bb9c-18b72cc059ef">
+        <File Id="SystemPackage.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftSystemDebugInfo">
+      <Component Id="SystemPackage.pdb" Directory="_usr_bin" Guid="95301361-03eb-458b-a5d7-6f48ec148a28">
+        <File Id="SystemPackage.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftPackageManager">
+      <Component Id="Basics.dll" Directory="_usr_bin" Guid="b8032e5d-802d-4ce0-963a-c799873db876">
         <File Id="Basics.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Build.dll" Directory="_usr_bin" Guid="ca159fa2-d672-4e1d-ac16-44dc38ad6db2">
         <File Id="Build.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Commands.dll" Directory="_usr_bin" Guid="5648becc-7676-4f6e-a60e-6967f9b0ba4f">
         <File Id="Commands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageGraph.dll" Directory="_usr_bin" Guid="254500b8-b2ac-4c9f-add3-6511b0e5bfa7">
         <File Id="PackageGraph.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageLoading.dll" Directory="_usr_bin" Guid="cdbb8b34-7b84-48ed-8929-209a158f5d01">
         <File Id="PackageLoading.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageModel.dll" Directory="_usr_bin" Guid="1e8f566e-83f0-4657-9eed-598a96a957d9">
         <File Id="PackageModel.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" Checksum="yes" />
+      </Component>
+      <Component Id="SPMBuildCore.dll" Directory="_usr_bin" Guid="a4f1dc7d-8f1e-4d0d-8f71-974ddcb9e09a">
         <File Id="SPMBuildCore.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Workspace.dll" Directory="_usr_bin" Guid="b86661de-9783-416f-ab1b-cc4c658bca3b">
         <File Id="Workspace.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.dll" Checksum="yes" />
+      </Component>
 
+      <Component Id="swift_build.exe" Directory="_usr_bin" Guid="5b3f6590-545c-42e3-9081-8582eb37a822">
         <File Id="swift_build.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package.exe" Directory="_usr_bin" Guid="40cee004-aa80-4948-ae39-f6ad32da56eb">
         <File Id="swift_package.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_run.exe" Directory="_usr_bin" Guid="dd9432af-c962-46ff-9639-6da39fea14f3">
         <File Id="swift_run.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_test.exe" Directory="_usr_bin" Guid="b8e43529-83f1-4c75-8630-e0937ad5d50d">
         <File Id="swift_test.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.exe" Checksum="yes" />
       </Component>
 
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SwiftPackageManagerDebugInfo" Guid="642629c0-be0d-4a8f-8e8e-375f4c6c5451">
-        <File Id="Basics.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
-        <File Id="Build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
-        <File Id="Commands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
-        <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
-        <File Id="PackageLoading.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
-        <File Id="PackageModel.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
-        <File Id="SPMBuildCore.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
-        <File Id="Workspace.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
-
-        <File Id="swift_build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
-        <File Id="swift_package.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
-        <File Id="swift_run.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />
-        <File Id="swift_test.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-
-      <!-- swift-system -->
-      <Component Id="SwiftSystem" Guid="12bc7c44-ee92-4d7f-ad73-d33465707195">
-        <File Id="SystemPackage.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.dll" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SwiftSystemDebugInfo" Guid="91a89290-7436-4b6e-925a-3e1d43304f20">
-        <File Id="SystemPackage.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_lib_swift_pm_ManifestAPI">
-      <Component Id="SwiftPackageManagerManifestAPI" Guid="45a219f2-f92c-4644-99a0-33f55f35a43d">
+      <Component Id="PackageDescription.dll" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="6fc98caf-05c4-456c-b005-cb390a9389be">
         <File Id="PackageDescription.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageDescription.lib" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="dd357616-fcdf-4b80-b3e7-37d7ab3ced12">
         <File Id="PackageDescription.lib" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" Checksum="yes" />
+      </Component>
+      <Component Id="PackageDescription.swiftdoc" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="bc633eff-f7ae-4c79-ac0b-2cfabfa09fee">
         <File Id="PackageDescription.swiftdoc" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="PackageDescription.swiftmodule" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="279cd44c-7ed8-4ed4-befc-9ce020e55398">
         <File Id="PackageDescription.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" Checksum="yes" />
       </Component>
 
-      <?ifdef INCLUDE_DEBUG_INFO?>
-      <Component Id="SwiftPackageManagerManifestAPIDebugInfo" Guid="c49ea278-c632-44de-8337-360f4759ac6b">
-        <File Id="PackageDescription.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_lib_swift_pm_PluginAPI">
-      <Component Id="SwiftPackageManagerPluginAPI" Guid="34eba1ba-c801-4449-9d97-bdaded0fad5f">
+      <Component Id="PackagePlugin.dll" Directory="_usr_lib_swift_pm_PluginAPI" Guid="35bcc747-7923-420c-80c0-e95b6673b3b1">
         <File Id="PackagePlugin.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackagePlugin.lib" Directory="_usr_lib_swift_pm_PluginAPI" Guid="9b94e0c0-4ea1-4cbb-97e3-c668f43eb576">
         <File Id="PackagePlugin.lib" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.lib" Checksum="yes" />
+      </Component>
+      <Component Id="PackagePlugin.swiftdoc" Directory="_usr_lib_swift_pm_PluginAPI" Guid="4b5ea540-ed27-4c24-9fea-c9284a59af01">
         <File Id="PackagePlugin.swiftdoc" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="PackagePlugin.swiftmodule" Directory="_usr_lib_swift_pm_PluginAPI" Guid="89fddf67-8afc-4254-a57b-f74cbb2a958e">
         <File Id="PackagePlugin.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftmodule" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <?ifdef INCLUDE_DEBUG_INFO?>
-      <Component Id="SwiftPackageManagerPluginAPIDebugInfo" Guid="af21f0c7-88c8-4e44-b662-5ea8a5c84ae7">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftPackageManagerDebugInfo">
+      <Component Id="Basics.pdb" Directory="_usr_bin" Guid="7237e918-9b5b-4c2c-9330-bb8670624463">
+        <File Id="Basics.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="Build.pdb" Directory="_usr_bin" Guid="5da27caf-801f-430a-9b9a-e5efbf13708e">
+        <File Id="Build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="Commands.pdb" Directory="_usr_bin" Guid="949a08c5-ec4e-4d69-a18a-d8547a66c50a">
+        <File Id="Commands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="PackageGraph.pdb" Directory="_usr_bin" Guid="07b49917-5bdd-4491-a151-cb180a04aa90">
+        <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="PackageLoading.pdb" Directory="_usr_bin" Guid="94294eda-8c10-446c-a26f-c652bf6da155">
+        <File Id="PackageLoading.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="PackageModel.pdb" Directory="_usr_bin" Guid="3f849e3c-649f-426d-b088-d840600dbca2">
+        <File Id="PackageModel.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="SPMBuildCore.pdb" Directory="_usr_bin" Guid="aff3a3f5-2bc4-4fa1-b07d-f4e85bb54734">
+        <File Id="SPMBuildCore.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="Workspace.pdb" Directory="_usr_bin" Guid="a690ccb6-cc82-47f1-91c3-bed6994dc44b">
+        <File Id="Workspace.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_build.pdb" Directory="_usr_bin" Guid="bfea3c79-9656-4dee-8259-d041db3be1ba">
+        <File Id="swift_build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package.pdb" Directory="_usr_bin" Guid="0b9cf255-e141-43d3-af4b-e93984b57b4f">
+        <File Id="swift_package.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_run.pdb" Directory="_usr_bin" Guid="aedc7604-351a-4134-baaf-6364db8d53b3">
+        <File Id="swift_run.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_test.pdb" Directory="_usr_bin" Guid="afec8751-e99d-4e2b-b7e9-32e6c3e4507f">
+        <File Id="swift_test.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.pdb" Checksum="yes" />
+      </Component>
+
+      <Component Id="PackageDescription.pdb" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="01d006f5-431e-4f75-820d-98249c580893">
+        <File Id="PackageDescription.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
+      </Component>
+
+      <Component Id="PackagePlugin.pdb" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="7739a6e7-b8f7-4b99-bd7e-0fd13b717b94">
         <File Id="PackagePlugin.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\pluginAPI\PackagePlugin.pdb" Checksum="yes" />
       </Component>
-      <?endif?>
-    </DirectoryRef>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="IndexStoreDB">
+      <Component Id="IndexStoreDB.dll" Directory="_usr_bin" Guid="cc64657d-581f-4295-9834-5471d6cd8aaa">
+        <File Id="IndexStoreDB.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="IndexStoreDBDebugInfo">
+      <Component Id="IndexStoreDB.pdb" Directory="_usr_bin" Guid="5d0e18ba-c959-4c07-862d-e0bde9f7f79b">
+        <File Id="IndexStoreDB.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SourceKitLSP">
+      <Component Id="sourcekit_lsp.exe" Directory="_usr_bin" Guid="61d82a9e-2f72-415c-b6bb-9f43ec3f6bcd">
+        <File Id="sourcekit_lsp.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SourceKitLSPDebugInfo">
+      <Component Id="sourcekit_lsp.pdb" Directory="_usr_bin" Guid="e8a2c9bd-2988-43a4-9382-6d85b3d6e7b4">
+        <File Id="soucekit_lsp.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
 
     <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows x86_64" Level="1" Title="Swift Developer Tools (Windows x86_64)">
-      <ComponentRef Id="IndexStoreDB" />
-      <ComponentRef Id="SourceKitLSP" />
-      <ComponentRef Id="SwiftCrypto" />
-      <ComponentRef Id="SwiftCollections" />
-      <ComponentRef Id="SwiftPackageManager" />
-      <ComponentRef Id="SwiftSystem" />
-      <ComponentRef Id="SwiftPackageManagerManifestAPI" />
-      <ComponentRef Id="SwiftPackageManagerPluginAPI" />
+      <ComponentGroupRef Id="SwiftCrypto" />
+      <ComponentGroupRef Id="SwiftCollections" />
+      <ComponentGroupRef Id="SwiftSystem" />
+      <ComponentGroupRef Id="SwiftPackageManager" />
+      <ComponentGroupRef Id="SourceKitLSP" />
+      <ComponentGroupRef Id="IndexStoreDB" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows x86_64" Level="0" Title="Debug Info">
         <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-        <ComponentRef Id="IndexStoreDBDebugInfo" />
-        <ComponentRef Id="SourceKitLSPDebugInfo" />
-        <ComponentRef Id="SwiftCryptoDebugInfo" />
-        <ComponentRef Id="SwiftCollectionsDebugInfo" />
-        <ComponentRef Id="SwiftPackageManagerDebugInfo" />
-        <ComponentRef Id="SwiftSystemDebugInfo" />
-        <ComponentRef Id="SwiftPackageManagerManifestAPIDebugInfo" />
-        <ComponentRef Id="SwiftPackageManagerPluginAPIDebugInfo" />
+        <ComponentGroupRef Id="SwiftCryptoDebugInfo" />
+        <ComponentGroupRef Id="SwiftCollectionsDebugInfo" />
+        <ComponentGroupRef Id="SwiftSystemDebugInfo" />
+        <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />
+        <ComponentGroupRef Id="SourceKitLSPDebugInfo" />
+        <ComponentGroupRef Id="IndexStoreDBDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>

--- a/platforms/Windows/icu-amd64.wxs
+++ b/platforms/Windows/icu-amd64.wxs
@@ -25,20 +25,28 @@
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="_usr_bin">
-      <Component Id="ICURuntime" Guid="77a97eb2-4a5c-4d85-9fb7-692fd37d9b68">
+    <ComponentGroup Id="ICU" Directory="_usr_bin">
+      <Component Id="icudt.dll" Guid="0fcd685e-e7be-4f00-874e-160b1b0bc45b">
         <File Id="icudt.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icudt$(var.ProductVersionMajor).dll" Checksum="yes" />
+      </Component>
+      <Component Id="icuin.dll" Guid="d7c9b71a-df54-4c6d-9f8f-18273322f0dc">
         <File Id="icuin.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).dll" Checksum="yes" />
+      </Component>
+      <Component Id="icuuc.dll" Guid="d9abc6db-1cd1-4ab8-b762-1fde12b3a741">
         <File Id="icuuc.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).dll" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="ICUDebugInfo" Guid="c4643ea4-e585-466d-a5ad-078ee75cee8c">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="ICUDebugInfo" Directory="_usr_bin">
+      <Component Id="icuin.pdb" Guid="ba918d12-3c1a-49fc-b67a-e63577a772bb">
         <File Id="icuin.pdb" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="icuuc.pdb" Guid="c0a0d274-0dd2-4e2d-931e-bbedbbd57bf0">
         <File Id="icuuc.pdb" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).pdb" Checksum="yes" DiskId="2" />
       </Component>
-      <?endif ?>
-    </DirectoryRef>
+    </ComponentGroup>
+    <?endif ?>
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="EnvironmentVariables" Guid="97fe0a23-32e0-481d-8827-215f4c74f03c">
@@ -48,13 +56,13 @@
 
     <!-- Features -->
     <Feature Id="WinX64ICU" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift ICU for Windows x86_64" Level="1" Title="Swift ICU for Windows x86_64">
-      <ComponentRef Id="ICURuntime" />
+      <ComponentGroupRef Id="ICU" />
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift ICU for Windows x86_64" Level="0" Title="Debug Information">
         <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-        <ComponentRef Id="ICUDebugInfo" />
+        <ComponentGroupRef Id="ICUDebugInfo" />
       </Feature>
       <?endif ?>
     </Feature>

--- a/platforms/Windows/icu-x86.wxs
+++ b/platforms/Windows/icu-x86.wxs
@@ -25,20 +25,28 @@
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="_usr_bin">
-      <Component Id="ICURuntime" Guid="7256ab43-a1b5-4af2-8549-2d5f8edcac8b">
+    <ComponentGroup Id="ICU" Directory="_usr_bin">
+      <Component Id="icudt.dll" Guid="791a58ad-1317-4cfb-965b-03cd81fafd31">
         <File Id="icudt.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icudt$(var.ProductVersionMajor).dll" Checksum="yes" />
+      </Component>
+      <Component Id="icuin.dll" Guid="3f29a80a-4fe5-468a-b1c8-6a6e9196491f">
         <File Id="icuin.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).dll" Checksum="yes" />
+      </Component>
+      <Component Id="icuuc.dll" Guid="d433b3e3-63e2-4066-b66a-670eab04b38f">
         <File Id="icuuc.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).dll" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="ICUDebugInfo" Guid="56091ee6-dfbd-4b53-a579-eaea5f36767a">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="ICUDebugInfo" Directory="_usr_bin">
+      <Component Id="icuin.pdb" Guid="8f2872f3-ce5c-4e1d-880a-e516c8e4dc03">
         <File Id="icuin.pdb" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="icuuc.pdb" Guid="c4f7c8bd-8fda-4f3e-a8ee-52a9ff8d493d">
         <File Id="icuuc.pdb" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).pdb" Checksum="yes" DiskId="2" />
       </Component>
-      <?endif ?>
-    </DirectoryRef>
+    </ComponentGroup>
+    <?endif ?>
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="EnvironmentVariables" Guid="ef4b454a-efa5-44d2-a7ad-3e965539ec48">

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -26,57 +26,131 @@
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="_usr_bin">
-      <Component Id="SwiftRuntime" Guid="cd825076-16da-4530-84c8-810f3ae472a8">
+    <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">
+      <Component Id="BlocksRuntime.dll" Guid="bf2447f9-0ff5-48b6-864f-e738f9c51fb0">
         <File Id="BlocksRuntime.dll" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.dll" Guid="3167f6ca-0a20-445e-87eb-c65c2db4e17c">
         <File Id="dispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Foundation.dll" Guid="9f47536a-4fae-41c4-b20f-1ffacd3d46d0">
         <File Id="Foundation.dll" Source="$(var.SDK_ROOT)\usr\bin\Foundation.dll" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationNetworking.dll" Guid="f36f2cc6-0034-4ddd-924f-865523fdf4e2">
         <File Id="FoundationNetworking.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.dll" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationXML.dll" Guid="e5bc9e2b-3083-4b61-a553-59224bc1f6f3">
         <File Id="FoundationXML.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_Concurrency.dll" Guid="ce77eb06-eb96-4ea5-b9ce-c103f0b74063">
         <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_Differentiation.dll" Guid="cef7dda7-cbfc-478c-932b-211f9b9d12f0">
         <File Id="swift_Differentiation.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDistributed.dll" Guid="455f1af2-2c0a-40d4-b2a0-5a3479f6970f">
         <File Id="swiftDistributed.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_RegexParser.dll" Guid="bd2d3e51-1091-4a80-a9b5-5daae6c36881">
         <File Id="swift_RegexParser.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_StringProcessing.dll" Guid="198f58ad-8797-40ee-b109-dec6f9b57b27">
         <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftCore.dll" Guid="4098dff8-8b8d-48ee-a234-d29104d4c809">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDispatch.dll" Guid="312ffb9e-7ecf-423f-8f59-3041d2776e4a">
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
-        <!-- <File Id="swiftDemangle.dll" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" /> -->
+      </Component>
+      <!--
+      <Component Id="swiftDemangle.dll" Guid="baa8777d-cd9b-4da8-8a88-353b95602fbd">
+        <File Id="swiftDemangle.dll" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" />
+      </Component>
+      -->
+      <Component Id="swiftCRT.dll" Guid="6ef8eecb-780a-46a0-bddd-79b9a7bb8316">
         <File Id="swiftCRT.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftRemoteMirror.dll" Guid="2292dd48-e253-446d-9eb3-650d9264af77">
         <File Id="swiftRemoteMirror.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftSwiftOnoneSupport.dll" Guid="bb44ff8b-a243-4986-a11a-3800323994a9">
         <File Id="swiftSwiftOnoneSupport.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftWinSDK.dll" Guid="42cda8cb-fb2f-4967-8720-2d2c012b72a0">
         <File Id="swiftWinSDK.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.dll" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <Component Id="SwiftUtilities" Guid="a5126e94-79df-455c-83de-04e064ad586b">
+    <ComponentGroup Id="SwiftUtilities" Directory="_usr_bin">
+      <Component Id="plutil.exe" Guid="49b166e5-98e4-47dd-bfff-e73fd2e38b4c">
         <File Id="plutil.exe" Source="$(var.SDK_ROOT)\usr\bin\plutil.exe" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SwiftRuntimeDebugInfo" Guid="b61b71f4-8387-4be1-a756-1d06e796003c">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftRuntimeDebugInfo">
+      <Component Id="BlocksRuntime.pdb" Guid="230f07ae-6378-410e-8c21-6f6af65ab10c">
         <File Id="BlocksRuntime.pdb" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="dispatch.pdb" Guid="9540ccae-ca75-449d-bab0-1ba691a22615">
         <File Id="dispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="Foundation.pdb" Guid="4acf2787-e5df-45fa-a13f-d17eace5477e">
         <File Id="Foundation.pdb" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="FoundationNetworking.pdb" Guid="a099090f-2db2-4f06-aa87-afbc89926e2f">
         <File Id="FoundationNetworking.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="FoundationXML.pdb" Guid="97bc6b02-8ac0-4a28-a032-7ebe1dd0d496">
         <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_Concurrency.pdb" Guid="433dd15e-f72c-4294-9bf5-0be4771d1c10">
         <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_Differentiation.pdb" Guid="0f761b2c-f01c-4c46-b29a-9e319912089b">
         <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftDistributed.pdb" Guid="cac90c19-4f03-40e4-be41-f3f7d9484230">
         <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_RegexParser.pdb" Guid="1272f4c6-36a2-4323-abce-daab5a8e02d9">
         <File Id="swift_RegexParser.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_StringProcessing.pdb" Guid="d123c083-9dca-4814-875e-27458ae378d9">
         <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCore.pdb" Guid="57d56adc-dc40-4d6f-b0d7-11d472f11dbe">
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftDispatch.pdb" Guid="155ba810-d2a9-420e-890b-08dfb966daa6">
         <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
-        <!-- <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" /> -->
+      </Component>
+      <!--
+      <Component Id="swiftDemangle.pdb" Guid="37b6f780-2d6b-45b9-8c54-dc253af0a644">
+        <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      -->
+      <Component Id="swiftCRT.pdb" Guid="42ce883f-3187-46d3-b5db-3efed0b34858">
         <File Id="swiftCRT.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftRemoteMirror.pdb" Guid="b7c53b19-31f8-4f7e-bb72-226cdf46012a">
         <File Id="swiftRemoteMirror.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftSwiftOnoneSupport.pdb" Guid="65fcbe1b-f4a6-437e-8e58-6d4504ee789e">
         <File Id="swiftSwiftOnoneSupport.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftWinSDK.pdb" Guid="793e856f-5f54-48c8-af91-47262bf86b87">
         <File Id="swiftWinSDK.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
       </Component>
+    </ComponentGroup>
 
-      <Component Id="SwiftUtilitiesDebugInfo" Guid="b76da977-e914-46b7-98bc-7d8b033bf4ae">
+    <ComponentGroup Id="SwiftUtilitiesDebugInfo">
+      <Component Id="plutil.pdb" Guid="20169950-ef36-465e-a52c-cf071e1c0b44">
         <File Id="plutil.pdb" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
       </Component>
-      <?endif ?>
-    </DirectoryRef>
+    </ComponentGroup>
+    <?endif?>
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="EnvironmentVariables" Guid="f249625e-aacd-4b17-a464-8f8df05ba5f3">
@@ -86,19 +160,19 @@
 
     <!-- Feature -->
     <Feature Id="WinX64SwiftRuntime" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows x86_64" Level="1" Title="Swift Runtime for Windows x86_64">
-      <ComponentRef Id="SwiftRuntime" />
+      <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows x86_64" Level="0" Title="Debug Information">
         <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-        <ComponentRef Id="SwiftRuntimeDebugInfo" />
+        <ComponentGroupRef Id="SwiftRuntimeDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
     <Feature Id="WinX64SwiftUtilities" Absent="allow" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows x86_64" Level="1" Title="Swift Utilities for Windows x86_64">
-      <ComponentRef Id="SwiftUtilities" />
+      <ComponentGroupRef Id="SwiftUtilities" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows x86_64" Level="0" Title="Debug Information">

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -25,57 +25,131 @@
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="_usr_bin">
-      <Component Id="SwiftRuntime" Guid="3907413c-a51b-4972-9275-5dfca3eb9e1d">
+    <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">
+      <Component Id="BlocksRuntime.dll" Guid="06162783-5e61-42ec-af15-3f8b09e8562a">
         <File Id="BlocksRuntime.dll" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.dll" Guid="204e99a2-1404-4523-b13a-d471650f3d10">
         <File Id="dispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Foundation.dll" Guid="aef0c5c5-c381-4c5a-8ac9-ccd2fba70265">
         <File Id="Foundation.dll" Source="$(var.SDK_ROOT)\usr\bin\Foundation.dll" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationNetworking.dll" Guid="4d31dc16-130d-499c-b861-c9147e20069c">
         <File Id="FoundationNetworking.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.dll" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationXML.dll" Guid="154951da-1a4a-4034-b318-51aa3069a512">
         <File Id="FoundationXML.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_Concurrency.dll" Guid="08d4e353-00af-4db0-9c55-2ea50eeddeb7">
         <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_Differentiation.dll" Guid="cf6be869-0b63-4b81-9bc6-5b7cad7ee629">
         <File Id="swift_Differentiation.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDistributed.dll" Guid="4c730ba2-47fc-4d96-ad87-e16646a3f310">
         <File Id="swiftDistributed.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_RegexParser.dll" Guid="cfb0432b-01c4-4ef4-9e8a-b90236f20606">
         <File Id="swift_RegexParser.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_StringProcessing.dll" Guid="e6070d4e-9e60-46cb-94a4-ec499c354099">
         <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftCore.dll" Guid="d816134d-2de1-4e50-90dd-a36675c09c3e">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDispatch.dll" Guid="fd38df32-2bcd-4da4-98b3-f26abd1ac6de">
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
-        <!-- <File Id="swiftDemangle.dll" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" /> -->
+      </Component>
+      <!--
+      <Component Id="swiftDemangle.dll" Guid="3a9cc33f-df6f-4700-8e82-d908e4e1093d">
+        <File Id="swiftDemangle.dll" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" />
+      </Component>
+      -->
+      <Component Id="swiftCRT.dll" Guid="c457345e-7d64-4fdb-9c84-0dc5586aa1c5">
         <File Id="swiftCRT.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftRemoteMirror.dll" Guid="a7b35013-cff3-4199-a26a-4d222f6dcc49">
         <File Id="swiftRemoteMirror.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftSwiftOnoneSupport.dll" Guid="3d438ca5-a22f-4870-9db9-7ac783550029">
         <File Id="swiftSwiftOnoneSupport.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftWinSDK.dll" Guid="a1f69b1c-a649-46dd-849b-03373a0911c7">
         <File Id="swiftWinSDK.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.dll" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <Component Id="SwiftUtilities" Guid="a704701d-95e2-458b-aab1-f4678eaf34ba">
+    <ComponentGroup Id="SwiftUtilities" Directory="_usr_bin">
+      <Component Id="plutil.exe" Guid="0f4a9a59-b623-4cd3-a1f5-e7f05a81744f">
         <File Id="plutil.exe" Source="$(var.SDK_ROOT)\usr\bin\plutil.exe" Checksum="yes" />
       </Component>
+    </ComponentGroup>
 
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SwiftRuntimeDebugInfo" Guid="e70e5fea-c76a-4d0c-8a1c-5beb350a37eb">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftRuntimeDebugInfo">
+      <Component Id="BlocksRuntime.pdb" Guid="ae1e5c85-3672-4114-9e82-f8152ed8e919">
         <File Id="BlocksRuntime.pdb" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="dispatch.pdb" Guid="1f2385b7-e4d4-464c-b987-5139949499c2">
         <File Id="dispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="Foundation.pdb" Guid="2fa5fdb1-e875-46e3-aa18-5aac03ee6f63">
         <File Id="Foundation.pdb" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="FoundationNetworking.pdb" Guid="0636b89e-a623-4ef5-adf7-56ab5250987b">
         <File Id="FoundationNetworking.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="FoundationXML.pdb" Guid="e9e6eb2e-9423-4e6d-8b91-751e174624a4">
         <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_Concurrency.pdb" Guid="4c11a732-031a-4c07-81ba-49407a0870f5">
         <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_Differentiation.pdb" Guid="e4eb5456-7142-4be4-a1ca-1328f76ed875">
         <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftDistributed.pdb" Guid="e6f9a9a6-1ba2-4807-b35a-7726ac30b91e">
         <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_RegexParser.pdb" Guid="c69fd450-0fbf-4b30-baf0-f5107c65cf28">
         <File Id="swift_RegexParser.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_StringProcessing.pdb" Guid="e1d856db-107e-452b-95ba-d8b0c4bc4cbf">
         <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCore.pdb" Guid="abd0c880-8dcc-4c23-88d4-afb224d3433b">
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftDispatch.pdb" Guid="cff0a63a-a76a-4785-92b0-4894ffa19a7d">
         <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
-        <!-- <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" /> -->
+      </Component>
+      <!--
+      <Component Id="swiftDemangle.pdb" Guid="0dd0b3b5-3d85-48aa-a7c7-ca804c685a99">
+        <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      -->
+      <Component Id="swiftCRT.pdb" Guid="0f4fbbfa-e85e-4c18-93a0-37ab09b80bf7">
         <File Id="swiftCRT.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftRemoteMirror.pdb" Guid="2bcc963d-e2d7-44f1-a7aa-0524bec668c6">
         <File Id="swiftRemoteMirror.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftSwiftOnoneSupport.pdb" Guid="a013f1d6-3e2a-4e0a-b315-e40b87967d1b">
         <File Id="swiftSwiftOnoneSupport.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftWinSDK.pdb" Guid="c8924901-6ed0-4629-a940-0eeaeeb5039e">
         <File Id="swiftWinSDK.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
       </Component>
+    </ComponentGroup>
 
-      <Component Id="SwiftUtilitiesDebugInfo" Guid="f7c6aeb8-5345-498d-8f4a-509536ec8e6c">
+    <ComponentGroup Id="SwiftUtilitiesDebugInfo">
+      <Component Id="plutil.pdb" Guid="76275d27-3e4f-40f5-9810-a4fbe1d16e5e">
         <File Id="plutil.pdb" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
       </Component>
-      <?endif ?>
-    </DirectoryRef>
+    </ComponentGroup>
+    <?endif?>
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="EnvironmentVariables" Guid="3b4386ac-3341-407d-b946-6e670f4a83f6">

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -110,240 +110,345 @@
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="XCTest_usr_bin64">
-      <Component Id="XCTestRuntime" Guid="3d49884d-1ff2-4f2f-bdb1-5dacba74e256">
+    <ComponentGroup Id="XCTest">
+      <Component Id="XCTest.dll" Directory="XCTest_usr_bin64" Guid="11b12995-a7e6-4de3-954d-d4ddc977633f">
         <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
       </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="XCTestRuntimeDebugInfo" Guid="a967ad27-bf6b-496b-9529-435f8a85ad21">
-        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <?endif?>
-    </DirectoryRef>
-
-    <DirectoryRef Id="XCTest_usr_lib_swift_windows_x86_64">
-      <Component Id="XCTestLibraries" Guid="3602ef83-8da8-47d3-b3ec-942e916c420b">
+      <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_x86_64" Guid="3debc3cd-3f48-4cd7-8e9a-7403b1d45b37">
         <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
       </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="XCTest.swiftmodule">
-      <Component Id="XCTestSwiftModule" Guid="a52d9a17-c0e2-47f1-be01-4d47692423e3">
+      <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="12731d72-ef57-4c29-a05e-a44534b331c2">
         <File Id="XCTest.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="XCTest.swiftmodule" Directory="XCTest.swiftmodule" Guid="62ecaad6-4f0f-4009-8b0c-cd5128e3615d">
         <File Id="XCTest.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftmodule" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
-    <DirectoryRef Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror">
-      <Component Id="SwiftRemoteMirrorHeaders" Guid="1653308a-60bc-4771-9635-8b3e67ba46c5">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="XCTestDebugInfo">
+      <Component Id="XCTest.pdb" Directory="XCTest_usr_bin64" Guid="6ad780c3-7245-4b63-b0b0-ba04e65f1638">
+        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftRemoteMirror">
+      <Component Id="MemoryReaderInterface.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="4493ba7f-b3b3-4cb3-b645-6457e81ad752">
         <File Id="MemoryReaderInterface.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\MemoryReaderInterface.h" Checksum="yes" />
+      </Component>
+      <Component Id="Platform.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="61384dc6-be9c-42cd-847b-fb94617fcab1">
         <File Id="Platform.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\Platform.h" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftRemoteMirror.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="bcc781b4-94ea-4ae6-aa1e-e26e62f04e10">
         <File Id="SwiftRemoteMirror.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirror.h" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftRemoteMirrorTypes.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="c15a0af1-e521-4ffc-845b-4f7176db4e2c">
         <File Id="SwiftRemoteMirrorTypes.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" Checksum="yes" />
       </Component>
-    </DirectoryRef>
 
-    <DirectoryRef Id="WindowsSDK_usr_include_Block">
-      <Component Id="BlocksRuntimeHeaders" Guid="56ef7e66-3a7b-41a3-967c-1c9247183bb6">
-        <File Id="BlocksRuntime_Block.h" Source="$(var.SDK_ROOT)\usr\lib\swift\Block\Block.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WindowsSDK_usr_include_dispatch">
-      <Component Id="DispatchHeaders" Guid="7d683f4f-7a40-4ef9-821f-12ca867edb7b">
-        <File Id="base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\base.h" Checksum="yes" />
-        <File Id="dispatch_block.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\block.h" Checksum="yes" />
-        <File Id="data.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\data.h" Checksum="yes" />
-        <File Id="dispatch.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" Checksum="yes" />
-        <File Id="group.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\group.h" Checksum="yes" />
-        <File Id="introspection.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" Checksum="yes" />
-        <File Id="io.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\io.h" Checksum="yes" />
-        <File Id="dispatch.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" Checksum="yes" />
-        <File Id="dispatch_object.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\object.h" Checksum="yes" />
-        <File Id="once.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\once.h" Checksum="yes" />
-        <File Id="queue.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\queue.h" Checksum="yes" />
-        <File Id="semaphore.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" Checksum="yes" />
-        <File Id="source.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\source.h" Checksum="yes" />
-        <File Id="time.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\time.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WindowsSDK_usr_include_os">
-      <Component Id="DispatchOSHeaders" Guid="0caaa892-0d73-44eb-af99-e42ba5a0f928">
-        <File Id="generic_unix_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_unix_base.h" Checksum="yes" />
-        <File Id="generic_win_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_win_base.h" Checksum="yes" />
-        <File Id="os_object.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\object.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_Concurrency.swiftmodule">
-      <Component Id="_Concurrency.swiftmodule" Guid="c9ff4b16-0ca1-4be9-8d53-fff74bac18ca">
-        <File Id="_Concurrency.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_Concurrency.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_Concurrency.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_Differentiation.swiftmodule">
-      <Component Id="_Differentiation.swiftmodule" Guid="e033eda9-3d7b-4cc6-9493-bd5ee2993235">
-        <File Id="_Differentiation.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_Differentiation.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_Differentiation.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="Distributed.swiftmodule">
-      <Component Id="Distributed.swiftmodule" Guid="63ea424f-ae9f-4e47-b5d4-cdd04ebc5fdd">
-        <File Id="Distributed.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="Distributed.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="Distributed.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_RegexParser.swiftmodule">
-      <Component Id="_RegexParser.swiftmodule" Guid="44e30ebc-57c0-4531-9756-7d30583f5c11">
-        <File Id="_RegexParser.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_RegexParser.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_RegexParser.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_StringProcessing.swiftmodule">
-      <Component Id="_StringProcessing.swiftmodule" Guid="6baa3833-10a9-4df3-a568-241791d13449">
-        <File Id="_StringProcessing.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_StringProcessing.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_StringProcessing.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="CRT.swiftmodule">
-      <Component Id="CRT.swiftmodule" Guid="fef33579-241c-44a6-b772-cfdc5721fcc7">
-        <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="CRT.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="CRT.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="dispatch.swiftmodule">
-      <Component Id="Dispatch.swiftmodule" Guid="0bb44335-c778-4e57-b072-6370b6b71d23">
-        <File Id="Dispatch.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftdoc" Checksum="yes" />
-        <File Id="Dispatch.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="Foundation.swiftmodule">
-      <Component Id="Foundation.swiftmodule" Guid="08d334bb-9dd3-478a-907e-c515e0d87c0d">
-        <File Id="Foundation.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftdoc" Checksum="yes" />
-        <File Id="Foundation.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="FoundationNetworking.swiftmodule">
-      <Component Id="FoundationNetworking.swiftmodule" Guid="8037da71-8bd2-479c-a1b2-421df3423284">
-        <File Id="FoundationNetworking.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftdoc" Checksum="yes" />
-        <File Id="FoundationNetworking.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="FoundationXML.swiftmodule">
-      <Component Id="FoundationXML.swiftmodule" Guid="7e405291-54db-4a8f-bcc7-d016aa2418d6">
-        <File Id="FoundationXML.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftdoc" Checksum="yes" />
-        <File Id="FoundationXML.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="Swift.swiftmodule">
-      <Component Id="Swift.swiftmodule" Guid="a0676bb0-ae06-402d-b442-ad6eabede927">
-        <File Id="Swift.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="Swift.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="Swift.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="SwiftOnoneSupport.swiftmodule">
-      <Component Id="SwiftOnoneSupport.swiftmodule" Guid="c4950dc9-b0d2-48c9-8f8d-426e6d3c6c78">
-        <File Id="SwiftOnoneSupport.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="SwiftOnoneSupport.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="SwiftOnoneSupport.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WinSDK.swiftmodule">
-      <Component Id="WinSDK.swiftmodule" Guid="9fb3ebfa-da7d-4fb8-a3ec-ebc0aa6b7814">
-        <File Id="WinSDK.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="WinSDK.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="WinSDK.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WindowsSDK_usr_lib_swift_windows_x86_64">
-      <Component Id="Registrar" Guid="7c968f4a-c039-4605-8a96-2670284e1993">
-        <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftrt.obj" Checksum="yes" />
-      </Component>
-
-      <Component Id="_ConcurrencyLibraries" Guid="6188de52-0a9b-4a62-bfde-f115a6b76cf7">
-        <File Id="swift_Concurrency.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Concurrency.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="_DifferentiationLibraries" Guid="a240db64-c797-4e43-9c52-ec5e16a36bf9">
-        <File Id="swift_Differentiation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Differentiation.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="_DistributedLibraries" Guid="c3d65ddc-89e9-4ff9-bf1f-ef91bc0b1009">
-        <File Id="swiftDistributed.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftDistributed.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="BlocksRuntimeLibraries" Guid="c521f7e9-179a-49ed-a643-035d8a96be56">
-        <File Id="BlocksRuntime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="DispatchLibraries" Guid="6bd9a2cd-9ba8-499d-884b-22aa5156b5bc">
-        <File Id="dispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
-        <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="FoundationLibraries" Guid="44c3e8a3-3cf4-485a-a01f-52bbad5cbe20">
-        <File Id="Foundation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
-        <File Id="FoundationNetworking.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
-        <File Id="FoundationXML.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SwiftLibraries" Guid="a9288d7e-c197-4cab-938f-5926be290a71">
-        <File Id="swiftCore.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCore.lib" Checksum="yes" />
-        <File Id="swiftSwiftOnoneSupport.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftSwiftOnoneSupport.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SwiftSDKOverlayLibraries" Guid="03f5b5bc-ab5a-4287-818e-c164dcfbef1a">
-        <File Id="swiftCRT.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCRT.lib" Checksum="yes" />
-        <File Id="swiftWinSDK.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftWinSDK.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SwiftRemoteMirrorLibraries" Guid="36e05640-2023-47fa-a81c-ad3f15eae659">
+      <Component Id="swiftRemoteMirror.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="36e05640-2023-47fa-a81c-ad3f15eae659">
         <File Id="swiftRemoteMirror.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
-    <DirectoryRef Id="WindowsSDK_usr_share">
-      <Component Id="SupportFiles" Guid="2be1e214-512b-4895-9aef-93c8e263a698">
+    <ComponentGroup Id="BlocksRuntime">
+      <Component Id="Block.h" Directory="WindowsSDK_usr_include_Block" Guid="46ea8477-b407-41ac-a3ea-d6db791524d9">
+        <File Id="Block.h_46ea8477b40741aca3ead6db791524d9" Source="$(var.SDK_ROOT)\usr\lib\swift\Block\Block.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="BlocksRuntime.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="57b69603-8619-4af4-9056-babbaa76e633">
+        <File Id="BlocksRuntime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="dispatch">
+      <Component Id="base.h" Directory="WindowsSDK_usr_include_dispatch" Guid="a263a074-5bc5-4823-95a9-f91a314b6cf0">
+        <File Id="base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\base.h" Checksum="yes" />
+      </Component>
+      <Component Id="block.h" Directory="WindowsSDK_usr_include_dispatch" Guid="3629b098-826c-4d98-89a7-b486160dddfa">
+        <File Id="block.h_3629b098826c4d9889a7b486160dddfa" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\block.h" Checksum="yes" />
+      </Component>
+      <Component Id="data.h" Directory="WindowsSDK_usr_include_dispatch" Guid="1d9bb083-bb0e-46de-b82b-b582c55df716">
+        <File Id="data.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\data.h" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.h" Directory="WindowsSDK_usr_include_dispatch" Guid="a4e8a91e-b54b-485e-8f47-83e23bb435b3">
+        <File Id="dispatch.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" Checksum="yes" />
+      </Component>
+      <Component Id="group.h" Directory="WindowsSDK_usr_include_dispatch" Guid="6a992ce8-127a-4826-87fc-009e3666c980">
+        <File Id="group.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\group.h" Checksum="yes" />
+      </Component>
+      <Component Id="introspection.h" Directory="WindowsSDK_usr_include_dispatch" Guid="1177a222-a855-495e-bb4c-40b58bf2a72f">
+        <File Id="introspection.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" Checksum="yes" />
+      </Component>
+      <Component Id="io.h" Directory="WindowsSDK_usr_include_dispatch" Guid="4cbd900b-ea17-42d0-ad01-555e64203e34">
+        <File Id="io.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\io.h" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.modulemap" Directory="WindowsSDK_usr_include_dispatch" Guid="29d12456-9a40-47a8-9f0c-328e27ea9921">
+        <File Id="dispatch.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="object.h_f87c5a369294493489839a2cabdb7ae7" Directory="WindowsSDK_usr_include_dispatch" Guid="f87c5a36-9294-4934-8983-9a2cabdb7ae7">
+        <File Id="object.h_f87c5a369294493489839a2cabdb7ae7" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\object.h" Checksum="yes" />
+      </Component>
+      <Component Id="once.h" Directory="WindowsSDK_usr_include_dispatch" Guid="24c2b93d-8912-4cc7-a23d-11df4afa6c10">
+        <File Id="once.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\once.h" Checksum="yes" />
+      </Component>
+      <Component Id="queue.h" Directory="WindowsSDK_usr_include_dispatch" Guid="db4bb4ee-6a95-4692-9793-af888ac633e2">
+        <File Id="queue.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\queue.h" Checksum="yes" />
+      </Component>
+      <Component Id="semaphore.h" Directory="WindowsSDK_usr_include_dispatch" Guid="99b07079-67e8-418c-a4a1-647b28e2bfd0">
+        <File Id="semaphore.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" Checksum="yes" />
+      </Component>
+      <Component Id="source.h" Directory="WindowsSDK_usr_include_dispatch" Guid="740ec071-b663-461f-8408-83f65a804d7e">
+        <File Id="source.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\source.h" Checksum="yes" />
+      </Component>
+      <Component Id="time.h" Directory="WindowsSDK_usr_include_dispatch" Guid="4f234266-768c-4e42-80fd-829cd6d62c91">
+        <File Id="time.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\time.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="generic_unix_base.h" Directory="WindowsSDK_usr_include_os" Guid="66347322-84a9-4246-9d69-17b2e03dea63">
+        <File Id="generic_unix_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_unix_base.h" Checksum="yes" />
+      </Component>
+      <Component Id="generic_win_base.h" Directory="WindowsSDK_usr_include_os" Guid="1b418910-d049-4040-a1a0-47844b90cc10">
+        <File Id="generic_win_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_win_base.h" Checksum="yes" />
+      </Component>
+      <Component Id="object.h_3af0f0745780408e9fb16b614066623f" Directory="WindowsSDK_usr_include_os" Guid="3af0f074-5780-408e-9fb1-6b614066623f">
+        <File Id="object.h_3af0f0745780408e9fb16b614066623f" Source="$(var.SDK_ROOT)\usr\lib\swift\os\object.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="dispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="ff370cd8-58c1-476d-9964-b3b41ff69b34">
+        <File Id="dispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="Dispatch.swiftdoc" Directory="dispatch.swiftmodule" Guid="ef314d01-4432-43c4-9b11-5725db379551">
+        <File Id="Dispatch.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Dispatch.swiftmodule" Directory="dispatch.swiftmodule" Guid="e9b23638-1dd2-4c95-b053-f97c451625d5">
+        <File Id="Dispatch.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="b3e67468-2c5d-40cd-b332-7b21a0df301f">
+        <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Concurrency">
+      <Component Id="_Concurrency.swiftdoc" Directory="_Concurrency.swiftmodule" Guid="037314fe-f333-4ce4-b3bc-28947337032c">
+        <File Id="_Concurrency.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_Concurrency.swiftinterface" Directory="_Concurrency.swiftmodule" Guid="43c29738-0629-4cb2-b7b5-be61f603cd6a">
+        <File Id="_Concurrency.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_Concurrency.swiftmodule" Directory="_Concurrency.swiftmodule" Guid="623c170b-2515-4a37-93fc-466cfc1de71c">
+        <File Id="_Concurrency.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_Concurrency.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="ed01d594-ebfc-43a8-8bb5-59207ef9f25d">
+        <File Id="swift_Concurrency.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Concurrency.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Differentiation">
+      <Component Id="_Differentiation.swiftdoc" Directory="_Differentiation.swiftmodule" Guid="a5781b17-c798-4bc5-b52b-2afbb669b39a">
+        <File Id="_Differentiation.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_Differentiation.swiftinterface" Directory="_Differentiation.swiftmodule" Guid="7cc38d95-db0e-4ee5-9e8c-1980ccf17b3a">
+        <File Id="_Differentiation.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_Differentiation.swiftmodule" Directory="_Differentiation.swiftmodule" Guid="81f2ea19-4988-4cbf-9b80-5743660dc542">
+        <File Id="_Differentiation.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_Differentiation.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="d805a096-2e63-4f0a-9ca0-c1e121428914">
+        <File Id="swift_Differentiation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Differentiation.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Distributed">
+      <Component Id="Distributed.swiftdoc" Directory="Distributed.swiftmodule" Guid="73093dfc-8d44-4530-999d-c0d456ebfe05">
+        <File Id="Distributed.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Distributed.swiftinterface" Directory="Distributed.swiftmodule" Guid="4da938da-e741-49a2-8013-aa0d3e63b96c">
+        <File Id="Distributed.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Distributed.swiftmodule" Directory="Distributed.swiftmodule" Guid="41a27397-861b-432b-bf5e-7cb80cc5df3d">
+        <File Id="Distributed.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDistributed.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="71f8c1a0-c7c6-4846-bd2a-7e5004b66025">
+        <File Id="swiftDistributed.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftDistributed.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_RegexParser">
+      <Component Id="_RegexParser.swiftdoc" Directory="_RegexParser.swiftmodule" Guid="865561ee-9a35-4719-a1af-4a80ff047c24">
+        <File Id="_RegexParser.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_RegexParser.swiftinterface" Directory="_RegexParser.swiftmodule" Guid="f68bfb2b-9bda-484e-ab84-673372fcff1f">
+        <File Id="_RegexParser.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_RegexParser.swiftmodule" Directory="_RegexParser.swiftmodule" Guid="0bca67d0-a8b4-4c6e-ae8f-b3024acdb140">
+        <File Id="_RegexParser.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_RegexParser.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="3474a027-0314-42d1-b599-685d38a0f3b4">
+        <File Id="swift_RegexParser.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_RegexParser.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_StringProcessing">
+      <Component Id="_StringProcessing.swiftdoc" Directory="_StringProcessing.swiftmodule" Guid="e11d39c3-8e94-4e8c-8ce6-8ccdc0dc68bf">
+        <File Id="_StringProcessing.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_StringProcessing.swiftinterface" Directory="_StringProcessing.swiftmodule" Guid="b96be564-104d-4dc5-85df-b6100f83f386">
+        <File Id="_StringProcessing.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_StringProcessing.swiftmodule" Directory="_StringProcessing.swiftmodule" Guid="8beb4a8c-212e-4932-bdfa-2e33841806bc">
+        <File Id="_StringProcessing.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_StringProcessing.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="f1f57f0b-9856-4371-a346-b02099094179">
+        <File Id="swift_StringProcessing.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_StringProcessing.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="CRT">
+      <Component Id="CRT.swiftdoc" Directory="CRT.swiftmodule" Guid="c38cbe87-7578-45e5-a3c7-3f235bd9c1a5">
+        <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="CRT.swiftinterface" Directory="CRT.swiftmodule" Guid="cb11ce9c-1fe4-4bfa-a8e4-4faf193e86a2">
+        <File Id="CRT.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="CRT.swiftmodule" Directory="CRT.swiftmodule" Guid="64e4fb99-e5ef-418f-ab76-eeac26d91c55">
+        <File Id="CRT.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCRT.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="9914dbcc-d0a6-4bf5-ab13-e00cda0210ab">
+        <File Id="swiftCRT.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCRT.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Foundation">
+      <Component Id="Foundation.swiftdoc" Directory="Foundation.swiftmodule" Guid="d5ace934-794c-416f-886e-b9ae39eb8208">
+        <File Id="Foundation.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Foundation.swiftmodule" Directory="Foundation.swiftmodule" Guid="059df0fa-17ec-407f-b325-247e3a329235">
+        <File Id="Foundation.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="Foundation.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="e97a352d-56d9-40b9-9851-afc7f912c017">
+        <File Id="Foundation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="FoundationNetworking">
+      <Component Id="FoundationNetworking.swiftdoc" Directory="FoundationNetworking.swiftmodule" Guid="f545c9fa-5846-487d-befc-34c94fe62ef0">
+        <File Id="FoundationNetworking.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationNetworking.swiftmodule" Directory="FoundationNetworking.swiftmodule" Guid="f3f5ea84-8277-4c12-b273-79c866a3bf57">
+        <File Id="FoundationNetworking.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="FoundationNetworking.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="d9060dd4-3f73-4398-8985-7f51d5f2e838">
+        <File Id="FoundationNetworking.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="FoundationXML">
+      <Component Id="FoundationXML.swiftdoc" Directory="FoundationXML.swiftmodule" Guid="9586f066-c134-4c4b-af93-b26892234274">
+        <File Id="FoundationXML.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationXML.swiftmodule" Directory="FoundationXML.swiftmodule" Guid="fbe5a3ff-d206-4af1-bed4-f314b397fefe">
+        <File Id="FoundationXML.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="FoundationXML.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="1f4549d9-49b8-4b8d-92f6-eab44c5dc2db">
+        <File Id="FoundationXML.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Swift">
+      <Component Id="Swift.swiftdoc" Directory="Swift.swiftmodule" Guid="8be56a7d-a239-4b4f-a6ff-91798da32f5a">
+        <File Id="Swift.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Swift.swiftinterface" Directory="Swift.swiftmodule" Guid="8a648338-518f-48e3-84c2-82e4caa8f8cf">
+        <File Id="Swift.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Swift.swiftmodule" Directory="Swift.swiftmodule" Guid="1ddfa091-0221-483c-90b8-4a805d9a63ea">
+        <File Id="Swift.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCore.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="a411246a-7f6c-4309-8546-c067f4d0ec8b">
+        <File Id="swiftCore.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCore.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="SwiftOnoneSupport">
+      <Component Id="SwiftOnoneSupport.swiftdoc" Directory="SwiftOnoneSupport.swiftmodule" Guid="3e824882-1b31-4d24-9357-c781ce222ff4">
+        <File Id="SwiftOnoneSupport.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftOnoneSupport.swiftinterface" Directory="SwiftOnoneSupport.swiftmodule" Guid="3fb52679-e9de-452b-a313-055760eefd6c">
+        <File Id="SwiftOnoneSupport.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftOnoneSupport.swiftmodule" Directory="SwiftOnoneSupport.swiftmodule" Guid="7dced608-bf33-4cf9-8141-385508ed8c97">
+        <File Id="SwiftOnoneSupport.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftSwiftOnoneSupport.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="0b76dc44-edc9-46aa-bd03-719b33df63f0">
+        <File Id="swiftSwiftOnoneSupport.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftSwiftOnoneSupport.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="WinSDK">
+      <Component Id="WinSDK.swiftdoc" Directory="WinSDK.swiftmodule" Guid="2bbd543c-9b6e-44ed-b17a-285edd2e9730">
+        <File Id="WinSDK.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="WinSDK.swiftinterface" Directory="WinSDK.swiftmodule" Guid="803b0ed4-80ae-4762-8090-cc23ffa4d3fc">
+        <File Id="WinSDK.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="WinSDK.swiftmodule" Directory="WinSDK.swiftmodule" Guid="f3f0780d-bcfb-4ea8-8bff-e80d05fe0861">
+        <File Id="WinSDK.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftWinSDK.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="a117b49f-b373-4ae4-a43e-ea71f7a6be3d">
+        <File Id="swiftWinSDK.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftWinSDK.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_x86_64">
+      <Component Id="swiftrt.obj" Guid="e546282a-79c8-4555-a45a-68a1447fa5d8">
+        <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftrt.obj" Checksum="yes" />
+      </Component>
+      <!--
+      <Component Id="swiftrtd.obj" Guid="13624873-29b3-41f1-adff-c18d27950980">
+        <File Id="swiftrtd.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftrtd.obj" Checksum="yes" />
+      </Component>
+      -->
+    </ComponentGroup>
+
+    <ComponentGroup Id="SupportFiles" Directory="WindowsSDK_usr_share">
+      <Component Id="ucrt.modulemap" Guid="4b5c1a1d-a6cf-4d06-81f7-e752f0a3f4db">
         <File Id="ucrt.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\ucrt.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="winsdk.modulemap" Guid="a3b7cb7c-730e-4c6b-ada8-d39f4c72f41e">
         <File Id="winsdk.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\winsdk.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="visualc.modulemap" Guid="cd59b968-d431-44a0-870b-16c9fbfde01d">
         <File Id="visualc.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="visualc.apinotes" Guid="11318e14-7d68-490e-8c64-f1332f1d63f7">
         <File Id="visualc.apinotes" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.apinotes" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
-    <DirectoryRef Id="WindowsPlatform">
-      <Component Id="Info.plist" Guid="03130625-9732-4c44-ae81-eddfd97cbe6c">
+    <ComponentGroup Id="Configuration">
+      <Component Id="Info.plist" Directory="WindowsPlatform" Guid="6cc713d1-2f44-4a47-8e1e-7f71e1dce68b">
         <File Id="Info.plist" Source="$(var.PLATFORM_ROOT)\Info.plist" Checksum="yes" />
       </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WindowsSDK">
-      <Component Id="SDKSettings.plist" Guid="1562926d-6c1d-4cc1-9ab2-42effae919d2">
+      <Component Id="SDKSettings.plist" Directory="WindowsSDK" Guid="5e7d06bc-cad8-4c8b-803b-686adfbcb220">
         <File Id="SDKSettings.plist" Source="$(var.SDK_ROOT)\SDKSettings.plist" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="EnvironmentVariables" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
@@ -354,49 +459,28 @@
 
     <!-- Features -->
     <Feature Id="WinX64SDK" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows x86_64" Level="1" Title="Swift SDK for Windows x86_64">
-      <ComponentRef Id="XCTestRuntime" />
-      <ComponentRef Id="XCTestLibraries" />
-      <ComponentRef Id="XCTestSwiftModule" />
-
-      <ComponentRef Id="BlocksRuntimeHeaders" />
-      <ComponentRef Id="BlocksRuntimeLibraries" />
-
-      <ComponentRef Id="DispatchHeaders" />
-      <ComponentRef Id="DispatchOSHeaders" />
-      <ComponentRef Id="DispatchLibraries" />
-
-      <ComponentRef Id="_Concurrency.swiftmodule" />
-      <ComponentRef Id="_Differentiation.swiftmodule" />
-      <ComponentRef Id="Distributed.swiftmodule" />
-      <ComponentRef Id="_RegexParser.swiftmodule" />
-      <ComponentRef Id="_StringProcessing.swiftmodule" />
-      <ComponentRef Id="CRT.swiftmodule" />
-      <ComponentRef Id="Dispatch.swiftmodule" />
-      <ComponentRef Id="Foundation.swiftmodule" />
-      <ComponentRef Id="FoundationNetworking.swiftmodule" />
-      <ComponentRef Id="FoundationXML.swiftmodule"/>
-      <ComponentRef Id="Swift.swiftmodule" />
-      <ComponentRef Id="SwiftOnoneSupport.swiftmodule" />
-      <ComponentRef Id="WinSDK.swiftmodule" />
-
-      <ComponentRef Id="_ConcurrencyLibraries" />
-      <ComponentRef Id="_DifferentiationLibraries" />
-      <ComponentRef Id="_DistributedLibraries" />
-      <ComponentRef Id="FoundationLibraries" />
-      <ComponentRef Id="SwiftLibraries" />
-      <ComponentRef Id="SwiftSDKOverlayLibraries" />
-
-      <ComponentRef Id="SwiftRemoteMirrorHeaders" />
-      <ComponentRef Id="SwiftRemoteMirrorLibraries" />
+      <ComponentGroupRef Id="XCTest" />
+      <ComponentGroupRef Id="dispatch" />
+      <ComponentGroupRef Id="BlocksRuntime" />
+      <ComponentGroupRef Id="SwiftRemoteMirror" />
+      <ComponentGroupRef Id="_Concurrency" />
+      <ComponentGroupRef Id="_Differentiation" />
+      <ComponentGroupRef Id="Distributed" />
+      <ComponentGroupRef Id="_RegexParser" />
+      <ComponentGroupRef Id="_StringProcessing" />
+      <ComponentGroupRef Id="CRT" />
+      <ComponentGroupRef Id="Foundation" />
+      <ComponentGroupRef Id="FoundationNetworking" />
+      <ComponentGroupRef Id="FoundationXML" />
+      <ComponentGroupRef Id="Swift" />
+      <ComponentGroupRef Id="SwiftOnoneSupport" />
+      <ComponentGroupRef Id="WinSDK" />
 
       <ComponentGroupRef Id="SwiftShims" />
 
-      <ComponentRef Id="Registrar" />
-
-      <ComponentRef Id="SupportFiles" />
-
-      <ComponentRef Id="Info.plist" />
-      <ComponentRef Id="SDKSettings.plist" />
+      <ComponentGroupRef Id="Registrar" />
+      <ComponentGroupRef Id="SupportFiles" />
+      <ComponentGroupRef Id="Configuration" />
 
       <ComponentRef Id="EnvironmentVariables" />
 

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -75,7 +75,7 @@
                               </Directory>
                               <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                               </Directory>
-                              <Directory Id="dispatch.swiftmodule" Name="dispatch.swiftmodule">
+                              <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                               </Directory>
                               <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
                               </Directory>
@@ -220,10 +220,10 @@
         <File Id="dispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
       </Component>
 
-      <Component Id="Dispatch.swiftdoc" Directory="dispatch.swiftmodule" Guid="ef314d01-4432-43c4-9b11-5725db379551">
+      <Component Id="Dispatch.swiftdoc" Directory="Dispatch.swiftmodule" Guid="ef314d01-4432-43c4-9b11-5725db379551">
         <File Id="Dispatch.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftdoc" Checksum="yes" />
       </Component>
-      <Component Id="Dispatch.swiftmodule" Directory="dispatch.swiftmodule" Guid="e9b23638-1dd2-4c95-b053-f97c451625d5">
+      <Component Id="Dispatch.swiftmodule" Directory="Dispatch.swiftmodule" Guid="e9b23638-1dd2-4c95-b053-f97c451625d5">
         <File Id="Dispatch.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftmodule" Checksum="yes" />
       </Component>
 

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -75,7 +75,7 @@
                               </Directory>
                               <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                               </Directory>
-                              <Directory Id="dispatch.swiftmodule" Name="dispatch.swiftmodule">
+                              <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                               </Directory>
                               <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
                               </Directory>
@@ -220,10 +220,10 @@
         <File Id="dispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
       </Component>
 
-      <Component Id="Dispatch.swiftdoc" Directory="dispatch.swiftmodule" Guid="58f7770e-2cef-4277-8d7f-d0470164442d">
+      <Component Id="Dispatch.swiftdoc" Directory="Dispatch.swiftmodule" Guid="58f7770e-2cef-4277-8d7f-d0470164442d">
         <File Id="Dispatch.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Dispatch.swiftdoc" Checksum="yes" />
       </Component>
-      <Component Id="Dispatch.swiftmodule" Guid="e37a27e0-9462-4eec-8e3d-d028f34a6ff6">
+      <Component Id="Dispatch.swiftmodule" Directory="Dispatch.swiftmodule" Guid="e37a27e0-9462-4eec-8e3d-d028f34a6ff6">
         <File Id="Dispatch.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Dispatch.swiftmodule" Checksum="yes" />
       </Component>
 

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -110,287 +110,371 @@
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="XCTest_usr_bin32">
-      <Component Id="XCTestRuntime" Guid="bdc2cb3a-fd3e-4568-94a8-a7a12be19e93">
+    <ComponentGroup Id="XCTest">
+      <Component Id="XCTest.dll" Directory="XCTest_usr_bin32" Guid="bbd2f8c3-52a1-49e4-898e-2bfafb9d5985">
         <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
       </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="XCTestRuntimeDebugInfo" Guid="fcdaadcf-adf2-4441-897b-207d5987a4dc">
-        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <?endif?>
-    </DirectoryRef>
-
-    <DirectoryRef Id="XCTest_usr_lib_swift_windows_i686">
-      <Component Id="XCTestLibraries" Guid="74484c8d-e076-40a8-a1ab-0b6a2ea3e0a6">
+      <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_i686" Guid="76f535ad-b9c7-48d9-baf7-033a5c023a23">
         <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
       </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="XCTest.swiftmodule">
-      <Component Id="XCTestSwiftModule" Guid="819be784-87c1-4891-8a44-1a19894709bc">
+      <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="e07c62a7-8463-4dd7-b198-73ffd52d00fa">
         <File Id="XCTest.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\i686\XCTest.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="XCTest.swiftmodule" Directory="XCTest.swiftmodule" Guid="39ac696e-f50c-4261-bbb0-7f171ccd969d">
         <File Id="XCTest.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\i686\XCTest.swiftmodule" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
-    <DirectoryRef Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror">
-      <Component Id="SwiftRemoteMirrorHeaders" Guid="1653308a-60bc-4771-9635-8b3e67ba46c5">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="XCTestDebugInfo">
+      <Component Id="XCTest.pdb" Directory="XCTest_usr_bin32" Guid="f9f54891-8fe4-444b-b7a1-dc4787e069ee">
+        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftRemoteMirror">
+      <Component Id="MemoryReaderInterface.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="4493ba7f-b3b3-4cb3-b645-6457e81ad752">
         <File Id="MemoryReaderInterface.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\MemoryReaderInterface.h" Checksum="yes" />
+      </Component>
+      <Component Id="Platform.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="61384dc6-be9c-42cd-847b-fb94617fcab1">
         <File Id="Platform.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\Platform.h" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftRemoteMirror.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="bcc781b4-94ea-4ae6-aa1e-e26e62f04e10">
         <File Id="SwiftRemoteMirror.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirror.h" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftRemoteMirrorTypes.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="c15a0af1-e521-4ffc-845b-4f7176db4e2c">
         <File Id="SwiftRemoteMirrorTypes.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" Checksum="yes" />
       </Component>
-    </DirectoryRef>
 
-    <DirectoryRef Id="WindowsSDK_usr_include_Block">
-      <Component Id="BlocksRuntimeHeaders" Guid="56ef7e66-3a7b-41a3-967c-1c9247183bb6">
-        <File Id="BlocksRuntime_Block.h" Source="$(var.SDK_ROOT)\usr\lib\swift\Block\Block.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WindowsSDK_usr_include_dispatch">
-      <Component Id="DispatchHeaders" Guid="7d683f4f-7a40-4ef9-821f-12ca867edb7b">
-        <File Id="base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\base.h" Checksum="yes" />
-        <File Id="dispatch_block.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\block.h" Checksum="yes" />
-        <File Id="data.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\data.h" Checksum="yes" />
-        <File Id="dispatch.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" Checksum="yes" />
-        <File Id="group.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\group.h" Checksum="yes" />
-        <File Id="introspection.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" Checksum="yes" />
-        <File Id="io.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\io.h" Checksum="yes" />
-        <File Id="dispatch.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" Checksum="yes" />
-        <File Id="dispatch_object.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\object.h" Checksum="yes" />
-        <File Id="once.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\once.h" Checksum="yes" />
-        <File Id="queue.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\queue.h" Checksum="yes" />
-        <File Id="semaphore.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" Checksum="yes" />
-        <File Id="source.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\source.h" Checksum="yes" />
-        <File Id="time.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\time.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WindowsSDK_usr_include_os">
-      <Component Id="DispatchOSHeaders" Guid="0caaa892-0d73-44eb-af99-e42ba5a0f928">
-        <File Id="generic_unix_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_unix_base.h" Checksum="yes" />
-        <File Id="generic_win_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_win_base.h" Checksum="yes" />
-        <File Id="os_object.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\object.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_Concurrency.swiftmodule">
-      <Component Id="_Concurrency.swiftmodule" Guid="b7ab49b2-61dd-4fba-82a1-b4933d67f32a">
-        <File Id="_Concurrency.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_Concurrency.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_Concurrency.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_Differentiation.swiftmodule">
-      <Component Id="_Differentiation.swiftmodule" Guid="7634ee8c-d6ef-47a2-b802-3bd0e66430cb">
-        <File Id="_Differentiation.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_Differentiation.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_Differentiation.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="Distributed.swiftmodule">
-      <Component Id="Distributed.swiftmodule" Guid="472906e4-301b-4709-adf8-6f96c8df2b22">
-        <File Id="Distributed.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="Distributed.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="Distributed.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_RegexParser.swiftmodule">
-      <Component Id="_RegexParser.swiftmodule" Guid="db814242-ca96-481d-9b5f-f2590e8a0c5b">
-        <File Id="_RegexParser.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_RegexParser.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_RegexParser.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_StringProcessing.swiftmodule">
-      <Component Id="_StringProcessing.swiftmodule" Guid="decf71d3-ced0-40d1-9587-1bde19af92a3">
-        <File Id="_StringProcessing.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_StringProcessing.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_StringProcessing.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="CRT.swiftmodule">
-      <Component Id="CRT.swiftmodule" Guid="6b5b1b68-104a-4625-9249-86631d6b01e6">
-        <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="CRT.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="CRT.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="dispatch.swiftmodule">
-      <Component Id="Dispatch.swiftmodule" Guid="3ecb847f-95ab-4320-9c82-8ce0159af700">
-        <File Id="Dispatch.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Dispatch.swiftdoc" Checksum="yes" />
-        <File Id="Dispatch.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Dispatch.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="Foundation.swiftmodule">
-      <Component Id="Foundation.swiftmodule" Guid="0339989d-8440-4178-b9a3-aeec0fd2d800">
-        <File Id="Foundation.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Foundation.swiftdoc" Checksum="yes" />
-        <File Id="Foundation.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Foundation.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="FoundationNetworking.swiftmodule">
-      <Component Id="FoundationNetworking.swiftmodule" Guid="38e3a849-3d1c-4326-90ae-5b550e53c4d3">
-        <File Id="FoundationNetworking.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\FoundationNetworking.swiftdoc" Checksum="yes" />
-        <File Id="FoundationNetworking.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\FoundationNetworking.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="FoundationXML.swiftmodule">
-      <Component Id="FoundationXML.swiftmodule" Guid="6fae0f96-085c-4dd4-b731-ff940e1e3a21">
-        <File Id="FoundationXML.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\FoundationXML.swiftdoc" Checksum="yes" />
-        <File Id="FoundationXML.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\FoundationXML.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="Swift.swiftmodule">
-      <Component Id="Swift.swiftmodule" Guid="56bbb98b-45b7-4446-b3a9-b2ef045fa1be">
-        <File Id="Swift.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="Swift.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="Swift.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="SwiftOnoneSupport.swiftmodule">
-      <Component Id="SwiftOnoneSupport.swiftmodule" Guid="ac9348b7-55a2-4b5c-8900-a5f270d687a1">
-        <File Id="SwiftOnoneSupport.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="SwiftOnoneSupport.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="SwiftOnoneSupport.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WinSDK.swiftmodule">
-      <Component Id="WinSDK.swiftmodule" Guid="330434cb-1f63-467a-b66b-6660f217e3c0">
-        <File Id="WinSDK.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="WinSDK.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="WinSDK.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WindowsSDK_usr_lib_swift_windows_i686">
-      <Component Id="Registrar" Guid="41a46fb5-4144-4c25-94a8-5f65cc90b128">
-        <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftrt.obj" Checksum="yes" />
-      </Component>
-
-      <Component Id="_ConcurrencyLibraries" Guid="628aa2ca-fe0f-460c-ab1c-28a5cae0cb89">
-        <File Id="swift_Concurrency.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swift_Concurrency.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="_DifferentiationLibraries" Guid="9290b204-6e40-40fc-96ef-2ff380a8e584">
-        <File Id="swift_Differentiation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swift_Differentiation.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="_DistributedLibraries" Guid="224fa581-6165-475e-b55b-57a9b0505cc8">
-        <File Id="swiftDistributed.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftDistributed.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="BlocksRuntimeLibraries" Guid="99269181-9e69-41df-8bda-a2c1ad1b8404">
-        <File Id="BlocksRuntime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="DispatchLibraries" Guid="0fef7923-c403-46c8-a813-18e64fb8456b">
-        <File Id="dispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
-        <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="FoundationLibraries" Guid="59f23dff-898c-4c22-ba58-c3f827847127">
-        <File Id="Foundation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
-        <File Id="FoundationNetworking.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
-        <File Id="FoundationXML.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SwiftLibraries" Guid="c7e45a34-f18b-4633-9897-2c594bd945e7">
-        <File Id="swiftCore.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftCore.lib" Checksum="yes" />
-        <File Id="swiftSwiftOnoneSupport.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftSwiftOnoneSupport.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SwiftSDKOverlayLibraries" Guid="c1ff5f7b-ec47-4fe3-82a7-e4d5a0f9a9b3">
-        <File Id="swiftCRT.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftCRT.lib" Checksum="yes" />
-        <File Id="swiftWinSDK.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftWinSDK.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SwiftRemoteMirrorLibraries" Guid="69746a8a-e2f7-4e04-97d0-4e5dab18e366">
+      <Component Id="wwiftRemoteMirror.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="3d429d95-1f9d-4b59-85f2-2676ae95539b">
         <File Id="swiftRemoteMirror.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftRemoteMirror.lib" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
-    <DirectoryRef Id="WindowsSDK_usr_share">
-      <Component Id="SupportFiles" Guid="2be1e214-512b-4895-9aef-93c8e263a698">
+    <ComponentGroup Id="BlocksRuntime">
+      <Component Id="Block.h" Directory="WindowsSDK_usr_include_Block" Guid="46ea8477-b407-41ac-a3ea-d6db791524d9">
+        <File Id="Block.h_46ea8477b40741aca3ead6db791524d9" Source="$(var.SDK_ROOT)\usr\lib\swift\Block\Block.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="BlocksRuntime.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="0cd38131-8998-4fd7-805d-ca36fb798dbc">
+        <File Id="BlocksRuntime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="dispatch">
+      <Component Id="base.h" Directory="WindowsSDK_usr_include_dispatch" Guid="a263a074-5bc5-4823-95a9-f91a314b6cf0">
+        <File Id="base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\base.h" Checksum="yes" />
+      </Component>
+      <Component Id="block.h" Directory="WindowsSDK_usr_include_dispatch" Guid="3629b098-826c-4d98-89a7-b486160dddfa">
+        <File Id="block.h_3629b098826c4d9889a7b486160dddfa" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\block.h" Checksum="yes" />
+      </Component>
+      <Component Id="data.h" Directory="WindowsSDK_usr_include_dispatch" Guid="1d9bb083-bb0e-46de-b82b-b582c55df716">
+        <File Id="data.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\data.h" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.h" Directory="WindowsSDK_usr_include_dispatch" Guid="a4e8a91e-b54b-485e-8f47-83e23bb435b3">
+        <File Id="dispatch.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" Checksum="yes" />
+      </Component>
+      <Component Id="group.h" Directory="WindowsSDK_usr_include_dispatch" Guid="6a992ce8-127a-4826-87fc-009e3666c980">
+        <File Id="group.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\group.h" Checksum="yes" />
+      </Component>
+      <Component Id="introspection.h" Directory="WindowsSDK_usr_include_dispatch" Guid="1177a222-a855-495e-bb4c-40b58bf2a72f">
+        <File Id="introspection.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" Checksum="yes" />
+      </Component>
+      <Component Id="io.h" Directory="WindowsSDK_usr_include_dispatch" Guid="4cbd900b-ea17-42d0-ad01-555e64203e34">
+        <File Id="io.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\io.h" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.modulemap" Directory="WindowsSDK_usr_include_dispatch" Guid="29d12456-9a40-47a8-9f0c-328e27ea9921">
+        <File Id="dispatch.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="object.h_f87c5a369294493489839a2cabdb7ae7" Directory="WindowsSDK_usr_include_dispatch" Guid="f87c5a36-9294-4934-8983-9a2cabdb7ae7">
+        <File Id="object.h_f87c5a369294493489839a2cabdb7ae7" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\object.h" Checksum="yes" />
+      </Component>
+      <Component Id="once.h" Directory="WindowsSDK_usr_include_dispatch" Guid="24c2b93d-8912-4cc7-a23d-11df4afa6c10">
+        <File Id="once.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\once.h" Checksum="yes" />
+      </Component>
+      <Component Id="queue.h" Directory="WindowsSDK_usr_include_dispatch" Guid="db4bb4ee-6a95-4692-9793-af888ac633e2">
+        <File Id="queue.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\queue.h" Checksum="yes" />
+      </Component>
+      <Component Id="semaphore.h" Directory="WindowsSDK_usr_include_dispatch" Guid="99b07079-67e8-418c-a4a1-647b28e2bfd0">
+        <File Id="semaphore.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" Checksum="yes" />
+      </Component>
+      <Component Id="source.h" Directory="WindowsSDK_usr_include_dispatch" Guid="740ec071-b663-461f-8408-83f65a804d7e">
+        <File Id="source.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\source.h" Checksum="yes" />
+      </Component>
+      <Component Id="time.h" Directory="WindowsSDK_usr_include_dispatch" Guid="4f234266-768c-4e42-80fd-829cd6d62c91">
+        <File Id="time.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\time.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="generic_unix_base.h" Directory="WindowsSDK_usr_include_os" Guid="66347322-84a9-4246-9d69-17b2e03dea63">
+        <File Id="generic_unix_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_unix_base.h" Checksum="yes" />
+      </Component>
+      <Component Id="generic_win_base.h" Directory="WindowsSDK_usr_include_os" Guid="1b418910-d049-4040-a1a0-47844b90cc10">
+        <File Id="generic_win_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_win_base.h" Checksum="yes" />
+      </Component>
+      <Component Id="object.h_3af0f0745780408e9fb16b614066623f" Directory="WindowsSDK_usr_include_os" Guid="3af0f074-5780-408e-9fb1-6b614066623f">
+        <File Id="object.h_3af0f0745780408e9fb16b614066623f" Source="$(var.SDK_ROOT)\usr\lib\swift\os\object.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="dispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="28cbf6a7-c6fc-40bc-adf3-2fc03aa47251">
+        <File Id="dispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="Dispatch.swiftdoc" Directory="dispatch.swiftmodule" Guid="58f7770e-2cef-4277-8d7f-d0470164442d">
+        <File Id="Dispatch.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Dispatch.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Dispatch.swiftmodule" Guid="e37a27e0-9462-4eec-8e3d-d028f34a6ff6">
+        <File Id="Dispatch.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Dispatch.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="97e1a280-673c-4eb3-8c79-e0d82c6bc9c9">
+        <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Concurrency">
+      <Component Id="_Concurrency.swiftdoc" Directory="_Concurrency.swiftmodule" Guid="6e17d82a-42d9-4894-8778-dcc8eca37a3b">
+        <File Id="_Concurrency.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_Concurrency.swiftinterface" Directory="_Concurrency.swiftmodule" Guid="30779706-bee0-4f4c-9af6-b595c4536ec6">
+        <File Id="_Concurrency.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_Concurrency.swiftmodule" Directory="_Concurrency.swiftmodule" Guid="83e40d4d-0dfc-4feb-8005-352a5f42dd7b">
+        <File Id="_Concurrency.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_Concurrency.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="98293a0c-368f-469e-a412-876d5235cf1b">
+        <File Id="swift_Concurrency.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swift_Concurrency.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Differentiation">
+      <Component Id="_Differentiation.swiftdoc" Directory="_Differentiation.swiftmodule" Guid="e07ea533-15d2-4f49-aecd-1de6a3068ed7">
+        <File Id="_Differentiation.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_Differentiation.swiftinterface" Directory="_Differentiation.swiftmodule" Guid="f7e74941-7c91-4c58-86d8-7e8441b8a385">
+        <File Id="_Differentiation.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_Differentiation.swiftmodule" Directory="_Differentiation.swiftmodule" Guid="61923e0f-b2f4-4cac-8f11-8ae4c8f32a2a">
+        <File Id="_Differentiation.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_Differentiation.lib" Directory="WIndowsSDK_usr_lib_swift_windows_i686" Guid="7bb128ab-fbd7-4f1f-9a95-4dced2262672">
+        <File Id="swift_Differentiation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swift_Differentiation.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Distributed">
+      <Component Id="Distributed.swiftdoc" Directory="Distributed.swiftmodule" Guid="b0888823-92f6-4bc9-afad-c59a5996c816">
+        <File Id="Distributed.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Distributed.swiftinterface" Directory="Distributed.swiftmodule" Guid="cb1616a5-cab5-4263-bec8-3fcb3c02e113">
+        <File Id="Distributed.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Distributed.swiftmodule" Directory="Distributed.swiftmodule" Guid="f9f43910-32ad-4c5f-b66f-3f59944223f3">
+        <File Id="Distributed.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDistributed.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="ab4afcd2-4bd0-4373-a1ba-9936a4c7d405">
+        <File Id="swiftDistributed.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftDistributed.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_RegexParser">
+      <Component Id="_RegexParser.swiftdoc" Directory="_RegexParser.swiftmodule" Guid="ac7461ff-45ae-41ca-90b7-0b0bc5e3f314">
+        <File Id="_RegexParser.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_RegexParser.swiftinterface" Directory="_RegexParser.swiftmodule" Guid="2ac3904d-a2d7-49e2-8423-a2275a0e7bca">
+        <File Id="_RegexParser.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_RegexParser.swiftmodule" Directory="_RegexParser.swiftmodule" Guid="da0d0a3a-f041-4f93-90c1-3d43b480ee1a">
+        <File Id="_RegexParser.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_RegexParser.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="7e3f40f3-44ad-4e68-ab41-827cdb6ed3c2">
+        <File Id="swift_RegexParser.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swift_RegexParser.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_StringProcessing">
+      <Component Id="_StringProcessing.swiftdoc" Directory="_StringProcessing.swiftmodule" Guid="ab423792-6865-439f-bb5d-234a69d4b041">
+        <File Id="_StringProcessing.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_StringProcessing.swiftinterface" Directory="_StringProcessing.swiftmodule" Guid="9c68230f-6c66-4bf7-9e6b-576a567acf9e">
+        <File Id="_StringProcessing.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_StringProcessing.swiftmodule" Directory="_StringProcessing.swiftmodule" Guid="2c25d0e8-a8b0-4fb6-938b-f3349aadbd23">
+        <File Id="_StringProcessing.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_StringProcessing.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="3bc3e09f-5462-4e71-96e2-b46066286444">
+        <File Id="swift_StringProcessing.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swift_StringProcessing.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="CRT">
+      <Component Id="CRT.swiftdoc" Directory="CRT.swiftmodule" Guid="925b5dec-5efc-4362-8760-12f1971ed90c">
+        <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="CRT.swiftinterface" Directory="CRT.swiftmodule" Guid="9098c012-c049-438b-a1c6-c8c7f59468d6">
+        <File Id="CRT.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="CRT.swiftmodule" Directory="CRT.swiftmodule" Guid="67057ea8-c6d6-490a-acd3-86ef3a109f6d">
+        <File Id="CRT.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCRT.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="6f0a9b0d-a564-45a1-b01b-081c26fb6d4e">
+        <File Id="swiftCRT.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftCRT.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Foundation">
+      <Component Id="Foundation.swiftdoc" Directory="Foundation.swiftmodule" Guid="345d3a2b-7b55-4413-82b7-7e7b7ce17798">
+        <File Id="Foundation.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Foundation.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Foundation.swiftmodule" Directory="Foundation.swiftmodule" Guid="4e0ac4ae-5937-43fb-963a-901459e4f8ef">
+        <File Id="Foundation.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Foundation.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="Foundation.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="742b8a52-5809-4852-a4a4-c8437fd7f6ac">
+        <File Id="Foundation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="FoundationNetworking">
+      <Component Id="FoundationNetworking.swiftdoc" Directory="FoundationNetworking.swiftmodule" Guid="dd44bae6-fa96-4b79-9276-9ffcea0b78b4">
+        <File Id="FoundationNetworking.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\FoundationNetworking.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationNetworking.swiftmodule" Directory="FoundationNetworking.swiftmodule" Guid="04d1e62a-439c-4693-afee-c672d083ce79">
+        <File Id="FoundationNetworking.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\FoundationNetworking.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="FoundationNetworking.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="15dc0abc-ce8d-4535-b1a0-b1a1f8b554e0">
+        <File Id="FoundationNetworking.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="FoundationXML">
+      <Component Id="FoundationXML.swiftdoc" Directory="FoundationXML.swiftmodule" Guid="4bb9b03a-5e96-4a7f-b4ec-0ad82d51a52c">
+        <File Id="FoundationXML.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\FoundationXML.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationXML.swiftmodule" Directory="FoundationXML.swiftmodule" Guid="37a874a6-228b-4d8e-bfe6-67c5ef42ff30">
+        <File Id="FoundationXML.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\FoundationXML.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="FoundationXML.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="528492ce-aa8f-4628-895e-1941603495a5">
+        <File Id="FoundationXML.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Swift">
+      <Component Id="Swift.swiftdoc" Directory="Swift.swiftmodule" Guid="10d79d0f-1013-42a3-a950-35e9f0037d01">
+        <File Id="Swift.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Swift.swiftinterface" Directory="Swift.swiftmodule" Guid="d34ccebd-7374-43e2-bbb2-6b5312aa9f7a">
+        <File Id="Swift.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Swift.swiftmodule" Directory="Swift.swiftmodule" Guid="14db8439-bb0b-4735-8403-1a48998aefe0">
+        <File Id="Swift.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCore.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="39d9de50-66d5-4b4e-99af-30ccbf84507a">
+        <File Id="swiftCore.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftCore.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="SwiftOnoneSupport">
+      <Component Id="SwiftOnoneSupport.swiftdoc" Directory="SwiftOnoneSupport.swiftmodule" Guid="56054ec3-b957-4924-9bb2-83de1aa5cafe">
+        <File Id="SwiftOnoneSupport.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftOnoneSupport.swiftinterface" Directory="SwiftOnoneSupport.swiftmodule" Guid="6026a5a8-f096-416c-bd06-ceadd8e75519">
+        <File Id="SwiftOnoneSupport.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftOnoneSupport.swiftmodule" Directory="SwiftOnoneSupport.swiftmodule" Guid="d7802f37-7a5d-4c20-9dcf-1687e0ff4146">
+        <File Id="SwiftOnoneSupport.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftSwiftOnoneSupport.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686 Guid="5394f49f-99b4-4049-81c4-c601d17700d4">
+        <File Id="swiftSwiftOnoneSupport.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftSwiftOnoneSupport.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="WinSDK">
+      <Component Id="WinSDK.swiftdoc" Directory="WinSDK.swiftmodule" Guid="fb9ca366-fbf6-4da1-b9ee-5fc924a4e62c">
+        <File Id="WinSDK.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="WinSDK.swiftinterface" Directory="WinSDK.swiftmodule" Guid="6613b7c0-91f8-4c9e-a699-a3db00bd2ae4">
+        <File Id="WinSDK.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="WinSDK.swiftmodule" Directory="WinSDK.swiftmodule" Guid="daae10d4-8450-41e3-a8fc-9bdffa398d78">
+        <File Id="WinSDK.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftWinSDK.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="1f9e4d1b-4a7e-4849-b319-d55510114903">
+        <File Id="swiftWinSDK.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftWinSDK.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_i686">
+      <Component Id="swiftrt.obj" Guid="a3da165c-3b42-4ad2-a412-a0bb4e31cba5">
+        <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftrt.obj" Checksum="yes" />
+      </Component>
+      <!--
+      <Component Id="swiftrtd.obj" Guid="457b9d66-ebc9-40be-9e3d-6d3fd75c01f6">
+        <File Id="swiftrtd.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftrtd.obj" Checksum="yes" />
+      </Component>
+      -->
+    </ComponentGroup>
+
+    <ComponentGroup Id="SupportFiles" Directory="WindowsSDK_usr_share">
+      <Component Id="ucrt.modulemap" Guid="4b5c1a1d-a6cf-4d06-81f7-e752f0a3f4db">
         <File Id="ucrt.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\ucrt.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="winsdk.modulemap" Guid="a3b7cb7c-730e-4c6b-ada8-d39f4c72f41e">
         <File Id="winsdk.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\winsdk.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="visualc.modulemap" Guid="cd59b968-d431-44a0-870b-16c9fbfde01d">
         <File Id="visualc.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="visualc.apinotes" Guid="11318e14-7d68-490e-8c64-f1332f1d63f7">
         <File Id="visualc.apinotes" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.apinotes" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
-    <DirectoryRef Id="WindowsPlatform">
-      <Component Id="Info.plist" Guid="03130625-9732-4c44-ae81-eddfd97cbe6c">
+    <ComponentGroup Id="Configuration">
+      <Component Id="Info.plist" Directory="WindowsPlatform" Guid="6cc713d1-2f44-4a47-8e1e-7f71e1dce68b">
         <File Id="Info.plist" Source="$(var.PLATFORM_ROOT)\Info.plist" Checksum="yes" />
       </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WindowsSDK">
-      <Component Id="SDKSettings.plist" Guid="1562926d-6c1d-4cc1-9ab2-42effae919d2">
+      <Component Id="SDKSettings.plist" Directory="WindowsSDK" Guid="5e7d06bc-cad8-4c8b-803b-686adfbcb220">
         <File Id="SDKSettings.plist" Source="$(var.SDK_ROOT)\SDKSettings.plist" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
 
     <!-- Features -->
     <Feature Id="Win32SDK" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows i686" Level="1" Title="Swift SDK for Windows i686">
-      <ComponentRef Id="XCTestRuntime" />
-      <ComponentRef Id="XCTestLibraries" />
-      <ComponentRef Id="XCTestSwiftModule" />
-
-      <ComponentRef Id="BlocksRuntimeHeaders" />
-      <ComponentRef Id="BlocksRuntimeLibraries" />
-
-      <ComponentRef Id="DispatchHeaders" />
-      <ComponentRef Id="DispatchOSHeaders" />
-      <ComponentRef Id="DispatchLibraries" />
-
-      <ComponentRef Id="_Concurrency.swiftmodule" />
-      <ComponentRef Id="_Differentiation.swiftmodule" />
-      <ComponentRef Id="Distributed.swiftmodule" />
-      <ComponentRef Id="_RegexParser.swiftmodule" />
-      <ComponentRef Id="_StringProcessing.swiftmodule" />
-      <ComponentRef Id="CRT.swiftmodule" />
-      <ComponentRef Id="Dispatch.swiftmodule" />
-      <ComponentRef Id="Foundation.swiftmodule" />
-      <ComponentRef Id="FoundationNetworking.swiftmodule" />
-      <ComponentRef Id="FoundationXML.swiftmodule"/>
-      <ComponentRef Id="Swift.swiftmodule" />
-      <ComponentRef Id="SwiftOnoneSupport.swiftmodule" />
-      <ComponentRef Id="WinSDK.swiftmodule" />
-
-      <ComponentRef Id="_ConcurrencyLibraries" />
-      <ComponentRef Id="_DifferentiationLibraries" />
-      <ComponentRef Id="_DistributedLibraries" />
-      <ComponentRef Id="FoundationLibraries" />
-      <ComponentRef Id="SwiftLibraries" />
-      <ComponentRef Id="SwiftSDKOverlayLibraries" />
-
-      <ComponentRef Id="SwiftRemoteMirrorHeaders" />
-      <ComponentRef Id="SwiftRemoteMirrorLibraries" />
+      <ComponentGroupRef Id="XCTest" />
+      <ComponentGroupRef Id="dispatch" />
+      <ComponentGroupRef Id="BlocksRuntime" />
+      <ComponentGroupRef Id="SwiftRemoteMirror" />
+      <ComponentGroupRef Id="_Concurrency" />
+      <ComponentGroupRef Id="_Differentiation" />
+      <ComponentGroupRef Id="Distributed" />
+      <ComponentGroupRef Id="_RegexParser" />
+      <ComponentGroupRef Id="_StringProcessing" />
+      <ComponentGroupRef Id="CRT" />
+      <ComponentGroupRef Id="Foundation" />
+      <ComponentGroupRef Id="FoundationNetworking" />
+      <ComponentGroupRef Id="FoundationXML" />
+      <ComponentGroupRef Id="Swift" />
+      <ComponentGroupRef Id="SwiftOnoneSupport" />
+      <ComponentGroupRef Id="WinSDK" />
 
       <ComponentGroupRef Id="SwiftShims" />
 
-      <ComponentRef Id="Registrar" />
-
-      <ComponentRef Id="SupportFiles" />
-
-      <ComponentRef Id="Info.plist" />
-      <ComponentRef Id="SDKSettings.plist" />
+      <ComponentGroupRef Id="Registrar" />
+      <ComponentGroupRef Id="SupportFiles" />
+      <ComponentGroupRef Id="Configuration" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows i686" Level="0" Title="Debug Information">

--- a/platforms/Windows/toolchain.wxs
+++ b/platforms/Windows/toolchain.wxs
@@ -537,8 +537,14 @@
 
     <ComponentGroup Id="swift">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="swift_api_digester.exe" Directory="_usr_bin" Guid="ed1dbe33-7003-44bc-8aa8-c5735d09c8fd">
+        <File Id="swift_api_digester.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-api-digester.exe" Checksum="yes" />
+      </Component>
       <Component Id="swift_autolink_extract.exe" Directory="_usr_bin" Guid="26c29024-5fb1-4aed-8150-c1bfa271f469">
         <File Id="swift_autolink_extract.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-autolink-extract.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_symbolgraph_extract.exe" Directory="_usr_bin" Guid="f51c6f69-68f7-4af7-b3c8-6de9cc93262f">
+        <File Id="swift_symbolgraph_extract.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-symbolgraph-extract.exe" Checksum="yes" />
       </Component>
 
       <Component Id="swift_demangle.exe" Directory="_usr_bin" Guid="8c42f286-7ddf-4637-ad4b-18e6904bc006">

--- a/platforms/Windows/toolchain.wxs
+++ b/platforms/Windows/toolchain.wxs
@@ -14,17 +14,19 @@
     <Media Id="1" Cabinet="toolchain.cab" EmbedCab="yes" CompressionLevel="high" />
 
     <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.clang.cab" />
-    <Media Id="3" Cabinet="PDBs.lldb.cab" />
-    <Media Id="4" Cabinet="PDBs.llvm.cab" />
-    <Media Id="5" Cabinet="PDBs.swift.cab" />
-    <Media Id="6" Cabinet="PDBs.SourceKit.cab" />
-    <Media Id="7" Cabinet="PDBs.lld.cab" />
-    <Media Id="8" Cabinet="PDBs.llbuild.cab" />
-    <Media Id="9" Cabinet="PDBs.swift-driver.cab" />
-    <Media Id="10" Cabinet="PDBs.ArgumentParser.cab" />
-    <Media Id="11" Cabinet="PDBs.ToolsSupportCore.cab" />
-    <Media Id="12" Cabinet="PDBs.Yams.cab" />
+    <Media Id="2" Cabinet="PDBs.llvm.cab" />
+    <Media Id="3" Cabinet="PDBs.clang.cab" />
+    <Media Id="4" Cabinet="PDBs.lld.cab" />
+    <Media Id="5" Cabinet="PDBs.lldb.cab" />
+    <Media Id="6" Cabinet="PDBs.BlocksRuntime.cab" />
+    <Media Id="7" Cabinet="PDBs.dispatch.cab" />
+    <Media Id="8" Cabinet="PDBs.SourceKit.cab" />
+    <Media Id="9" Cabinet="PDBs.swift.cab" />
+    <Media Id="10" Cabinet="PDBs.llbuild.cab" />
+    <Media Id="11" Cabinet="PDBs.ArgumentParser.cab" />
+    <Media Id="12" Cabinet="PDBs.ToolsSupportCore.cab" />
+    <Media Id="13" Cabinet="PDBs.Yams.cab" />
+    <Media Id="14" Cabinet="PDBs.swift-driver.cab" />
     <?endif?>
 
     <!-- Directory Structure -->
@@ -102,362 +104,691 @@
     </SetDirectory>
 
     <!-- Components -->
-    <DirectoryRef Id="_usr_bin">
-      <Component Id="Toolchain" Guid="d150bdb3-d0f4-4a12-bacf-4dc0b1724d9e">
-        <!-- clang -->
-
-        <!-- symlinks -->
-        <File Id="clang_cl.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cl.exe" Checksum="yes" />
-        <File Id="clang_cpp.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cpp.exe" Checksum="yes" />
-        <File Id="clang__.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang++.exe" Checksum="yes" />
-        <!-- /symlinks -->
-
-        <File Id="clang_format.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.exe" Checksum="yes" />
-        <File Id="clang_tidy.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.exe" Checksum="yes" />
-        <File Id="clang.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.exe" Checksum="yes" />
-        <File Id="libclang.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.dll" Checksum="yes" />
-        <File Id="libIndexStore.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.dll" Checksum="yes" />
-        <!-- clang-offload-bundler.exe, clang-refactor.exe, clang-rename.exe, optremarks.dll, scan-build, scan-view -->
-
-        <!-- lld -->
-
-        <!-- symlinks -->
-        <File Id="ld.lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld.lld.exe" Checksum="yes" />
-        <File Id="ld64.lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld64.lld.exe" Checksum="yes" />
-        <File Id="lld_link.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld-link.exe" Checksum="yes" />
-        <File Id="wasm_ld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\wasm-ld.exe" Checksum="yes" />
-        <!-- /symlinks -->
-
-        <File Id="lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.exe" Checksum="yes" />
-
-        <!-- lldb -->
-        <File Id="lldb_server.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.exe" Checksum="yes" />
-        <File Id="lldb_vscode.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.exe" Checksum="yes" />
-        <File Id="lldb.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.exe" Checksum="yes" />
-        <File Id="liblldb.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.dll" Checksum="yes" />
-        <File Id="repl_swift.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\repl_swift.exe" Checksum="yes" />
-        <!-- lldb-argdumper.exe -->
-
-        <!-- llvm -->
-
-        <!-- symlinks -->
-        <!-- addr2line.exe, ar.exe, c++filt.exe, dwp.exe, nm.exe, objcopy.exe, objdump.exe, ranlib.exe, readelf.exe, size.exe, strings.exe -->
+    <ComponentGroup Id="binutils">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="llvm_dlltool.exe" Directory="_usr_bin" Guid="8d92d7ee-5612-4624-8430-4376452ab466">
         <File Id="llvm_dlltool.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dlltool.exe" Checksum="yes" />
+      </Component>
+      <Component Id="lldb_lib.exe" Directory="_usr_bin" Guid="4669a49f-ae98-4968-83ad-1b171afa305b">
         <File Id="llvm_lib.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lib.exe" Checksum="yes" />
-        <File Id="lldb_ranlib.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ranlib.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_ranlib.exe" Directory="_usr_bin" Guid="477c51a4-b382-4c9f-b723-25dfec897528">
+        <File Id="llvm_ranlib.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ranlib.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_readelf.exe" Directory="_usr_bin" Guid="89f2ec1e-eacd-481c-94df-27a13f4a0fa7">
         <File Id="llvm_readelf.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readelf.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_strip.exe" Directory="_usr_bin" Guid="5ad256b2-ec0f-46c9-9972-4f0b3ee0323a">
         <File Id="llvm_strip.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strip.exe" Checksum="yes" />
-        <!-- /symlinks -->
+      </Component>
+      <!--
+      TODO(compnerd) we should symlink addr2line.exe, ar.exe, c++filt.exe, dwp.exe, nm.exe, objcopy.exe, objdump.exe, ranlib.exe, readelf.exe, size.exe, strings.exe
+      -->
 
+      <Component Id="dsymutil.exe" Directory="_usr_bin" Guid="b9beabfe-2fa2-4a8a-b86b-768135c56756">
         <File Id="dsymutil.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_ar.exe" Directory="_usr_bin" Guid="23c30835-eab9-4f09-bb8e-45a007793c63">
         <File Id="llvm_ar.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_cov.exe" Directory="_usr_bin" Guid="0c53ebd9-b094-4a41-95d4-2a09b73cee12">
         <File Id="llvm_cov.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_cvtres.exe" Directory="_usr_bin" Guid="769d4bfd-a773-4d02-83e0-02d89b9d828c">
         <File Id="llvm_cvtres.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_cxxfilt.exe" Directory="_usr_bin" Guid="f947e114-7a8e-4f50-9e02-f8c446858255">
         <File Id="llvm_cxxfilt.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_dwarfdump.exe" Directory="_usr_bin" Guid="a100ff0c-9500-43ca-9b00-4890a45f7f9c">
         <File Id="llvm_dwarfdump.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_dwp.exe" Directory="_usr_bin" Guid="11189785-0ccb-4ac4-b7d4-91c904ccec61">
         <File Id="llvm_dwp.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_lipo.exe" Directory="_usr_bin" Guid="af903d78-8e81-4abb-b12b-69b2d08f4fb9">
         <File Id="llvm_lipo.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_mt.exe" Directory="_usr_bin" Guid="7a4b42b8-7fce-4826-8851-dec723a00e1a">
         <File Id="llvm_mt.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_nm.exe" Directory="_usr_bin" Guid="434564e5-82e2-47f0-821a-fd25789b74ca">
         <File Id="llvm_nm.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_objcopy.exe" Directory="_usr_bin" Guid="835921fe-0109-45f2-be8a-aa389637b195">
         <File Id="llvm_objcopy.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_objdump.exe" Directory="_usr_bin" Guid="1c462d49-75f5-4910-9863-d1f388ec9c3a">
         <File Id="llvm_objdump.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_pdbutil.exe" Directory="_usr_bin" Guid="90a56d58-6ca1-43e1-a813-4f204fe2f7cc">
         <File Id="llvm_pdbutil.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_profdata.exe" Directory="_usr_bin" Guid="93b4f6d8-9abc-41d4-86c9-60618fd52b47">
         <File Id="llvm_profdata.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_rc.exe" Directory="_usr_bin" Guid="c997b4fa-6915-436c-901c-b569e02ac3f9">
         <File Id="llvm_rc.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_readobj.exe" Directory="_usr_bin" Guid="fd06b83c-a2b2-4d08-b956-85feb81548be">
         <File Id="llvm_readobj.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_size.exe" Directory="_usr_bin" Guid="aedc4485-35e6-4963-b3d3-cc9d1f2757fb">
         <File Id="llvm_size.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_strings.exe" Directory="_usr_bin" Guid="25d7604e-4bbd-4821-ab9a-410be2167dfe">
         <File Id="llvm_strings.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_symbolizer.exe" Directory="_usr_bin" Guid="67a0a14f-d7fc-4041-bf16-ce8ea48af36f">
         <File Id="llvm_symbolizer.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_undname.exe" Directory="_usr_bin" Guid="55b66015-960d-42fe-a32e-bc525361f91a">
         <File Id="llvm_undname.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="LTO.dll" Directory="_usr_bin" Guid="6eb91b05-b32e-4c1f-bb01-9593027b7e59">
         <File Id="LTO.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.dll" Checksum="yes" />
-
-        <!-- swift -->
-
-        <!-- symlinks -->
-        <File Id="swift_autolink_extract.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-autolink-extract.exe" Checksum="yes" />
-        <!-- /symlinks -->
-
-        <File Id="swift_demangle.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.exe" Checksum="yes" />
-        <File Id="swift_frontend.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.exe" Checksum="yes" />
-        <File Id="swiftDemangle.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.dll" Checksum="yes" />
-        <File Id="_InternalSwiftScan.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.dll" Checksum="yes" />
-        <File Id="_InternalSwiftSyntaxParser.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.dll" Checksum="yes" />
-
-        <!-- sourcekit -->
-        <File Id="BlocksRuntime.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
-        <File Id="dispatch.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
-        <File Id="sourcekitdInProc.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.dll" Checksum="yes" />
-
-        <!-- non-LLVM build components -->
-
-        <!-- llbuild -->
-        <File Id="llbuild.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.dll" Checksum="yes" />
-        <File Id="llbuildSwift.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" Checksum="yes" />
-
-        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
-
-        <!-- swift-driver -->
-        <!-- symlinks -->
-        <File Id="swiftc.exe" Name="swiftc.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
-        <!-- /symlinks -->
-
-        <File Id="swift.exe" Name="swift.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
-        <File Id="swift_help.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-help.exe" Checksum="yes" />
-        <File Id="swift_build_sdk_interfaces.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-sdk-interfaces.exe" Checksum="yes" />
-        <File Id="SwiftOptions.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" Checksum="yes" />
-        <File Id="SwiftDriver.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
-        <File Id="SwiftDriverExecution.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriverExecution.dll" Checksum="yes" />
-
-        <!-- swift-argument-parser -->
-        <File Id="ArgumentParser.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
-        <File Id="ArgumentParserToolInfo.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.dll" Checksum="yes" />
-
-        <!-- tools-support-core -->
-        <File Id="TSCBasic.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" Checksum="yes" />
-        <File Id="TSCLibc.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.dll" Checksum="yes" />
-        <File Id="TSCUtility.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
-
-        <!-- Yams -->
-        <File Id="Yams.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
       </Component>
 
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="ToolchainDebugInfo" Guid="b8eab90b-cf24-48c2-b727-e90231ad87be">
-        <!-- clang -->
-        <File Id="clang_format.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.pdb" Checksum="yes" DiskId="2" />
-        <File Id="clang_tidy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.pdb" Checksum="yes" />
-        <File Id="clang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.pdb" Checksum="yes" DiskId="2" />
-        <File Id="libclang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.pdb" Checksum="yes" DiskId="2" />
-        <File Id="libIndexStore.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.pdb" Checksum="yes" DiskId="2" />
-
-        <!-- lld -->
-        <File Id="lld.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.pdb" Checksum="yes" DiskId="7" />
-
-        <!-- lldb -->
-        <File Id="lldb_server.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.pdb" Checksum="yes" DiskId="3" />
-        <File Id="lldb_vscode.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.pdb" Checksum="yes" DiskId="3" />
-        <File Id="lldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.pdb" Checksum="yes" DiskId="3" />
-        <File Id="liblldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.pdb" Checksum="yes" DiskId="3" />
-
-        <!-- llvm -->
-        <File Id="dsymutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_ar.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_cov.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_cvtres.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_cxxfilt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_dwarfdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_dwp.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_lipo.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_mt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_nm.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_objcopy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_objdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_pdbutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_profdata.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_rc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_readobj.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_size.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_strings.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_symbolizer.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.pdb" Checksum="yes" DiskId="4" />
-        <File Id="llvm_undname.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.pdb" Checksum="yes" DiskId="4" />
-        <File Id="LTO.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.pdb" Checksum="yes" DiskId="4" />
-
-        <!-- swift -->
-        <File Id="swift_demangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.pdb" Checksum="yes" DiskId="5" />
-        <File Id="swift_frontend.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.pdb" Checksum="yes" DiskId="5" />
-        <File Id="swiftDemangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="5" />
-        <File Id="_InternalSwiftScan.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.pdb" Checksum="yes" DiskId="5" />
-        <File Id="_InternalSwiftSyntaxParser.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.pdb" Checksum="yes" DiskId="5" />
-
-        <!-- sourcekit -->
-        <File Id="BlocksRuntime.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
-        <File Id="dispatch.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="6" />
-        <File Id="sourcekitdInProc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.pdb" Checksum="yes" DiskId="6" />
-
-        <!-- non-LLVM build components -->
-
-        <!-- llbuild -->
-        <File Id="llbuild.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.pdb" Checksum="yes" DiskId="8" />
-        <File Id="llbuildSwift.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" DiskId="8" />
-
-        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" DiskId="8" />
-
-        <!-- swift-driver -->
-        <File Id="swift.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.pdb" Checksum="yes" DiskId="9" />
-        <File Id="swift_help.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-help.pdb" Checksum="yes" DiskId="9" />
-        <File Id="swift_build_sdk_interfaces.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-build-sdk-interfaces.pdb" Checksum="yes" DiskId="9" />
-        <File Id="SwiftOptions.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" DiskId="9" />
-        <File Id="SwiftDriver.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" DiskId="9" />
-        <File Id="SwiftDriverExecution.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.pdb" Checksum="yes" DiskId="9" />
-
-        <!-- swift-argument-parser -->
-        <File Id="ArgumentParser.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" DiskId="10" />
-        <File Id="ArgumentParserToolInfo.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.pdb" Checksum="yes" DiskId="10" />
-
-        <!-- tools-support-core -->
-        <File Id="TSCBasic.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" DiskId="11" />
-        <File Id="TSCLibc.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.pdb" Checksum="yes" DiskId="11" />
-        <File Id="TSCUtility.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" DiskId="11" />
-
-        <!-- Yams -->
-        <File Id="Yams.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" DiskId="12" />
-      </Component>
-      <?endif?>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_lib">
-      <Component Id="ToolchainLibraries" Guid="c8c86ead-78b5-49be-815b-7e7d12ba1582">
-        <File Id="BlocksRuntime.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\BlocksRuntime.lib" Checksum="yes" />
-        <File Id="dispatch.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\dispatch.lib" Checksum="yes" />
-        <File Id="libclang.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libclang.lib" Checksum="yes" />
-        <File Id="libIndexStore.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libIndexStore.lib" Checksum="yes" />
-        <File Id="liblldb.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\liblldb.lib" Checksum="yes" />
+      <Component Id="LTO.lib" Directory="_usr_lib" Guid="c02d7ff8-cd67-4b1f-9c48-80cf9de845c5">
         <File Id="LTO.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\LTO.lib" Checksum="yes" />
-        <File Id="sourcekitdInProc.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\sourcekitdInProc.lib" Checksum="yes" />
-        <File Id="swiftDemangle.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swiftDemangle.lib" Checksum="yes" />
-        <File Id="_InternalSwiftScan.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftScan.lib" Checksum="yes" />
-        <File Id="_InternalSwiftSyntaxParser.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftSyntaxParser.lib" Checksum="yes" />
       </Component>
-    </DirectoryRef>
 
-    <DirectoryRef Id="_usr_lib_site_packages_lldb">
-      <Component Id="LLDBPythonScripts" Guid="ab01c50e-3e1f-48d2-ac47-e07978a98aa3">
-        <File Id="LLDB___init__.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\__init__.py" Checksum="yes" />
-        <File Id="_lldb.pyd" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\_lldb.pyd" Checksum="yes" />
-        <File Id="embedded_interpreter.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\embedded_interpreter.py" Checksum="yes" />
-        <File Id="lldb_argdumper.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\lldb-argdumper.exe" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_lib_site_packages_lldb_formatters">
-      <Component Id="LLDBFormatters" Guid="f8fdf112-c3f1-4e0d-814f-6128c9375869">
-        <File Id="logger.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\Logger.py" Checksum="yes" />
-        <File Id="LLDBFormatters___init__.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\__init__.py" Checksum="yes" />
-        <File Id="attrib_fromdict.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\attrib_fromdict.py" Checksum="yes" />
-        <File Id="cache.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cache.py" Checksum="yes" />
-        <File Id="metrics.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\metrics.py" Checksum="yes" />
-        <File Id="synth.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\synth.py" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_lib_site_packages_lldb_formatters_cpp">
-      <Component Id="LLDBFormattersCPP" Guid="68217602-585a-4bfc-8c39-41c4bc1f3969">
-        <File Id="LLDBFormattersCPP___init__.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\__init__.py" Checksum="yes" />
-        <File Id="gnu_libstdcpp.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\gnu_libstdcpp.py" Checksum="yes" />
-        <File Id="libcxx.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\libcxx.py" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_lib_site_packages_lldb_utils">
-      <Component Id="LLDBUtils" Guid="f1402112-72fd-450a-962c-a0a29ec23278">
-        <File Id="LLDBUtils___init__.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\__init__.py" Checksum="yes" />
-        <File Id="in_call_stack.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\in_call_stack.py" Checksum="yes" />
-        <File Id="symbolication.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\symbolication.py" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <!-- TODO(compnerd): install the block headers from Swift -->
-    <!--
-    <DirectoryRef Id="_usr_include">
-      <Component Id="BlockRuntimeHeaders" Guid="87f18903-e252-41c4-ade9-aeb4819eeebe">
-      <File Id="BlocskRuntimeBlock.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\Block.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-    -->
-
-    <DirectoryRef Id="_usr_include__InternalSwiftScan">
-      <Component Id="_InternalSwiftScanHeaders" Guid="d680187a-4f9e-4008-ab79-ab5eeb13fd50">
-        <File Id="DependencyScan.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScan.h" Checksum="yes" />
-        <File Id="DependencyScanMacros.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScanMacros.h" Checksum="yes" />
-        <File Id="_InternalSwiftScan.modulemap" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\module.modulemap" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_include__InternalSwiftSyntaxParser">
-      <Component Id="_InternalSwiftSyntaxParserHeaders" Guid="81ae1aef-7471-4637-b0a2-86b6f9def568">
-        <File Id="SwiftSyntaxParser.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxParser.h" Checksum="yes" />
-        <File Id="SwiftSyntaxCDataTypes.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxCDataTypes.h" Checksum="yes" />
-        <File Id="_InternalSwiftSyntaxParser.modulemap" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\module.modulemap" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_include_clang_c">
-      <Component Id="libclangHeader" Guid="3bd9acb2-6d90-4197-afb7-ebec49c4aa75">
-        <File Id="BuildSystem.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\BuildSystem.h" Checksum="yes" />
-        <File Id="CXCompilationDatabase.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXCompilationDatabase.h" Checksum="yes" />
-        <File Id="CXErrorCode.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXErrorCode.h" Checksum="yes" />
-        <File Id="CXString.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXString.h" Checksum="yes" />
-        <File Id="Documentation.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Documentation.h" Checksum="yes" />
-        <File Id="FatalErrorHandler.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\FatalErrorHandler.h" Checksum="yes" />
-        <File Id="Index.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Index.h" Checksum="yes" />
-        <File Id="Platform.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Platform.h" Checksum="yes" />
-        <File Id="Refactor.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Refactor.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_include_indexstore">
-      <Component Id="IndexStoreHeaders" Guid="a9555162-c45d-404f-aec2-44f7a82ca4fe">
-        <File Id="indexstore.h" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\indexstore.h" Checksum="yes" />
-        <File Id="IndexStoreCXX.h" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\IndexStoreCXX.h" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_include_llvm_c">
-      <Component Id="LTOHeaders" Guid="dd5ced9e-e3d5-4bf3-9f47-de0c8ca20720">
+      <Component Id="lto.h" Directory="_usr_include_llvm_c" Guid="f5630176-7faf-488b-9db3-428e0ad3a64f">
         <File Id="lto.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\llvm-c\lto.h" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
-    <!-- TODO(compnerd): install the dispatch headers from swift -->
-    <!--
-    <DirectoryRef Id="_usr_include_dispatch">
-      <Component Id="DispatchHeaders" Guid="4f9607c6-e517-40a4-9c66-4f76411582ff">
-        <File Id="base.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\base.h" Checksum="yes" />
-        <File Id="dispatch_block.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\block.h" Checksum="yes" />
-        <File Id="data.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\data.h" Checksum="yes" />
-        <File Id="dispatch.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\dispatch.h" Checksum="yes" />
-        <File Id="group.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\group.h" Checksum="yes" />
-        <File Id="introspection.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\introspection.h" Checksum="yes" />
-        <File Id="io.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\io.h" Checksum="yes" />
-        <File Id="dispatch.modulemap" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\dispatch.modulemap" Checksum="yes" />
-        <File Id="dispatch_object.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\object.h" Checksum="yes" />
-        <File Id="once.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\once.h" Checksum="yes" />
-        <File Id="queue.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\queue.h" Checksum="yes" />
-        <File Id="semaphore.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\semaphore.h" Checksum="yes" />
-        <File Id="source.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\source.h" Checksum="yes" />
-        <File Id="time.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\dispatch\time.h" Checksum="yes" />
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="binutilsDebugInfo">
+      <Component Id="dsymutil.pdb" Directory="_usr_bin" Guid="678d56e2-6121-4c97-9bdc-7539baa4857b">
+        <File Id="dsymutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.pdb" Checksum="yes" DiskId="2" />
       </Component>
-    </DirectoryRef>
-
-    <DirectoryRef Id="_usr_include_os">
-      <Component Id="DispatchOSHeaders" Guid="7b2d5d0e-f4eb-4562-a739-095715347718">
-        <File Id="generic_unix_base.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\generic_unix_base.h" Checksum="yes" />
-        <File Id="generic_win_base.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\generic_win_base.h" Checksum="yes" />
-        <File Id="os_object.h" Source="$(var.TOOLCHAIN_ROOT)\libdispatch-prefix\include\os\object.h" Checksum="yes" />
+      <Component Id="llvm_ar.pdb" Directory="_usr_bin" Guid="68cf625a-8147-45d4-bfdf-26e07406d991">
+        <File Id="llvm_ar.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.pdb" Checksum="yes" DiskId="2" />
       </Component>
-    </DirectoryRef>
-    -->
+      <Component Id="llvm_cov.pdb" Directory="_usr_bin" Guid="f9788dbf-989b-4e91-86a8-00a38010eb79">
+        <File Id="llvm_cov.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_cvtres.pdb" Directory="_usr_bin" Guid="ecb48149-fb22-44c4-8da3-bff3b9c4f8ba">
+        <File Id="llvm_cvtres.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_cxxfilt.pdb" Directory="_usr_bin" Guid="4e7fb27f-3f91-4ae5-9c1f-c9da06e2e547">
+        <File Id="llvm_cxxfilt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_dwarfdump.pdb" Directory="_usr_bin" Guid="80aec81b-98ff-4768-82be-18916708e1fb">
+        <File Id="llvm_dwarfdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_dwp.pdb" Directory="_usr_bin" Guid="b61c1a91-b812-47ad-94a3-0adb8d417124">
+        <File Id="llvm_dwp.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_lipo.pdb" Directory="_usr_bin" Guid="915083a3-6c96-4f6b-ae93-2f8ef32d0f31">
+        <File Id="llvm_lipo.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_mt.pdb" Directory="_usr_bin" Guid="b1ff8ac6-231d-497b-8c66-502ddf9d7d4a">
+        <File Id="llvm_mt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_nm.pdb" Directory="_usr_bin" Guid="37b43872-0261-4eda-b104-e3093f8ccd8a">
+        <File Id="llvm_nm.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_objcopy.pdb" Directory="_usr_bin" Guid="17fb9703-06f9-43fe-a719-b05a319962ea">
+        <File Id="llvm_objcopy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_objdump.pdb" Directory="_usr_bin" Guid="6b951a96-ec63-4b43-8a13-7a24d438c1ab">
+        <File Id="llvm_objdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_pdbutil.pdb" Directory="_usr_bin" Guid="5a490f07-d4df-461d-b6ca-aed6c51757f0">
+        <File Id="llvm_pdbutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_profdata.pdb" Directory="_usr_bin" Guid="728aca25-78ca-428b-b393-d6dda0d73340">
+        <File Id="llvm_profdata.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_rc.pdb" Directory="_usr_bin" Guid="fe91ef90-4ed4-4c12-aa94-e8507d345ec1">
+        <File Id="llvm_rc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_readobj.pdb" Directory="_usr_bin" Guid="0dcda88c-339c-4d38-8784-72ba0acb9fc4">
+        <File Id="llvm_readobj.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_size.pdb" Directory="_usr_bin" Guid="8d55885c-17d4-4d67-86f5-3e4fe2f8133f">
+        <File Id="llvm_size.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_strings.pdb" Directory="_usr_bin" Guid="06c5757b-53fc-4ed3-ab85-a7063dfbfe81">
+        <File Id="llvm_strings.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_symbolizer.pdb" Directory="_usr_bin" Guid="15254998-b680-4eee-92fb-9abe0cce6199">
+        <File Id="llvm_symbolizer.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_undname.pdb" Directory="_usr_bin" Guid="0a8b17c5-c24e-4a0f-8654-72c88deb28a1">
+        <File Id="llvm_undname.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.pdb" Checksum="yes" DiskId="2" />
+      </Component>
 
-    <DirectoryRef Id="_usr_include_SourceKit">
-      <Component Id="SourceKitHeaders" Guid="758c7e7c-9214-4fff-bfb6-56cb1aa42e2b">
+      <Component Id="LTO.pdb" Directory="_usr_bin" Guid="dd03c59f-7f18-4d35-94cf-9887c4d39243">
+        <File Id="LTO.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="clang">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="clang_cl.exe" Directory="_usr_bin" Guid="f7c9cc75-059b-426e-af7f-abd54474a71d">
+        <File Id="clang_cl.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cl.exe" Checksum="yes" />
+      </Component>
+      <Component Id="clang_cpp.exe" Directory="_usr_bin" Guid="d2f3706e-7008-432f-a896-87f637b13aa3">
+        <File Id="clang_cpp.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cpp.exe" Checksum="yes" />
+      </Component>
+      <Component Id="clang__.exe" Directory="_usr_bin" Guid="7484b05e-f8c9-490d-849c-a939bfb88d37">
+        <File Id="clang__.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang++.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="clang_format.exe" Directory="_usr_bin" Guid="0ace9bf2-0ac0-4c92-aadf-ef4ed8c4478d">
+        <File Id="clang_format.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.exe" Checksum="yes" />
+      </Component>
+      <Component Id="clang_tidy.exe" Directory="_usr_bin" Guid="cd62bf9f-2734-4754-bbcf-26044044d3c2">
+        <File Id="clang_tidy.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.exe" Checksum="yes" />
+      </Component>
+      <Component Id="clang.exe" Directory="_usr_bin" Guid="030da6e7-c5f4-4cdc-9273-5969ad514c35">
+        <File Id="clang.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.exe" Checksum="yes" />
+      </Component>
+      <!--
+      TODO(compnerd) we should include clang-offload-bundler, clang-refactor, clang-rename, optremarks.dll, scan-build, scan-view
+      -->
+
+      <Component Id="libclang.dll" Directory="_usr_bin" Guid="c962b7f7-75b3-4adf-975e-adc19e5c7ba9">
+        <File Id="libclang.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.dll" Checksum="yes" />
+      </Component>
+      <Component Id="libIndexStore.dll" Directory="_usr_bin" Guid="4b2933ae-9682-42ee-a1c7-a8770ab121ee">
+        <File Id="libIndexStore.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="libclang.lib" Directory="_usr_lib" Guid="3e70651c-b564-471e-bdf3-d481f330695f">
+        <File Id="libclang.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libclang.lib" Checksum="yes" />
+      </Component>
+      <Component Id="libIndexStore.lib" Directory="_usr_lib" Guid="1f456149-31c9-454d-b1fe-9792134b0fe5">
+        <File Id="libIndexStore.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libIndexStore.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="BuildSystem.h" Directory="_usr_include_clang_c" Guid="b2cef896-4642-42db-8477-0db1497d349e">
+        <File Id="BuildSystem.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\BuildSystem.h" Checksum="yes" />
+      </Component>
+      <Component Id="CXCompilationDatabase.h" Directory="_usr_include_clang_c" Guid="8a3c8f12-f79f-4235-ab33-75d8480fd9cd">
+        <File Id="CXCompilationDatabase.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXCompilationDatabase.h" Checksum="yes" />
+      </Component>
+      <Component Id="CXErrorCode.h" Directory="_usr_include_clang_c" Guid="2fb03adf-e64f-4aa8-bdc9-563e71177639">
+        <File Id="CXErrorCode.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXErrorCode.h" Checksum="yes" />
+      </Component>
+      <Component Id="CXString.h" Directory="_usr_include_clang_c" Guid="630b267f-014c-4720-9047-4d8947751c8c">
+        <File Id="CXString.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXString.h" Checksum="yes" />
+      </Component>
+      <Component Id="Documentation.h" Directory="_usr_include_clang_c" Guid="cdb0468b-0b86-4c8f-9180-6b857321bdd5">
+        <File Id="Documentation.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Documentation.h" Checksum="yes" />
+      </Component>
+      <Component Id="FatalErrorHandler.h" Directory="_usr_include_clang_c" Guid="e2bd6c56-13b9-42e4-b142-c42b77b1410a">
+        <File Id="FatalErrorHandler.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\FatalErrorHandler.h" Checksum="yes" />
+      </Component>
+      <Component Id="Index.h" Directory="_usr_include_clang_c" Guid="6a0cc957-3126-4736-96e5-5e985b6f5447">
+        <File Id="Index.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Index.h" Checksum="yes" />
+      </Component>
+      <Component Id="Platform.h" Directory="_usr_include_clang_c" Guid="935b862d-eb69-4854-a07c-7c651a0c1dbc">
+        <File Id="Platform.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Platform.h" Checksum="yes" />
+      </Component>
+      <Component Id="Refactor.h" Directory="_usr_include_clang_c" Guid="b85d459f-adff-4933-bf92-7ef921586628">
+        <File Id="Refactor.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Refactor.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="indexstore.h" Directory="_usr_include_indexstore" Guid="877c9471-aafb-4fd3-aa68-32c8c25bae61">
+        <File Id="indexstore.h" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\indexstore.h" Checksum="yes" />
+      </Component>
+      <Component Id="IndexStoreCXX.h" Directory="_usr_include_indexstore" Guid="222ac75d-2924-4231-b2b8-c79bbf08e808">
+        <File Id="IndexStoreCXX.h" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\IndexStoreCXX.h" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="clangDebugInfo">
+      <Component Id="clang_format.pdb" Directory="_usr_bin" Guid="6b56108f-8c47-4cd8-926f-007b46390438">
+        <File Id="clang_format.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+      <Component Id="clang_format.pdb" Directory="_usr_bin" Guid="6b98925e-e6e2-4c90-9ef2-e3dc3d0b2d8a">
+        <File Id="clang_tidy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+      <Component Id="clang.pdb" Directory="_usr_bin" Guid="1259c5a6-7418-4cd7-aab1-e6912c37b1e3">
+        <File Id="clang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+
+      <Component Id="libclang.pdb" Directory="_usr_bin" Guid="d2d21dac-e7cb-494f-96be-c271af6cd02b">
+        <File Id="libclang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+      <Component Id="libIndexStore.pdb" Directory="_usr_bin" Guid="2f709fd4-d6d6-4878-acdc-a2f7218d8888">
+        <File Id="libIndexStore.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="lld">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="ld.lld.exe" Directory="_usr_bin" Guid="95cf3aaa-c2dd-4550-be0d-263e53c9f9f7">
+        <File Id="ld.lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld.lld.exe" Checksum="yes" />
+      </Component>
+      <Component Id="ld64.lld.exe" Directory="_usr_bin" Guid="54fedbe7-546e-4ddb-aa54-39f2013e91ce">
+        <File Id="ld64.lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld64.lld.exe" Checksum="yes" />
+      </Component>
+      <Component Id="lld_link.exe" Directory="_usr_bin" Guid="cadf2f77-2431-4972-b8a2-0b57efbf645d">
+        <File Id="lld_link.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld-link.exe" Checksum="yes" />
+      </Component>
+      <Component Id="wasm_ld.exe" Directory="_usr_bin" Guid="2fc02e3b-9744-4924-abad-3dc197213dac">
+        <File Id="wasm_ld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\wasm-ld.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="lld.exe" Directory="_usr_bin" Guid="abb51281-5916-41c7-b658-d4d5bf12fe51">
+        <File Id="lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.exe" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="lldDebugInfo">
+      <Component Id="lld.pdb" Directory="_usr_bin" Guid="595a700f-b994-418d-8d14-b164e75abbdd">
+        <File Id="lld.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.pdb" Checksum="yes" DiskId="4" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="lldb">
+      <Component Id="lldb_server.exe" Directory="_usr_bin" Guid="ba62d5bb-5091-4d92-aa94-fed5357ec01e">
+        <File Id="lldb_server.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.exe" Checksum="yes" />
+      </Component>
+      <Component Id="lldb_vscode.exe" Directory="_usr_bin" Guid="5a2b97cf-8780-48d0-a137-2a461f688e00">
+        <File Id="lldb_vscode.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.exe" Checksum="yes" />
+      </Component>
+      <Component Id="lldb.exe" Directory="_usr_bin" Guid="73d088b4-9500-4927-b0c1-0cf6b46f8142">
+        <File Id="lldb.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.exe" Checksum="yes" />
+      </Component>
+      <Component Id="repl_swift.exe" Directory="_usr_bin" Guid="658e62a0-1cea-4916-83fc-02dd1d85e9ff">
+        <File Id="repl_swift.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\repl_swift.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="liblldb.dll" Directory="_usr_bin" Guid="9babcdfa-6855-4923-8648-54551f8513b7">
+        <File Id="liblldb.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="liblldb.lib" Directory="_usr_lib" Guid="eb51b68a-a527-4cee-a371-08ca63ef6a88">
+        <File Id="liblldb.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\liblldb.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="__init__.py_c31e016e2f8b4fba9eebd73d5009e919" Directory="_usr_lib_site_packages_lldb" Guid="c31e016e-2f8b-4fba-9eeb-d73d5009e919">
+        <File Id="___init__.py_c31e016e2f8b4fba9eebd73d5009e919" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\__init__.py" Checksum="yes" />
+      </Component>
+      <Component Id="_lldb.py" Directory="_usr_lib_site_packages_lldb" Guid="a234bc15-77e1-42b5-81a6-3a7416262d1f">
+        <File Id="_lldb.pyd" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\_lldb.pyd" Checksum="yes" />
+      </Component>
+      <Component Id="embedded_interpreter.py" Directory="_usr_lib_site_packages_lldb" Guid="b910189d-d22e-43a9-951a-033efe9e72fe">
+        <File Id="embedded_interpreter.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\embedded_interpreter.py" Checksum="yes" />
+      </Component>
+      <Component Id="lldb_argdumper.exe" Directory="_usr_lib_site_packages_lldb" Guid="3706feec-5b55-472d-89f6-0f2ccfa80834">
+        <File Id="lldb_argdumper.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\lldb-argdumper.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="logger.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="788726e1-dd3c-4721-ae4b-08e729102662">
+        <File Id="logger.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\Logger.py" Checksum="yes" />
+      </Component>
+      <Component Id="__init__.py_6124a6ee9e584275b153b0e1ddb4a2b2" Directory="_usr_lib_site_packages_lldb_formatters" Guid="6124a6ee-9e58-4275-b153-b0e1ddb4a2b2">
+        <File Id="___init__.py_6124a6ee9e584275b153b0e1ddb4a2b2" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\__init__.py" Checksum="yes" />
+      </Component>
+      <Component Id="attrib_fromdict.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="6324266f-1b6f-4c3b-8cdd-9e88da64c9ed">
+        <File Id="attrib_fromdict.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\attrib_fromdict.py" Checksum="yes" />
+      </Component>
+      <Component Id="cache.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="de68dfa7-9ca4-4119-9d19-0899ba134e4b">
+        <File Id="cache.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cache.py" Checksum="yes" />
+      </Component>
+      <Component Id="metrics.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="f5fbf56e-d395-459f-a6c9-fd932af0fb32">
+        <File Id="metrics.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\metrics.py" Checksum="yes" />
+      </Component>
+      <Component Id="synth.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="7bb6b96d-5190-4595-9422-329be9800426">
+        <File Id="synth.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\synth.py" Checksum="yes" />
+      </Component>
+
+      <Component Id="__init__.py_1bd1d2dc68b7417b83484f6183339af2" Directory="_usr_lib_site_packages_lldb_formatters_cpp" Guid="1bd1d2dc-68b7-417b-8348-4f6183339af2">
+        <File Id="___init__.py_1bd1d2dc68b7417b83484f6183339af2" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\__init__.py" Checksum="yes" />
+      </Component>
+      <Component Id="gnu_libstdcpp.py" Directory="_usr_lib_site_packages_lldb_formatters_cpp" Guid="c7b267dc-53a1-4639-8409-65ca9bd2f238">
+        <File Id="gnu_libstdcpp.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\gnu_libstdcpp.py" Checksum="yes" />
+      </Component>
+      <Component Id="libcxx.py" Directory="_usr_lib_site_packages_lldb_formatters_cpp" Guid="11041e50-1d58-4022-a5e8-5034bf0c3dbf">
+        <File Id="libcxx.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\libcxx.py" Checksum="yes" />
+      </Component>
+
+      <Component Id="__init__.py_52ef75ed702f4acc8272e6b2f8aa5392" Directory="_usr_lib_site_packages_lldb_utils" Guid="52ef75ed-702f-4acc-8272-e6b2f8aa5392">
+        <File Id="___init__.py_52ef75ed702f4acc8272e6b2f8aa5392" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\__init__.py" Checksum="yes" />
+      </Component>
+      <Component Id="in_call_stack.py" Directory="_usr_lib_site_packages_lldb_utils" Guid="41cfbf1f-0007-490b-aa41-85ba42e800a4">
+        <File Id="in_call_stack.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\in_call_stack.py" Checksum="yes" />
+      </Component>
+      <Component Id="symbolication.py" Directory="_usr_lib_site_packages_lldb_utils" Guid="1f3134e6-3b8b-47aa-9103-dfff71d9f953">
+        <File Id="symbolication.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\symbolication.py" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="lldbDebugInfo">
+      <Component Id="lldb_server.pdb" Directory="_usr_bin" Guid="e814828d-0b71-4e51-bf57-6227642787a2">
+        <File Id="lldb_server.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.pdb" Checksum="yes" DiskId="5" />
+      </Component>
+      <Component Id="lldb_vscode.pdb" Directory="_usr_bin" Guid="e960363f-5f04-4584-b69b-8c42d35f9b34">
+        <File Id="lldb_vscode.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.pdb" Checksum="yes" DiskId="5" />
+      </Component>
+      <Component Id="lldb.pdb" Directory="_usr_bin" Guid="b64e3b50-55b7-472c-bf87-961b46757f94">
+        <File Id="lldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.pdb" Checksum="yes" DiskId="5" />
+      </Component>
+
+      <Component Id="liblldb.pdb" Directory="_usr_bin" Guid="b096068d-1b6d-4a53-a544-d718ac4b289a">
+        <File Id="liblldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.pdb" Checksum="yes" DiskId="5" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="BlocksRuntime">
+      <Component Id="BlocksRuntime.dll" Directory="_usr_bin" Guid="e170a9fa-d4e3-4b1a-9308-1bb9383fe771">
+        <File Id="BlocksRuntime.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
+      </Component>
+
+      <!-- TODO(compnerd) should we install the block headers and import libraries? -->
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="BlocksRuntimeDebugInfo">
+      <Component Id="BlocksRuntime.pdb" Directory="_usr_bin" Guid="6cb091fb-0aae-40d8-9e83-fb79bce9e592">
+        <File Id="BlocksRuntime.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="dispatch">
+      <Component Id="dispatch.dll" Directory="_usr_bin" Guid="27c600e2-40be-44a5-9089-76d9e6021b51">
+        <File Id="dispatch.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
+      </Component>
+
+      <!-- TODO(compnerd) should we install the dispatch headers and import libraries? -->
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="dispatchDebugInfo">
+      <Component Id="dispatch.pdb" Directory="_usr_bin" Guid="64524656-4b87-42f9-9e5b-50ed8c4e0315">
+        <File Id="dispatch.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="7" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SourceKit">
+      <Component Id="sourcekitdInProc.dll" Directory="_usr_bin" Guid="6d8cfa8d-a4eb-40b3-af29-afb80997494a">
+        <File Id="sourcekitdInProc.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="sourcekitd.h" Directory="_usr_include_SourceKit" Guid="bdb02d6c-b3f7-4109-bd41-fc04734484a4">
         <File Id="sourcekitd.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\SourceKit\sourcekitd.h" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
 
-    <DirectoryRef Id="_usr_lib_swift_migrator">
-      <Component Id="SwiftMigratorData" Guid="0d2c2da1-0634-4b6b-9f15-29f11995cb31">
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SourceKitDebugInfo">
+      <Component Id="sourcekitdInProc.pdb" Directory="_usr_bin" Guid="36e02ecc-48ce-4401-9e6d-4d8a54da8cdb">
+        <File Id="sourcekitdInProc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.pdb" Checksum="yes" DiskId="8" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="swift">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="swift_autolink_extract.exe" Directory="_usr_bin" Guid="26c29024-5fb1-4aed-8150-c1bfa271f469">
+        <File Id="swift_autolink_extract.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-autolink-extract.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_demangle.exe" Directory="_usr_bin" Guid="8c42f286-7ddf-4637-ad4b-18e6904bc006">
+        <File Id="swift_demangle.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_frontend.exe" Directory="_usr_bin" Guid="db33309e-2c2c-478a-9cb4-cd207f214167">
+        <File Id="swift_frontend.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDemangle.dll" Directory="_usr_bin" Guid="eec5bb03-9cf2-4823-99c7-b0a8beaf7f77">
+        <File Id="swiftDemangle.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.dll" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftScan.dll" Directory="_usr_bin" Guid="005fd33d-c5b9-4897-a467-57023dc7283a">
+        <File Id="_InternalSwiftScan.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.dll" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftSyntaxParser.dll" Directory="_usr_bin" Guid="c1671803-38a2-425e-9413-b3dcdcd5bdaf">
+        <File Id="_InternalSwiftSyntaxParser.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDemangle.lib" Directory="_usr_lib" Guid="65907d9f-5762-459f-9afb-321b6956102e">
+        <File Id="swiftDemangle.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swiftDemangle.lib" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftScan.lib" Directory="_usr_lib" Guid="4ea85284-8be7-4841-b808-8f4b210f9152">
+        <File Id="_InternalSwiftScan.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftScan.lib" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftSyntaxParser.lib" Directory="_usr_lib" Guid="cdf81ee6-a0ec-40ac-b275-58811b0e0ecd">
+        <File Id="_InternalSwiftSyntaxParser.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftSyntaxParser.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="SwiftSyntaxParser.h" Directory="_usr_include__InternalSwiftSyntaxParser" Guid="a5ce3a92-310b-437f-9167-967fbcc83f93">
+        <File Id="SwiftSyntaxParser.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxParser.h" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftSyntaxCDataTypes.h" Directory="_usr_include__InternalSwiftSyntaxParser" Guid="66f3b179-8fa2-4388-9d42-dfb97c7d434e">
+        <File Id="SwiftSyntaxCDataTypes.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxCDataTypes.h" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftSyntaxParser.modulemap" Directory="_usr_include__InternalSwiftSyntaxParser" Guid="05effc98-9cba-4513-bab8-84a40a806684">
+        <File Id="_InternalSwiftSyntaxParser.modulemap" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\module.modulemap" Checksum="yes" />
+      </Component>
+
+      <Component Id="DependencyScan.h" Directory="_usr_include__InternalSwiftScan" Guid="44c94a09-383d-4493-9918-347db8cccdc0">
+        <File Id="DependencyScan.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScan.h" Checksum="yes" />
+      </Component>
+      <Component Id="DependencyScanMacros.h" Directory="_usr_include__InternalSwiftScan" Guid="340f436f-bdf9-4240-8051-5fd335603abf">
+        <File Id="DependencyScanMacros.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScanMacros.h" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftScan.modulemap" Directory="_usr_include__InternalSwiftScan" Guid="1aed210d-a34a-492e-b570-3e0cf95b653c">
+        <File Id="_InternalSwiftScan.modulemap" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\module.modulemap" Checksum="yes" />
+      </Component>
+
+      <Component Id="ios4.json" Directory="_usr_lib_swift_migrator" Guid="86db2678-9f8b-446e-bfbc-eb45e725420e">
         <File Id="ios4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\ios4.json" Checksum="yes" />
+      </Component>
+      <Component Id="ios42.json" Directory="_usr_lib_swift_migrator" Guid="06aa6c34-82b1-47a6-8e92-eca9b580df63">
         <File Id="ios42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\ios42.json" Checksum="yes" />
+      </Component>
+      <Component Id="macos4.json" Directory="_usr_lib_swift_migrator" Guid="11d63a03-6e6d-4ed3-bc9e-7523317dd405">
         <File Id="macos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\macos4.json" Checksum="yes" />
+      </Component>
+      <Component Id="macos42.json" Directory="_usr_lib_swift_migrator" Guid="09e60396-323c-4386-8173-adddea96e825">
         <File Id="macos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\macos42.json" Checksum="yes" />
-        <File Id="overlay4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay4.json" Checksum="yes" />
+      </Component>
+      <Component Id="ovarlay4.json" Directory="_usr_lib_swift_migrator" Guid="a2e5710c-a524-4df1-a093-3aa652ab15c0">
+        <File Id="ovarlay4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay4.json" Checksum="yes" />
+      </Component>
+      <Component Id="overlay42.json" Directory="_usr_lib_swift_migrator" Guid="1fd63a8d-1fa6-4887-a291-6f70dd4fc677">
         <File Id="overlay42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay42.json" Checksum="yes" />
+      </Component>
+      <Component Id="tvos4.json" Directory="_usr_lib_swift_migrator" Guid="e93f55cd-ebcf-4a5c-8937-454ad915d832">
         <File Id="tvos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\tvos4.json" Checksum="yes" />
+      </Component>
+      <Component Id="tvos42.json" Directory="_usr_lib_swift_migrator" Guid="0b0e2f6f-e87d-4735-9a63-6472965575ea">
         <File Id="tvos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\tvos42.json" Checksum="yes" />
+      </Component>
+      <Component Id="watchos4.json" Directory="_usr_lib_swift_migrator" Guid="8caa03fe-b523-482f-819d-f49fb8a7d068">
         <File Id="watchos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos4.json" Checksum="yes" />
+      </Component>
+      <Component Id="watchos42.json" Directory="_usr_lib_swift_migrator" Guid="0b221d02-2fed-416e-89d2-b18b9c10d662">
         <File Id="watchos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos42.json" Checksum="yes" />
       </Component>
-    </DirectoryRef>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="swiftDebugInfo">
+      <Component Id="swift_demangle.pdb" Directory="_usr_bin" Guid="30250a78-68ca-414b-8717-135b4c87ee83">
+        <File Id="swift_demangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+      <Component Id="swift_frontend.pdb" Directory="_usr_bin" Guid="b01ae108-aa02-45a4-b751-497934842385">
+        <File Id="swift_frontend.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+
+      <Component Id="swiftDemangle.pdb" Directory="_usr_bin" Guid="ab2ef973-8ae1-4b2b-87db-62a81f2da8d7">
+        <File Id="swiftDemangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+      <Component Id="_InternalSwiftScan.pdb" Directory="_usr_bin" Guid="2321b5d4-fa60-495e-b275-3f0713c35278">
+        <File Id="_InternalSwiftScan.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+      <Component Id="_InternalSwiftSyntaxParser.pdb" Directory="_usr_bin" Guid="363ff271-f7ab-4912-9d91-c29709f267a9">
+        <File Id="_InternalSwiftSyntaxParser.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="llbuild">
+      <Component Id="swift_build_tool.exe" Directory="_usr_bin" Guid="f7f3b232-a07f-4bc2-9cf5-323060b9fd91">
+        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="llbuild.dll" Directory="_usr_bin" Guid="f140cd98-63b5-4b62-8990-36e2b66569d4">
+        <File Id="llbuild.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.dll" Checksum="yes" />
+      </Component>
+      <Component Id="llbuildSwift.dll" Directory="_usr_bin" Guid="4386ca67-150b-424f-a699-7029f41746d5">
+        <File Id="llbuildSwift.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="BlocksRuntime.lib" Directory="_usr_lib" Guid="b758a96a-644b-421d-a668-2ba2b55601aa">
+        <File Id="BlocksRuntime.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\BlocksRuntime.lib" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.lib" Directory="_usr_lib" Guid="b5d342d2-fc9a-46e5-93ac-1781e2055ac4">
+        <File Id="dispatch.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\dispatch.lib" Checksum="yes" />
+      </Component>
+      <Component Id="sourcekitdInProc.lib" Directory="_usr_lib" Guid="cd564210-c471-478e-b1c4-d6a35fc6572f">
+        <File Id="sourcekitdInProc.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\sourcekitdInProc.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="llbuildDebugInfo">
+      <Component Id="swift_build_tool.pdb" Directory="_usr_bin" Guid="731d2652-2a1f-45ad-904d-b51c9ae8d46a">
+        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" DiskId="10" />
+      </Component>
+
+      <Component Id="llbuild.pdb" Directory="_usr_bin" Guid="a94f8dc8-8148-4cf1-9d3d-6d55e1d332bb">
+        <File Id="llbuild.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.pdb" Checksum="yes" DiskId="10" />
+      </Component>
+      <Component Id="llbuildSwift.pdb" Directory="_usr_bin" Guid="7a0a4f52-344f-41cc-bd9a-266af3afbc84">
+        <File Id="llbuildSwift.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" DiskId="10" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftArgumentParser">
+      <Component Id="ArgumentParser.dll" Directory="_usr_bin" Guid="f8dc1ec7-d2bc-418c-8d70-310722b1a09c">
+        <File Id="ArgumentParser.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
+      </Component>
+      <Component Id="ArgumentParserToolInfo.dll" Directory="_usr_bin" Guid="f03f2fb9-9650-4ff8-b2c3-0e3d3296d3fa">
+        <File Id="ArgumentParserToolInfo.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftArgumentParserDebugInfo">
+      <Component Id="ArgumentParser.pdb" Directory="_usr_bin" Guid="6901fb07-e566-43b8-b5f4-3438debc623e">
+        <File Id="ArgumentParser.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" DiskId="11" />
+      </Component>
+      <Component Id="ArgumentParserToolInfo.pdb" Directory="_usr_bin" Guid="0492a335-d529-4fb4-a81c-2609d9e55898">
+        <File Id="ArgumentParserToolInfo.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.pdb" Checksum="yes" DiskId="11" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftToolsSupportCore">
+      <Component Id="TSCBasic.dll" Directory="_usr_bin" Guid="62c1421e-781b-4ffb-b11d-9d4f2a5bafa5">
+        <File Id="TSCBasic.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" Checksum="yes" />
+      </Component>
+      <Component Id="TSCLibc.dll" Directory="_usr_bin" Guid="a144d9e1-d665-48f8-a79a-cededb67b323">
+        <File Id="TSCLibc.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.dll" Checksum="yes" />
+      </Component>
+      <Component Id="TSCUtility.dll" Directory="_usr_bin" Guid="beebdc9b-09e6-4608-808b-a6d8b211d102">
+        <File Id="TSCUtility.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftToolsSupportCoreDebugInfo">
+      <Component Id="TSCBasic.pdb" Directory="_usr_bin" Guid="002d49f9-4322-4513-9a2f-36842423b676">
+        <File Id="TSCBasic.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" DiskId="12" />
+      </Component>
+      <Component Id="TSCLibc.pdb" Directory="_usr_bin" Guid="32773528-e1ba-451b-af9f-ecb7f3647e22">
+        <File Id="TSCLibc.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.pdb" Checksum="yes" DiskId="12" />
+      </Component>
+      <Component Id="TSCUtility.pdb" Directory="_usr_bin" Guid="62e56d7b-d2fa-4950-a876-2f7f23a6726a">
+        <File Id="TSCUtility.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" DiskId="12" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="Yams">
+      <Component Id="Yams.dll" Directory="_usr_bin" Guid="ddaf995c-a415-457f-a6d2-8721658cf18a">
+        <File Id="Yams.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="YamsDebugInfo">
+      <Component Id="Yams.pdb" Directory="_usr_bin" Guid="20e45503-ba75-4eff-a275-4f94ac6526b0">
+        <File Id="Yams.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" DiskId="13" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftDriver">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="swiftc.exe" Directory="_usr_bin" Guid="6a62153c-754c-4634-a072-403538b77404">
+        <File Id="swiftc.exe" Name="swiftc.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift.exe" Directory="_usr_bin" Guid="50db9b0e-f3f8-41b4-b356-d089f737497d">
+        <File Id="swift.exe" Name="swift.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_help.exe" Directory="_usr_bin" Guid="80beb165-26ad-42e1-8a14-2afa96941297">
+        <File Id="swift_help.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-help.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_build_sdk_interfaces.exe" Directory="_usr_bin" Guid="32a319b9-0aa9-4b4b-a174-e78820c77584">
+        <File Id="swift_build_sdk_interfaces.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-sdk-interfaces.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftOptions.dll" Directory="_usr_bin" Guid="36d6487d-3e15-43d1-b2e8-d24eeb470a7d">
+        <File Id="SwiftOptions.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDriver.dll" Directory="_usr_bin" Guid="415f3e47-a5fd-4652-9361-fff7e6e3e379">
+        <File Id="SwiftDriver.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDriverExecution.dll" Directory="_usr_bin" Guid="d0f36d77-c647-4897-9a81-b302ce1429e4">
+        <File Id="SwiftDriverExecution.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriverExecution.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftDriverDebugInfo">
+      <Component Id="swift.pdb" Directory="_usr_bin" Guid="b14f75f3-cd32-469b-b442-b2f62090cec3">
+        <File Id="swift.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+      <Component Id="swift_help.pdb" Directory="_usr_bin" Guid="02a7aa71-d30b-4fe7-9518-aa7ab9533652">
+        <File Id="swift_help.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-help.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+      <Component Id="swift_build_sdk_interfaces.pdb" Directory="_usr_bin" Guid="e9cdfc86-ae01-4967-a17d-c55ee1486f15">
+        <File Id="swift_build_sdk_interfaces.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-build-sdk-interfaces.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+
+      <Component Id="SwiftOptions.pdb" Directory="_usr_bin" Guid="86ba07e2-3271-4c17-9465-e4515ff7669b">
+        <File Id="SwiftOptions.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+      <Component Id="SwiftDriver.pdb" Directory="_usr_bin" Guid="61588fa0-87c2-4d16-8995-12090e9e8924">
+        <File Id="SwiftDriver.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+      <Component Id="SwiftDriverExecution.pdb" Directory="_usr_bin" Guid="1d28c854-ebc9-49ac-a62b-b44f37d1a617">
+        <File Id="SwiftDriverExecution.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="EnvironmentVariables" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
@@ -466,38 +797,44 @@
       </Component>
     </DirectoryRef>
 
-    <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows x86_64" Level="1" Title="Swift Toolchain for Windows x86_64">
-      <ComponentRef Id="Toolchain" />
-      <ComponentRef Id="ToolchainLibraries" />
-      <!--
-      <ComponentRef Id="BlockRuntimeHeaders" />
-      -->
-      <ComponentRef Id="_InternalSwiftSyntaxParserHeaders" />
-      <ComponentRef Id="_InternalSwiftScanHeaders" />
-      <ComponentRef Id="IndexStoreHeaders" />
-      <ComponentRef Id="libclangHeader" />
-      <ComponentRef Id="LTOHeaders" />
-      <!--
-      <ComponentRef Id="DispatchHeaders" />
-      <ComponentRef Id="DispatchOSHeaders" />
-      -->
-      <ComponentRef Id="SourceKitHeaders" />
-      <ComponentRef Id="SwiftMigratorData" />
+    <Feature Id="Toolchain" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows x86_64" Level="1" Title="Swift Toolchain for Windows x86_64">
+      <ComponentGroupRef Id="binutils" />
+      <ComponentGroupRef Id="clang" />
+      <ComponentGroupRef Id="lld" />
+      <ComponentGroupRef Id="lldb" />
+      <ComponentGroupRef Id="BlocksRuntime" />
+      <ComponentGroupRef Id="dispatch" />
+      <ComponentGroupRef Id="SourceKit" />
+      <ComponentGroupRef Id="swift" />
+      <ComponentGroupRef Id="llbuild" />
+      <ComponentGroupRef Id="SwiftArgumentParser" />
+      <ComponentGroupRef Id="SwiftToolsSupportCore" />
+      <ComponentGroupRef Id="Yams" />
+      <ComponentGroupRef Id="SwiftDriver" />
+
       <ComponentGroupRef Id="ClangResources" />
       <!--
       <ComponentGroupRef Id="SwiftShims" />
       -->
-      <ComponentRef Id="LLDBPythonScripts" />
-      <ComponentRef Id="LLDBFormatters" />
-      <ComponentRef Id="LLDBFormattersCPP" />
-      <ComponentRef Id="LLDBUtils" />
 
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows x86_64" Level="0" Title="Debug Information">
         <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-        <ComponentRef Id="ToolchainDebugInfo" />
+        <ComponentGroupRef Id="binutilsDebugInfo" />
+        <ComponentGroupRef Id="clangDebugInfo" />
+        <ComponentGroupRef Id="lldDebugInfo" />
+        <ComponentGroupRef Id="lldbDebugInfo" />
+        <ComponentGroupRef Id="BlocksRuntimeDebugInfo" />
+        <ComponentGroupRef Id="dispatchDebugInfo" />
+        <ComponentGroupRef Id="SourceKitDebugInfo" />
+        <ComponentGroupRef Id="swiftDebugInfo" />
+        <ComponentGroupRef Id="llbuildDebugInfo" />
+        <ComponentGroupRef Id="SwiftArgumentParserDebugInfo" />
+        <ComponentGroupRef Id="SwiftToolsSupportCoreDebugInfo" />
+        <ComponentGroupRef Id="YamsDebugInfo" />
+        <ComponentGroupRef Id="SwiftDriverDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>

--- a/platforms/Windows/toolchain.wxs
+++ b/platforms/Windows/toolchain.wxs
@@ -91,6 +91,8 @@
                 <Directory Id="_usr_libexec" Name="libexec">
                 </Directory>
                 <Directory Id="_usr_share" Name="share">
+                  <Directory Id="_usr_share_swift" Name="swift">
+                  </Directory>
                 </Directory>
               </Directory>
             </Directory>
@@ -623,6 +625,10 @@
       </Component>
       <Component Id="watchos42.json" Directory="_usr_lib_swift_migrator" Guid="0b221d02-2fed-416e-89d2-b18b9c10d662">
         <File Id="watchos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos42.json" Checksum="yes" />
+      </Component>
+
+      <Component Id="features.json" Directory="_usr_share_swift" Guid="bee4269c-afab-431d-b32e-39cdfec6c5be">
+        <File Id="features.json" Source="$(var.TOOLCHAIN_ROOT)\usr\share\swift\features.json" Checksum="yes" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
Update the 5.7 installer manifest to match the current main version.  This is primarily cleaning up the structural issues in the MSI which helps with MSI/bootstrapper sizing as well as packages up missing items.  The custom action is made more aggressive for updates as well.