### PR TITLE
WiX: setup the `PlatformToolset` value to the default

### DIFF
--- a/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
+++ b/platforms/Windows/CustomActions/SwiftInstaller/SwiftInstaller.vcxproj
@@ -50,8 +50,7 @@
 
     <NuGetTargetMoniker>native,Version=v0.0</NuGetTargetMoniker>
 
-    <!-- NOTE(compnerd) default to v142 (VS2019) toolset; VS2022 is v143 -->
-    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">$(DefaultPlatformToolset)</PlatformToolset>
     <PlatformToolset>$(PlatformToolset)</PlatformToolset>
 
     <IntDir>$(ProjectDir)build\$(Configuration)\$(PlatformShortName)\$(PlatformToolset)\obj\</IntDir>


### PR DESCRIPTION
With this we now get a default value for the `PlatformToolset` property
which will be configured based on the toolset that is installed.
Subsequently, the developer no longer needs to specify the value when
building the installer.