### PR TITLE
WiX: add missing `module.modulemap` for SwiftRemoteMirror

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -146,6 +146,9 @@
       <Component Id="SwiftRemoteMirrorTypes.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="c15a0af1-e521-4ffc-845b-4f7176db4e2c">
         <File Id="SwiftRemoteMirrorTypes.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" Checksum="yes" />
       </Component>
+      <Component Id="SwiftRemoteMirror.modulemap" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="6fbee223-32cd-4406-83d0-6e4df07ea8be">
+        <File Id="SwiftRemoteMirror.modulemap" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\module.modulemap" Checksum="yes" />
+      </Component>
 
       <Component Id="swiftRemoteMirror.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="36e05640-2023-47fa-a81c-ad3f15eae659">
         <File Id="swiftRemoteMirror.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib" Checksum="yes" />

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -146,6 +146,9 @@
       <Component Id="SwiftRemoteMirrorTypes.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="c15a0af1-e521-4ffc-845b-4f7176db4e2c">
         <File Id="SwiftRemoteMirrorTypes.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" Checksum="yes" />
       </Component>
+      <Component Id="SwiftRemoteMirror.modulemap" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="6fbee223-32cd-4406-83d0-6e4df07ea8be">
+        <File Id="SwiftRemoteMirror.modulemap" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\module.modulemap" Checksum="yes" />
+      </Component>
 
       <Component Id="swiftRemoteMirror.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="10f6539b-f57e-46ca-9d51-9f44b6a71b24">
         <File Id="swiftRemoteMirror.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftRemoteMirror.lib" Checksum="yes" />

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -146,6 +146,9 @@
       <Component Id="SwiftRemoteMirrorTypes.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="c15a0af1-e521-4ffc-845b-4f7176db4e2c">
         <File Id="SwiftRemoteMirrorTypes.h" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" Checksum="yes" />
       </Component>
+      <Component Id="SwiftRemoteMirror.modulemap" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="6fbee223-32cd-4406-83d0-6e4df07ea8be">
+        <File Id="SwiftRemoteMirror.modulemap" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\module.modulemap" Checksum="yes" />
+      </Component>
 
       <Component Id="wwiftRemoteMirror.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="3d429d95-1f9d-4b59-85f2-2676ae95539b">
         <File Id="swiftRemoteMirror.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftRemoteMirror.lib" Checksum="yes" />


### PR DESCRIPTION
Add the missing `module.modulemap` for the `SwiftRemoteMirror` library
which is required to make use of the module.  This restores the ability
to build `swift-inspect` with a release toolchain.