### PR TITLE
WiX: add missing runtime arm64 component manifest

### DIFF
--- a/platforms/Windows/icu-arm64.wxs
+++ b/platforms/Windows/icu-arm64.wxs
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift ICU for Windows aarch64" UpgradeCode="de2a9bb6-fee3-419e-abdb-34c69a13d2c7" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift ICU for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+
+    <Media Id="1" Cabinet="icu.cab" EmbedCab="yes" />
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
+    <?endif?>
+
+    <!-- Directory Structure -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="_" Name="icu-$(var.ProductVersion)">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin">
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift">
+      NOT INSTALLDIR
+    </SetDirectory>
+
+    <!-- Components -->
+    <ComponentGroup Id="ICU" Directory="_usr_bin">
+      <Component Id="icudt.dll" Guid="ec9241e1-4492-4160-abe9-31d6d13f63c8">
+        <File Id="icudt.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icudt$(var.ProductVersionMajor).dll" Checksum="yes" />
+      </Component>
+      <Component Id="icuin.dll" Guid="ebf2c28c-3d62-4ce6-a53d-085053638e33">
+        <File Id="icuin.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).dll" Checksum="yes" />
+      </Component>
+      <Component Id="icuuc.dll" Guid="2e2f7f64-436d-431e-aed3-58624a78dd07">
+        <File Id="icuuc.dll" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="ICUDebugInfo" Directory="_usr_bin">
+      <Component Id="icuin.pdb" Guid="b5a2eb8a-680a-4083-bb55-3a0edd653172">
+        <File Id="icuin.pdb" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuin$(var.ProductVersionMajor).pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="icuuc.pdb" Guid="268f08a1-b49a-4f17-8f38-b16dc9284be9">
+        <File Id="icuuc.pdb" Source="$(var.ICU_ROOT)\Library\icu-$(var.ProductVersion)\usr\bin\icuuc$(var.ProductVersionMajor).pdb" Checksum="yes" DiskId="2" />
+      </Component>
+    </ComponentGroup>
+    <?endif ?>
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="EnvironmentVariables" Guid="8e71a8e8-e44f-4575-ab00-dcc9b697511f">
+        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]icu-$(var.ProductVersion)\usr\bin" />
+      </Component>
+    </DirectoryRef>
+
+    <!-- Features -->
+    <Feature Id="WinARM64ICU" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift ICU for Windows aarch64" Level="1" Title="Swift ICU for Windows aarch64">
+      <ComponentGroupRef Id="ICU" />
+      <ComponentRef Id="EnvironmentVariables" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift ICU for Windows aarch64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentGroupRef Id="ICUDebugInfo" />
+      </Feature>
+      <?endif ?>
+    </Feature>
+
+    <!-- UI -->
+    <UI />
+  </Product>
+</Wix>


### PR DESCRIPTION
The ICU packaging manifest was missed in the initial set of packaging
manifests for ARM64.  Add the missing file.