### PR TITLE
WiX: add Windows SDK packaging manifest for ARM64

### DIFF
--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Runtime for Windows aarch64" UpgradeCode="bea8c6dc-f73e-445b-9486-2333d1cf2886" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Runtime for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+
+    <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
+    <?endif?>
+
+    <!-- Directory Structure -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="INSTALLDIR">
+        <!-- TODO(compnerd) use $(var.ProductVersion) -->
+        <Directory Id="_" Name="runtime-development">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin">
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift">
+      NOT INSTALLDIR
+    </SetDirectory>
+
+    <!-- Components -->
+    <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">
+      <Component Id="BlocksRuntime.dll" Guid="5040be00-a175-4813-81d4-ef77a4c7a01c">
+        <File Id="BlocksRuntime.dll" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.dll" Guid="48d9a273-cf10-46aa-a902-f32abce68198">
+        <File Id="dispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Foundation.dll" Guid="91eab4aa-865d-41e3-ac7c-9153aec3e271">
+        <File Id="Foundation.dll" Source="$(var.SDK_ROOT)\usr\bin\Foundation.dll" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationNetworking.dll" Guid="efa0addb-a974-4adf-b452-ec0a0f278e44">
+        <File Id="FoundationNetworking.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.dll" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationXML.dll" Guid="959fd680-b5b7-4c1d-bdd2-6c019a611874">
+        <File Id="FoundationXML.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_Concurrency.dll" Guid="67373728-5a66-401f-b62d-dc7ced8b87e8">
+        <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_Differentiation.dll" Guid="ba696988-87b4-41da-aaea-949602e86758">
+        <File Id="swift_Differentiation.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDistributed.dll" Guid="8cc487d0-0fb7-45c1-a900-50ba929f6711">
+        <File Id="swiftDistributed.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_RegexParser.dll" Guid="20f67580-0116-4e77-8670-65fec75abacb">
+        <File Id="swift_RegexParser.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swift_StringProcessing.dll" Guid="0e0dc47f-1e80-4ed1-8ee9-7de8139086ed">
+        <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftCore.dll" Guid="b11c37b0-b6ad-4e55-b4e7-0517ff7a161f">
+        <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDispatch.dll" Guid="ce50982a-4bb3-43fc-a5ce-9fc709143b47">
+        <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
+      </Component>
+      <!--
+      <Component Id="swiftDemangle.dll" Guid="160fec66-5211-45e8-aaed-6e5d7c7608f3">
+        <File Id="swiftDemangle.dll" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" />
+      </Component>
+      -->
+      <Component Id="swiftCRT.dll" Guid="8588d340-2466-4c38-a22e-ed4bb89cdf25">
+        <File Id="swiftCRT.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftRemoteMirror.dll" Guid="a9e05463-5af6-41ad-8a31-01da624d3b7a">
+        <File Id="swiftRemoteMirror.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftSwiftOnoneSupport.dll" Guid="771925a8-e5fd-4dc9-92d0-d6952c15c181">
+        <File Id="swiftSwiftOnoneSupport.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftWinSDK.dll" Guid="78df14d6-2f0d-4ee1-ad1e-f0c0521565e0">
+        <File Id="swiftWinSDK.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="SwiftUtilities" Directory="_usr_bin">
+      <Component Id="plutil.exe" Guid="b96bf921-fbad-4d1b-9559-38707605de06">
+        <File Id="plutil.exe" Source="$(var.SDK_ROOT)\usr\bin\plutil.exe" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftRuntimeDebugInfo">
+      <Component Id="BlocksRuntime.pdb" Guid="78e0a44c-7d34-4e87-962c-4bcc23f07a38">
+        <File Id="BlocksRuntime.pdb" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="dispatch.pdb" Guid="bc475b8b-81e4-48d4-a73d-ddb2ca47662e">
+        <File Id="dispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="Foundation.pdb" Guid="16f10b41-575a-4d75-a77d-4d7dbc9c6504">
+        <File Id="Foundation.pdb" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="FoundationNetworking.pdb" Guid="e2f4bc80-b6e8-4589-9fd4-cc1d58011f43">
+        <File Id="FoundationNetworking.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="FoundationXML.pdb" Guid="3c442778-665e-4060-88db-31af4b4255ba">
+        <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_Concurrency.pdb" Guid="6a14736b-be12-4618-bded-aa56a79003c3">
+        <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_Differentiation.pdb" Guid="8c274a2a-2d55-4007-8141-3952b85a4de0">
+        <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftDistributed.pdb" Guid="47bd82d8-3949-4b3e-830a-fa3ec8f61672">
+        <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_RegexParser.pdb" Guid="0575b1c6-fa5e-4db8-ac05-2a048054d9c6">
+        <File Id="swift_RegexParser.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swift_StringProcessing.pdb" Guid="6fd2d711-4452-4aca-91c0-34e240bcc2d0">
+        <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCore.pdb" Guid="ba858ada-58f6-499d-a9f3-fdad7e858e15">
+        <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftDispatch.pdb" Guid="3a9c9745-99bb-42c8-9a6d-1da25c0365e0">
+        <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <!--
+      <Component Id="swiftDemangle.pdb" Guid="01d707b8-4ce3-4fb7-a694-a71d56b0d779">
+        <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      -->
+      <Component Id="swiftCRT.pdb" Guid="3295a0ed-3e2b-4c5e-9cc6-8e99d3acc50c">
+        <File Id="swiftCRT.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftRemoteMirror.pdb" Guid="9993ed62-00d1-4f44-bda1-c9b9a9df60d2">
+        <File Id="swiftRemoteMirror.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftSwiftOnoneSupport.pdb" Guid="cb55867e-8bff-4961-b064-199b91a9e134">
+        <File Id="swiftSwiftOnoneSupport.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftWinSDK.pdb" Guid="15661f62-a003-41eb-ba01-4999ce9540cb">
+        <File Id="swiftWinSDK.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="SwiftUtilitiesDebugInfo">
+      <Component Id="plutil.pdb" Guid="e882f817-4ede-4720-85d6-ff54d5ca1f75">
+        <File Id="plutil.pdb" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="EnvironmentVariables" Guid="8681d813-eb32-46f9-8b1c-f622b38b5eaf">
+        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
+      </Component>
+    </DirectoryRef>
+
+    <!-- Feature -->
+    <Feature Id="WinARM64SwiftRuntime" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows aarch64" Level="1" Title="Swift Runtime for Windows aarch64">
+      <ComponentGroupRef Id="SwiftRuntime" />
+      <ComponentRef Id="EnvironmentVariables" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows aarch64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentGroupRef Id="SwiftRuntimeDebugInfo" />
+      </Feature>
+      <?endif?>
+    </Feature>
+
+    <Feature Id="WinARM64SwiftUtilities" Absent="allow" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows aarch64" Level="1" Title="Swift Utilities for Windows aarch64">
+      <ComponentGroupRef Id="SwiftUtilities" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows aarch64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentRef Id="SwiftUtilitiesDebugInfo" />
+      </Feature>
+      <?endif?>
+    </Feature>
+
+    <!-- UI -->
+    <UI />
+  </Product>
+</Wix>

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -1,0 +1,523 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift SDK for Windows aarch64" UpgradeCode="4c37a396-d9e2-490a-89b7-0a3d271d847f" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift SDK for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+
+    <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
+    <?endif?>
+
+    <!-- Directory Structure -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="DeveloperPlatforms" Name="Platforms">
+            <Directory Id="WindowsPlatform" Name="Windows.platform">
+              <Directory Id="WindowsPlatform_Developer" Name="Developer">
+                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+
+                  <!-- XCTest -->
+                  <!--
+                    FIXME(compnerd) this should actually be the proper version
+                    of XCTest, and needs to be reflected in the plist as well.
+                  -->
+                  <Directory Id="XCTest" Name="XCTest-development">
+                    <Directory Id="XCTest_usr" Name="usr">
+                      <Directory Id="XCTest_usr_bin64a" Name="bin64a">
+                      </Directory>
+                      <Directory Id="XCTest_usr_lib" Name="lib">
+                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="XCTest_usr_lib_swift_windows_aarch64" Name="aarch64">
+                              <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                              </Directory>
+                            </Directory>
+                          </Directory>
+                        </Directory>
+                      </Directory>
+                    </Directory>
+                  </Directory>
+                </Directory>
+
+                <Directory Id="SDKs" Name="SDKs">
+
+                  <!-- Windows.sdk -->
+                  <Directory Id="WindowsSDK" Name="Windows.sdk">
+                    <Directory Id="WindowsSDK_usr" Name="usr">
+                      <Directory Id="WindowsSDK_usr_include" Name="include">
+                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                          </Directory>
+                        </Directory>
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                            </Directory>
+                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                            </Directory>
+                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                            </Directory>
+                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                            </Directory>
+                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                            </Directory>
+                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                            </Directory>
+                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                            </Directory>
+                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                            </Directory>
+                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                            </Directory>
+                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                            </Directory>
+                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                            </Directory>
+                            <Directory Id="WindowsSDK_usr_lib_swift_windows_aarch64" Name="aarch64">
+                            </Directory>
+                          </Directory>
+                        </Directory>
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_share" Name="share">
+                      </Directory>
+                    </Directory>
+                  </Directory>
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
+      NOT INSTALLDIR
+    </SetDirectory>
+
+    <!-- Components -->
+    <ComponentGroup Id="XCTest">
+      <Component Id="XCTest.dll" Directory="XCTest_usr_bin64a" Guid="1a0dd34e-71eb-4441-af98-fed53631e34d">
+        <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
+      </Component>
+      <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_aarch64" Guid="bce787dd-393e-4285-aa81-448557385d40">
+        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
+      </Component>
+      <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="b2b83f97-6639-4b7b-8d32-2396463dfe71">
+        <File Id="XCTest.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\aarch64\XCTest.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="XCTest.swiftmodule" Directory="XCTest.swiftmodule" Guid="51ce13c0-ca04-4ee4-bb72-c0804cbbe405">
+        <File Id="XCTest.swiftmodule" Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\aarch64\XCTest.swiftmodule" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="XCTestDebugInfo">
+      <Component Id="XCTest.pdb" Directory="XCTest_usr_bin64a" Guid="92e52a04-6193-4a0f-bd4d-8ae3c30a2901">
+        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftRemoteMirror">
+      <Component Id="MemoryReaderInterface.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="4493ba7f-b3b3-4cb3-b645-6457e81ad752">
+        <File Id="MemoryReaderInterface.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\MemoryReaderInterface.h" Checksum="yes" />
+      </Component>
+      <Component Id="Platform.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="61384dc6-be9c-42cd-847b-fb94617fcab1">
+        <File Id="Platform.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\Platform.h" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftRemoteMirror.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="bcc781b4-94ea-4ae6-aa1e-e26e62f04e10">
+        <File Id="SwiftRemoteMirror.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirror.h" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftRemoteMirrorTypes.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="c15a0af1-e521-4ffc-845b-4f7176db4e2c">
+        <File Id="SwiftRemoteMirrorTypes.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftRemoteMirror.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="10f6539b-f57e-46ca-9d51-9f44b6a71b24">
+        <File Id="swiftRemoteMirror.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftRemoteMirror.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="BlocksRuntime">
+      <Component Id="Block.h" Directory="WindowsSDK_usr_include_Block" Guid="46ea8477-b407-41ac-a3ea-d6db791524d9">
+        <File Id="Block.h_46ea8477b40741aca3ead6db791524d9" Source="$(var.SDK_ROOT)\usr\lib\swift\Block\Block.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="BlocksRuntime.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="56c2dd37-f759-4402-93ed-e29af91da0dc">
+        <File Id="BlocksRuntime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="dispatch">
+      <Component Id="base.h" Directory="WindowsSDK_usr_include_dispatch" Guid="a263a074-5bc5-4823-95a9-f91a314b6cf0">
+        <File Id="base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\base.h" Checksum="yes" />
+      </Component>
+      <Component Id="block.h" Directory="WindowsSDK_usr_include_dispatch" Guid="3629b098-826c-4d98-89a7-b486160dddfa">
+        <File Id="block.h_3629b098826c4d9889a7b486160dddfa" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\block.h" Checksum="yes" />
+      </Component>
+      <Component Id="data.h" Directory="WindowsSDK_usr_include_dispatch" Guid="1d9bb083-bb0e-46de-b82b-b582c55df716">
+        <File Id="data.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\data.h" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.h" Directory="WindowsSDK_usr_include_dispatch" Guid="a4e8a91e-b54b-485e-8f47-83e23bb435b3">
+        <File Id="dispatch.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" Checksum="yes" />
+      </Component>
+      <Component Id="group.h" Directory="WindowsSDK_usr_include_dispatch" Guid="6a992ce8-127a-4826-87fc-009e3666c980">
+        <File Id="group.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\group.h" Checksum="yes" />
+      </Component>
+      <Component Id="introspection.h" Directory="WindowsSDK_usr_include_dispatch" Guid="1177a222-a855-495e-bb4c-40b58bf2a72f">
+        <File Id="introspection.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" Checksum="yes" />
+      </Component>
+      <Component Id="io.h" Directory="WindowsSDK_usr_include_dispatch" Guid="4cbd900b-ea17-42d0-ad01-555e64203e34">
+        <File Id="io.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\io.h" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.modulemap" Directory="WindowsSDK_usr_include_dispatch" Guid="29d12456-9a40-47a8-9f0c-328e27ea9921">
+        <File Id="dispatch.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="object.h_f87c5a369294493489839a2cabdb7ae7" Directory="WindowsSDK_usr_include_dispatch" Guid="f87c5a36-9294-4934-8983-9a2cabdb7ae7">
+        <File Id="object.h_f87c5a369294493489839a2cabdb7ae7" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\object.h" Checksum="yes" />
+      </Component>
+      <Component Id="once.h" Directory="WindowsSDK_usr_include_dispatch" Guid="24c2b93d-8912-4cc7-a23d-11df4afa6c10">
+        <File Id="once.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\once.h" Checksum="yes" />
+      </Component>
+      <Component Id="queue.h" Directory="WindowsSDK_usr_include_dispatch" Guid="db4bb4ee-6a95-4692-9793-af888ac633e2">
+        <File Id="queue.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\queue.h" Checksum="yes" />
+      </Component>
+      <Component Id="semaphore.h" Directory="WindowsSDK_usr_include_dispatch" Guid="99b07079-67e8-418c-a4a1-647b28e2bfd0">
+        <File Id="semaphore.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" Checksum="yes" />
+      </Component>
+      <Component Id="source.h" Directory="WindowsSDK_usr_include_dispatch" Guid="740ec071-b663-461f-8408-83f65a804d7e">
+        <File Id="source.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\source.h" Checksum="yes" />
+      </Component>
+      <Component Id="time.h" Directory="WindowsSDK_usr_include_dispatch" Guid="4f234266-768c-4e42-80fd-829cd6d62c91">
+        <File Id="time.h" Source="$(var.SDK_ROOT)\usr\lib\swift\dispatch\time.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="generic_unix_base.h" Directory="WindowsSDK_usr_include_os" Guid="66347322-84a9-4246-9d69-17b2e03dea63">
+        <File Id="generic_unix_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_unix_base.h" Checksum="yes" />
+      </Component>
+      <Component Id="generic_win_base.h" Directory="WindowsSDK_usr_include_os" Guid="1b418910-d049-4040-a1a0-47844b90cc10">
+        <File Id="generic_win_base.h" Source="$(var.SDK_ROOT)\usr\lib\swift\os\generic_win_base.h" Checksum="yes" />
+      </Component>
+      <Component Id="object.h_3af0f0745780408e9fb16b614066623f" Directory="WindowsSDK_usr_include_os" Guid="3af0f074-5780-408e-9fb1-6b614066623f">
+        <File Id="object.h_3af0f0745780408e9fb16b614066623f" Source="$(var.SDK_ROOT)\usr\lib\swift\os\object.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="dispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="c99d7b60-e701-46d9-a5c2-b419a4acc185">
+        <File Id="dispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="Dispatch.swiftdoc" Directory="Dispatch.swiftmodule" Guid="528787e5-4f31-4bb0-b152-bb62e675f1ec">
+        <File Id="Dispatch.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\Dispatch.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Dispatch.swiftmodule" Directory="Dispatch.swiftmodule" Guid="b569a553-e2f8-46c5-b33a-bfa7a77f9cbb">
+        <File Id="Dispatch.swiftmodule" Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\Dispatch.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="9800dd9e-9f94-4350-8e41-f18f19ac610d">
+        <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Concurrency">
+      <Component Id="_Concurrency.swiftdoc" Directory="_Concurrency.swiftmodule" Guid="35d5d47a-fc38-4c00-949f-8647dc58540f">
+        <File Id="_Concurrency.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_Concurrency.swiftinterface" Directory="_Concurrency.swiftmodule" Guid="149c1e9b-637d-4b6c-9434-cdd73ff02e4d">
+        <File Id="_Concurrency.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_Concurrency.swiftmodule" Directory="_Concurrency.swiftmodule" Guid="5d3d15c1-0cd1-4655-a7a5-f302c4a063fa">
+        <File Id="_Concurrency.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_Concurrency.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="d90a2779-efec-472a-a10a-517beb351344">
+        <File Id="swift_Concurrency.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swift_Concurrency.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Differentiation">
+      <Component Id="_Differentiation.swiftdoc" Directory="_Differentiation.swiftmodule" Guid="0a25a99a-183a-4939-80e1-db618880500f">
+        <File Id="_Differentiation.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_Differentiation.swiftinterface" Directory="_Differentiation.swiftmodule" Guid="6f57afae-51f2-4f40-9bbe-f23829d9d37f">
+        <File Id="_Differentiation.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_Differentiation.swiftmodule" Directory="_Differentiation.swiftmodule" Guid="fa022922-4100-400a-a261-523b9015c7f5">
+        <File Id="_Differentiation.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_Differentiation.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="ffadad49-4ad9-44ba-b2a8-aa0aa17bf504">
+        <File Id="swift_Differentiation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swift_Differentiation.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Distributed">
+      <Component Id="Distributed.swiftdoc" Directory="Distributed.swiftmodule" Guid="efec6103-719e-4991-9520-903635a4a983">
+        <File Id="Distributed.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Distributed.swiftinterface" Directory="Distributed.swiftmodule" Guid="8e56b03d-8d01-4a85-a5cc-d83a90c97d8a">
+        <File Id="Distributed.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Distributed.swiftmodule" Directory="Distributed.swiftmodule" Guid="465387dc-f3d9-4412-98bc-16e426e7f0d1">
+        <File Id="Distributed.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDistributed.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="0d5937de-5677-4f8c-acfd-0b4574020ff9">
+        <File Id="swiftDistributed.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftDistributed.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_RegexParser">
+      <Component Id="_RegexParser.swiftdoc" Directory="_RegexParser.swiftmodule" Guid="e061ecf8-f781-47cc-bc27-c7bb811f41e3">
+        <File Id="_RegexParser.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_RegexParser.swiftinterface" Directory="_RegexParser.swiftmodule" Guid="7516a102-4164-472f-a6d1-cab720445853">
+        <File Id="_RegexParser.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_RegexParser.swiftmodule" Directory="_RegexParser.swiftmodule" Guid="8897018d-1360-4ebd-a708-46ef67d15795">
+        <File Id="_RegexParser.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_RegexParser.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_RegexParser.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="8dc8aa9b-52e7-4ad6-b96b-73c4fc5dbd43">
+        <File Id="swift_RegexParser.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swift_RegexParser.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_StringProcessing">
+      <Component Id="_StringProcessing.swiftdoc" Directory="_StringProcessing.swiftmodule" Guid="6b0c7495-8009-4404-a0af-e3528a8f1f7c">
+        <File Id="_StringProcessing.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="_StringProcessing.swiftinterface" Directory="_StringProcessing.swiftmodule" Guid="dc40a8a2-3233-4131-9cdb-cc0d0fcbe8e3">
+        <File Id="_StringProcessing.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="_StringProcessing.swiftmodule" Directory="_StringProcessing.swiftmodule" Guid="9e75c1ec-48cd-4333-87d9-1c8d1d9cfd9a">
+        <File Id="_StringProcessing.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_StringProcessing.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="8383033e-347b-46cd-989c-3fade250bbd8">
+        <File Id="swift_StringProcessing.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swift_StringProcessing.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="CRT">
+      <Component Id="CRT.swiftdoc" Directory="CRT.swiftmodule" Guid="cf15b306-ea72-467c-9d26-b7f279ff8b87">
+        <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="CRT.swiftinterface" Directory="CRT.swiftmodule" Guid="f575ad67-c6c1-4cb0-9767-cdb394620409">
+        <File Id="CRT.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="CRT.swiftmodule" Directory="CRT.swiftmodule" Guid="41315818-9094-4798-9061-bd3da1304000">
+        <File Id="CRT.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCRT.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="251c4c34-1674-4b0e-bb5d-34633d19f5b8">
+        <File Id="swiftCRT.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftCRT.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Foundation">
+      <Component Id="Foundation.swiftdoc" Directory="Foundation.swiftmodule" Guid="b77de995-ebe7-409b-bfe6-2ae6c24e4d8d">
+        <File Id="Foundation.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\Foundation.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Foundation.swiftmodule" Directory="Foundation.swiftmodule" Guid="378ee0d8-4b4c-4ed4-b4ba-e151402889bb">
+        <File Id="Foundation.swiftmodule" Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\Foundation.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="Foundation.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="16fbbce7-d477-417e-a4ee-38cce52be06f">
+        <File Id="Foundation.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="FoundationNetworking">
+      <Component Id="FoundationNetworking.swiftdoc" Directory="FoundationNetworking.swiftmodule" Guid="7307a266-5429-4226-a688-945d9365c3b2">
+        <File Id="FoundationNetworking.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\FoundationNetworking.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationNetworking.swiftmodule" Directory="FoundationNetworking.swiftmodule" Guid="1687bb2e-ab81-4ad3-b58a-5a77c806879c">
+        <File Id="FoundationNetworking.swiftmodule" Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\FoundationNetworking.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="FoundationNetworking.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="ad44a2f5-d525-49ec-a9d9-4bcbcba849c4">
+        <File Id="FoundationNetworking.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="FoundationXML">
+      <Component Id="FoundationXML.swiftdoc" Directory="FoundationXML.swiftmodule" Guid="b6e1b3c7-870b-4fa6-8989-f246b169179a">
+        <File Id="FoundationXML.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\FoundationXML.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="FoundationXML.swiftmodule" Directory="FoundationXML.swiftmodule" Guid="8c0181b4-774d-4b90-b91a-7e5c6ad81ad7">
+        <File Id="FoundationXML.swiftmodule" Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\FoundationXML.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="FoundationXML.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="a67abcb5-c2a6-4904-ad0e-6d855a07aaa5">
+        <File Id="FoundationXML.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Swift">
+      <Component Id="Swift.swiftdoc" Directory="Swift.swiftmodule" Guid="26d8f53e-55ec-4345-8465-72e9cd291883">
+        <File Id="Swift.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Swift.swiftinterface" Directory="Swift.swiftmodule" Guid="d19ff757-8f0c-4e64-8198-ba83a696bff7">
+        <File Id="Swift.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Swift.swiftmodule" Directory="Swift.swiftmodule" Guid="447110bf-ef57-4402-8d9d-c73a34e141fc">
+        <File Id="Swift.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCore.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="4547e5cd-2254-462c-b52d-0e41bc1b5b17">
+        <File Id="swiftCore.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftCore.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="SwiftOnoneSupport">
+      <Component Id="SwiftOnoneSupport.swiftdoc" Directory="SwiftOnoneSupport.swiftmodule" Guid="0796a895-1912-4726-ae0b-bc5a5ef8e9f9">
+        <File Id="SwiftOnoneSupport.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftOnoneSupport.swiftinterface" Directory="SwiftOnoneSupport.swiftmodule" Guid="541a7a34-70b3-4f20-888a-47bc40ccb924">
+        <File Id="SwiftOnoneSupport.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftOnoneSupport.swiftmodule" Directory="SwiftOnoneSupport.swiftmodule" Guid="872800ff-6e4f-4a0c-95a7-ff40c4c0202b">
+        <File Id="SwiftOnoneSupport.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftSwiftOnoneSupport.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="c46f5b10-b7e9-4878-b852-74600609bfb0">
+        <File Id="swiftSwiftOnoneSupport.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftSwiftOnoneSupport.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="WinSDK">
+      <Component Id="WinSDK.swiftdoc" Directory="WinSDK.swiftmodule" Guid="0b55e59b-4a5c-4ad7-b92c-b4bf7be2cd66">
+        <File Id="WinSDK.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="WinSDK.swiftinterface" Directory="WinSDK.swiftmodule" Guid="4e748af4-86b6-49d8-ac5e-ca8d60d2afa6">
+        <File Id="WinSDK.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="WinSDK.swiftmodule" Directory="WinSDK.swiftmodule" Guid="26734a29-917e-4dca-9b52-e6a76d839efe">
+        <File Id="WinSDK.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftWinSDK.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="e67725d6-6cee-423d-a758-487ceabd8f13">
+        <File Id="swiftWinSDK.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftWinSDK.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_aarch64">
+      <Component Id="swiftrt.obj" Guid="7daf0d39-db9e-4ee7-913b-7815b04f30ee">
+        <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftrt.obj" Checksum="yes" />
+      </Component>
+      <!--
+      <Component Id="swiftrtd.obj" Guid="4f5d8876-6eb5-4d2b-a4fd-3b15d9e5b1e4">
+        <File Id="swiftrtd.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftrtd.obj" Checksum="yes" />
+      </Component>
+      -->
+    </ComponentGroup>
+
+    <ComponentGroup Id="SupportFiles" Directory="WindowsSDK_usr_share">
+      <Component Id="ucrt.modulemap" Guid="4b5c1a1d-a6cf-4d06-81f7-e752f0a3f4db">
+        <File Id="ucrt.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\ucrt.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="winsdk.modulemap" Guid="a3b7cb7c-730e-4c6b-ada8-d39f4c72f41e">
+        <File Id="winsdk.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\winsdk.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="visualc.modulemap" Guid="cd59b968-d431-44a0-870b-16c9fbfde01d">
+        <File Id="visualc.modulemap" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.modulemap" Checksum="yes" />
+      </Component>
+      <Component Id="visualc.apinotes" Guid="11318e14-7d68-490e-8c64-f1332f1d63f7">
+        <File Id="visualc.apinotes" Source="$(var.SWIFT_SOURCE_DIR)\stdlib\public\Platform\visualc.apinotes" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Configuration">
+      <Component Id="Info.plist" Directory="WindowsPlatform" Guid="6cc713d1-2f44-4a47-8e1e-7f71e1dce68b">
+        <File Id="Info.plist" Source="$(var.PLATFORM_ROOT)\Info.plist" Checksum="yes" />
+      </Component>
+      <Component Id="SDKSettings.plist" Directory="WindowsSDK" Guid="5e7d06bc-cad8-4c8b-803b-686adfbcb220">
+        <File Id="SDKSettings.plist" Source="$(var.SDK_ROOT)\SDKSettings.plist" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="EnvironmentVariables" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
+        <!-- <Condition> %PROCESSOR_ARCHITECTURE~="arm64" </Condition> -->
+        <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
+      </Component>
+    </DirectoryRef>
+
+    <!-- Features -->
+    <Feature Id="WinARM64SDK" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows aarch64" Level="1" Title="Swift SDK for Windows aarch64">
+      <ComponentGroupRef Id="XCTest" />
+      <ComponentGroupRef Id="dispatch" />
+      <ComponentGroupRef Id="BlocksRuntime" />
+      <ComponentGroupRef Id="SwiftRemoteMirror" />
+      <ComponentGroupRef Id="_Concurrency" />
+      <ComponentGroupRef Id="_Differentiation" />
+      <ComponentGroupRef Id="Distributed" />
+      <ComponentGroupRef Id="_RegexParser" />
+      <ComponentGroupRef Id="_StringProcessing" />
+      <ComponentGroupRef Id="CRT" />
+      <ComponentGroupRef Id="Foundation" />
+      <ComponentGroupRef Id="FoundationNetworking" />
+      <ComponentGroupRef Id="FoundationXML" />
+      <ComponentGroupRef Id="Swift" />
+      <ComponentGroupRef Id="SwiftOnoneSupport" />
+      <ComponentGroupRef Id="WinSDK" />
+
+      <ComponentGroupRef Id="SwiftShims" />
+
+      <ComponentGroupRef Id="Registrar" />
+      <ComponentGroupRef Id="SupportFiles" />
+      <ComponentGroupRef Id="Configuration" />
+
+      <ComponentRef Id="EnvironmentVariables" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows aarch64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentRef Id="XCTestRuntimeDebugInfo" />
+      </Feature>
+      <?endif ?>
+    </Feature>
+
+    <!-- UI -->
+    <UI />
+
+    <!-- Custom Actions -->
+    <Binary Id="SwiftInstaller.dll"
+            SourceFile="$(var.SwiftInstaller.TargetDir)\SwiftInstaller.dll" />
+
+    <CustomAction Id="SwiftInstaller_InstallAuxiliaryFiles"
+                  BinaryKey="SwiftInstaller.dll"
+                  DllEntry="SwiftInstaller_InstallAuxiliaryFiles"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check" />
+    <CustomAction Id="SwiftInstaller_InstallAuxiliaryFiles.SetProperty"
+                  Property="SwiftInstaller_InstallAuxiliaryFiles"
+                  Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"
+                  Return="check" />
+
+    <!-- Hooks -->
+    <InstallExecuteSequence>
+      <Custom Action="SwiftInstaller_InstallAuxiliaryFiles.SetProperty"
+              Before="SwiftInstaller_InstallAuxiliaryFiles" />
+
+      <Custom Action="SwiftInstaller_InstallAuxiliaryFiles" After="InstallExecute">
+        NOT REMOVE
+      </Custom>
+    </InstallExecuteSequence>
+  </Product>
+</Wix>


### PR DESCRIPTION
Add a variant of the manifest for the ARM64 SDK.  Now that the ARm64 SDK
can be built in its entirety, this is needed for the CI side of the work.