### PR TITLE
WiX: remove extraneous architecture in search path

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -62,33 +62,33 @@
                           <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
                           </Directory>
                           <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                            </Directory>
+                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                            </Directory>
+                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                            </Directory>
+                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                            </Directory>
+                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                            </Directory>
+                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                            </Directory>
+                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                            </Directory>
+                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                            </Directory>
+                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                            </Directory>
+                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                            </Directory>
+                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                            </Directory>
                             <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
-                              <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                              </Directory>
-                              <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                              </Directory>
-                              <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                              </Directory>
-                              <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                              </Directory>
-                              <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                              </Directory>
-                              <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                              </Directory>
-                              <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                              </Directory>
-                              <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                              </Directory>
-                              <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                              </Directory>
-                              <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                              </Directory>
-                              <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                              </Directory>
-                              <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                              </Directory>
-                              <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                              </Directory>
                             </Directory>
                           </Directory>
                         </Directory>

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -62,33 +62,33 @@
                           <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
                           </Directory>
                           <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                            </Directory>
+                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                            </Directory>
+                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                            </Directory>
+                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                            </Directory>
+                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                            </Directory>
+                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                            </Directory>
+                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                            </Directory>
+                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                            </Directory>
+                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                            </Directory>
+                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                            </Directory>
+                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                            </Directory>
                             <Directory Id="WindowsSDK_usr_lib_swift_windows_i686" Name="i686">
-                              <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                              </Directory>
-                              <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                              </Directory>
-                              <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                              </Directory>
-                              <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                              </Directory>
-                              <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                              </Directory>
-                              <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                              </Directory>
-                              <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                              </Directory>
-                              <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                              </Directory>
-                              <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                              </Directory>
-                              <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                              </Directory>
-                              <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                              </Directory>
-                              <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                              </Directory>
-                              <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                              </Directory>
                             </Directory>
                           </Directory>
                         </Directory>


### PR DESCRIPTION
Adjust the location of the swift modules to overlap across SDKs.  The
directory form of the swift module can easily overlap and co-exist.  Now
that the driver has learnt to scan the non-architecture dependent location
in addition to the architecture location dependent path, we can unify
the swiftmodule content in the SDK to a simpler layout.  The layout now
is:

~~~
SDKROOT
  `- usr
      `- lib
          `- swift
              `- [platform]
                  +- [module].swiftmodule
                  |   `- [triple].{swiftdoc,swiftmodule,swiftinterface}
                  `- [arch]
                      `- [import library]
~~~

On Windows, it would be preferable to further remove the intermediate
platform as we have that information earlier in the path.

Subsequent work remains to now ensure that the package manager will
similarly allow the XCTest swift modules to collapse.

While in theory it is possible to create a multi-architecture import
library, it is valuable to support user-selectable SDK installation
which requires that the we create the import libraries on the fly for
the selected architectures.  It is more convenient from a distribution
perspective to simply make the content static and as such continue to
use the architect dependent directory for the import library unlike the
swift module.

This is dependent on apple/swift#42419.