### PR TITLE
WiX: add toolchain and devtools manifest for ARM64

### DIFF
--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Developer Tools for Windows aarch64" UpgradeCode="" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Developer Tools for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+
+    <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
+    <?endif?>
+
+    <!-- Directory Structure -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Toolchains" Name="Toolchains">
+            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+              <Directory Id="_usr" Name="usr">
+                <Directory Id="_usr_bin" Name="bin">
+                </Directory>
+                <Directory Id="_usr_lib" Name="lib">
+                  <!-- FIXME(compnerd) should we include the SPM import libraries? -->
+                  <Directory Id="_usr_lib_swift" Name="swift">
+                    <Directory Id="_usr_lib_swift_pm" Name="pm">
+                      <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
+                      </Directory>
+                      <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+                      </Directory>
+                    </Directory>
+                  </Directory>
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
+      NOT INSTALLDIR
+    </SetDirectory>
+
+    <!-- Components -->
+    <ComponentGroup Id="SwiftCrypto">
+      <Component Id="Crypto.dll" Directory="_usr_bin" Guid="b70fbf9e-006b-4b05-9450-8b139fa90da1">
+        <File Id="Crypto.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftCryptoDebugInfo">
+      <Component Id="Crypto.pdb" Directory="_usr_bin" Guid="13765cd7-5212-4ce8-a3f0-83168b4e8afc">
+        <File Id="Crypto.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftCollections">
+      <Component Id="Collections.dll" Directory="_usr_bin" Guid="b705e7a1-698a-4608-b53f-48578380696c">
+        <File Id="Collections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
+      </Component>
+      <Component Id="DequeModule.dll" Directory="_usr_bin" Guid="7459f8ec-563c-4220-ae5a-3c52a31b2a93">
+        <File Id="DequeModule.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.dll" Checksum="yes" />
+      </Component>
+      <Component Id="OrderedCollections.dll" Directory="_usr_bin" Guid="7437801f-15d1-43b2-8649-7c3cdfeeb0d7">
+        <File Id="OrderedCollections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftCollectionsDebugInfo">
+      <Component Id="Collections.pdb" Directory="_usr_bin" Guid="d33e610e-171b-445b-bfbe-8f4dadaa8741">
+        <File Id="Collections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="DequeModule.pdb" Directory="_usr_bin" Guid="779c0307-95fe-4cf8-9631-fe2de10e6031">
+        <File Id="DequeModule.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="OrderedCollections.pdb" Directory="_usr_bin" Guid="0546f5b7-10c3-4766-968b-0add6b08c3e1">
+        <File Id="OrderedCollections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftSystem">
+      <Component Id="SystemPackage.dll" Directory="_usr_bin" Guid="3a77763d-f9fb-4f1e-a056-f785bb1912e9">
+        <File Id="SystemPackage.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftSystemDebugInfo">
+      <Component Id="SystemPackage.pdb" Directory="_usr_bin" Guid="157a0be9-c296-4244-8975-7125fb8306d4">
+        <File Id="SystemPackage.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftPackageManager">
+      <Component Id="Basics.dll" Directory="_usr_bin" Guid="03e5871a-9ded-4010-9708-6217f294edc4">
+        <File Id="Basics.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Build.dll" Directory="_usr_bin" Guid="4a7280fc-5018-485a-b15f-dec6b19eb5d1">
+        <File Id="Build.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Commands.dll" Directory="_usr_bin" Guid="b5a08920-f173-4a1b-8b80-dae0c3d21975">
+        <File Id="Commands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageGraph.dll" Directory="_usr_bin" Guid="0f4cd16f-a931-401c-9b49-9fc988e8d87e">
+        <File Id="PackageGraph.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageLoading.dll" Directory="_usr_bin" Guid="9f086102-597f-448f-ac82-127138fba0ba">
+        <File Id="PackageLoading.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageModel.dll" Directory="_usr_bin" Guid="faa15fdd-9ef2-46d8-af96-7a26a6c756f2">
+        <File Id="PackageModel.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" Checksum="yes" />
+      </Component>
+      <Component Id="SPMBuildCore.dll" Directory="_usr_bin" Guid="221b7bd2-9f99-4ef0-9a7e-b261e9370a77">
+        <File Id="SPMBuildCore.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" Checksum="yes" />
+      </Component>
+      <Component Id="Workspace.dll" Directory="_usr_bin" Guid="9740f123-1701-47d1-b18f-6ff89ac31edd">
+        <File Id="Workspace.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_build.exe" Directory="_usr_bin" Guid="a1feb617-1b46-446c-8002-08729f3fa267">
+        <File Id="swift_build.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package.exe" Directory="_usr_bin" Guid="2d46cc7c-1831-4caf-a225-9d2f283b4c10">
+        <File Id="swift_package.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_run.exe" Directory="_usr_bin" Guid="247b8727-71d3-4e80-bcaf-917a478598db">
+        <File Id="swift_run.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_test.exe" Directory="_usr_bin" Guid="ba9a9e55-d620-49b0-8647-5fa1778e3693">
+        <File Id="swift_test.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="PackageDescription.dll" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="f182c092-90b2-453e-b820-445d76c29477">
+        <File Id="PackageDescription.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageDescription.lib" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="cac0bbb7-184d-4b57-a414-e727660bb004">
+        <File Id="PackageDescription.lib" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" Checksum="yes" />
+      </Component>
+      <Component Id="PackageDescription.swiftdoc" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="488bcd93-32c6-422d-a2b3-45a4913b4dc8">
+        <File Id="PackageDescription.swiftdoc" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="PackageDescription.swiftmodule" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="47fdf73a-dbfe-47b9-973f-ca5b8856b162">
+        <File Id="PackageDescription.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="PackagePlugin.dll" Directory="_usr_lib_swift_pm_PluginAPI" Guid="7ca18c18-6efa-44e9-af2c-b0196dfb9778">
+        <File Id="PackagePlugin.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackagePlugin.lib" Directory="_usr_lib_swift_pm_PluginAPI" Guid="4b4345d1-3ab0-4742-bdd2-e3d61df5a74e">
+        <File Id="PackagePlugin.lib" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.lib" Checksum="yes" />
+      </Component>
+      <Component Id="PackagePlugin.swiftdoc" Directory="_usr_lib_swift_pm_PluginAPI" Guid="d8427dc3-4879-40bb-8f8b-439ef9c09143">
+        <File Id="PackagePlugin.swiftdoc" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="PackagePlugin.swiftmodule" Directory="_usr_lib_swift_pm_PluginAPI" Guid="250941c3-16a6-48f5-9142-1629c107ee7a">
+        <File Id="PackagePlugin.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftmodule" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftPackageManagerDebugInfo">
+      <Component Id="Basics.pdb" Directory="_usr_bin" Guid="2fdea2ca-5498-4cb1-bf74-b771321a0b2b">
+        <File Id="Basics.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="Build.pdb" Directory="_usr_bin" Guid="cbc19845-fd86-4d2a-977e-5ae49de856d4">
+        <File Id="Build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="Commands.pdb" Directory="_usr_bin" Guid="345f96d2-f9ac-4c83-8722-855686401a9d">
+        <File Id="Commands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="PackageGraph.pdb" Directory="_usr_bin" Guid="71a32056-bb8d-4d9b-ab76-e25ee6fd04bc">
+        <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="PackageLoading.pdb" Directory="_usr_bin" Guid="991958ab-0f7b-4547-8286-732671282ec1">
+        <File Id="PackageLoading.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="PackageModel.pdb" Directory="_usr_bin" Guid="511fd24a-f9b9-4c7b-97c1-5845dfc308d0">
+        <File Id="PackageModel.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="SPMBuildCore.pdb" Directory="_usr_bin" Guid="3f66ca4f-d560-496f-9f8f-bc350a559ce5">
+        <File Id="SPMBuildCore.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="Workspace.pdb" Directory="_usr_bin" Guid="cf7d3735-03f9-4d17-89b3-c051d1cc3c5a">
+        <File Id="Workspace.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_build.pdb" Directory="_usr_bin" Guid="84d4c04b-158f-446b-aa5e-9ffe3318dd02">
+        <File Id="swift_build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package.pdb" Directory="_usr_bin" Guid="7038d860-c614-4c74-b2ce-d6dc84f8f638">
+        <File Id="swift_package.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_run.pdb" Directory="_usr_bin" Guid="d5eb453e-1e43-4492-b9d6-e3c08b8f7b80">
+        <File Id="swift_run.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_test.pdb" Directory="_usr_bin" Guid="a9240a6b-9934-4356-80e9-5311d6c35fa5">
+        <File Id="swift_test.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.pdb" Checksum="yes" />
+      </Component>
+
+      <Component Id="PackageDescription.pdb" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="aabedd70-4b90-46ef-8db6-9724c2340f81">
+        <File Id="PackageDescription.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
+      </Component>
+
+      <Component Id="PackagePlugin.pdb" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="bbf77ff9-fa10-4fe3-ab4b-3cbf95fa6be9">
+        <File Id="PackagePlugin.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\pluginAPI\PackagePlugin.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="IndexStoreDB">
+      <Component Id="IndexStoreDB.dll" Directory="_usr_bin" Guid="cc4d9542-7334-4923-803d-457930d3234c">
+        <File Id="IndexStoreDB.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="IndexStoreDBDebugInfo">
+      <Component Id="IndexStoreDB.pdb" Directory="_usr_bin" Guid="f737eb31-c852-46f2-9f98-cb145362621d">
+        <File Id="IndexStoreDB.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SourceKitLSP">
+      <Component Id="sourcekit_lsp.exe" Directory="_usr_bin" Guid="1e4d7fbd-a435-4d11-bd17-2dec0b235c28">
+        <File Id="sourcekit_lsp.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SourceKitLSPDebugInfo">
+      <Component Id="sourcekit_lsp.pdb" Directory="_usr_bin" Guid="3a72124e-6b23-42ac-be52-c1ac2d7972f6">
+        <File Id="soucekit_lsp.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.pdb" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows aarch64" Level="1" Title="Swift Developer Tools (Windows aarch64)">
+      <ComponentGroupRef Id="SwiftCrypto" />
+      <ComponentGroupRef Id="SwiftCollections" />
+      <ComponentGroupRef Id="SwiftSystem" />
+      <ComponentGroupRef Id="SwiftPackageManager" />
+      <ComponentGroupRef Id="SourceKitLSP" />
+      <ComponentGroupRef Id="IndexStoreDB" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows aarch64" Level="0" Title="Debug Info">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentGroupRef Id="SwiftCryptoDebugInfo" />
+        <ComponentGroupRef Id="SwiftCollectionsDebugInfo" />
+        <ComponentGroupRef Id="SwiftSystemDebugInfo" />
+        <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />
+        <ComponentGroupRef Id="SourceKitLSPDebugInfo" />
+        <ComponentGroupRef Id="IndexStoreDBDebugInfo" />
+      </Feature>
+      <?endif?>
+    </Feature>
+
+    <!-- UI -->
+    <UI />
+  </Product>
+</Wix>

--- a/platforms/Windows/toolchain-arm64.wxs
+++ b/platforms/Windows/toolchain-arm64.wxs
@@ -1,0 +1,857 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Toolchain for Windows aarch64" UpgradeCode="7e95dc06-7f84-4e8e-a038-8304af0468fb" Version="$(var.ProductVersion)">
+    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Toolchain for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+
+    <!--
+      NOTE(compnerd) Use high compression as this is an extrodinarily large
+      cabinet.  With upstream being amenable to considering decorations for
+      DLL builds, this might be possible to reduce in the future hopefully.
+      In the mean time, burn the CPU cycles to try to claw back the minimal
+      bit of savings to hedge against the constant complaints that the MSIs
+      are too large.
+    -->
+    <Media Id="1" Cabinet="toolchain.cab" EmbedCab="yes" CompressionLevel="high" />
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <Media Id="2" Cabinet="PDBs.llvm.cab" />
+    <Media Id="3" Cabinet="PDBs.clang.cab" />
+    <Media Id="4" Cabinet="PDBs.lld.cab" />
+    <Media Id="5" Cabinet="PDBs.lldb.cab" />
+    <Media Id="6" Cabinet="PDBs.BlocksRuntime.cab" />
+    <Media Id="7" Cabinet="PDBs.dispatch.cab" />
+    <Media Id="8" Cabinet="PDBs.SourceKit.cab" />
+    <Media Id="9" Cabinet="PDBs.swift.cab" />
+    <Media Id="10" Cabinet="PDBs.llbuild.cab" />
+    <Media Id="11" Cabinet="PDBs.ArgumentParser.cab" />
+    <Media Id="12" Cabinet="PDBs.ToolsSupportCore.cab" />
+    <Media Id="13" Cabinet="PDBs.Yams.cab" />
+    <Media Id="14" Cabinet="PDBs.swift-driver.cab" />
+    <?endif?>
+
+    <!-- Directory Structure -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Toolchains" Name="Toolchains">
+            <!-- TODO(compnerd):
+              This really should be
+              unknown-Asserts-$(var.ProductVersion).xctoolchain,
+              though before changing, we should setup a
+              `unknown-Asserts-current.xctoolchain`
+              symlink. Additionally, beware that the environment chagnes
+              below will need to be updated to reflect this change. Ideally,
+              we would have as part of this a tool to select the different
+              toolchain versions.
+            -->
+            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+              <Directory Id="_usr" Name="usr">
+                <Directory Id="_usr_bin" Name="bin">
+                </Directory>
+                <Directory Id="_usr_include" Name="include">
+                  <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+                  </Directory>
+                  <Directory Id="_usr_include__InternalSwiftSyntaxParser" Name="_InternalSwiftSyntaxParser">
+                  </Directory>
+                  <Directory Id="_usr_include_clang_c" Name="clang-c">
+                  </Directory>
+                  <Directory Id="_usr_include_dispatch" Name="dispatch">
+                  </Directory>
+                  <Directory Id="_usr_include_indexstore" Name="indexstore">
+                  </Directory>
+                  <Directory Id="_usr_include_lldb" Name="lldb">
+                  </Directory>
+                  <Directory Id="_usr_include_llvm_c" Name="llvm-c">
+                  </Directory>
+                  <Directory Id="_usr_include_os" Name="os">
+                  </Directory>
+                  <Directory Id="_usr_include_SourceKit" Name="SourceKit">
+                  </Directory>
+                </Directory>
+                <Directory Id="_usr_lib" Name="lib">
+                  <Directory Id="_usr_lib_clang" Name="clang">
+                  </Directory>
+                  <Directory Id="_usr_lib_site_packages" Name="site-packages">
+                    <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
+                      <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
+                        <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                        </Directory>
+                      </Directory>
+                      <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
+                      </Directory>
+                    </Directory>
+                  </Directory>
+                  <Directory Id="_usr_lib_swift" Name="swift">
+                    <Directory Id="_usr_lib_swift_migrator" Name="migrator">
+                    </Directory>
+                    <Directory Id="_usr_lib_swift_shims" Name="shims">
+                    </Directory>
+                  </Directory>
+                </Directory>
+                <Directory Id="_usr_libexec" Name="libexec">
+                </Directory>
+                <Directory Id="_usr_share" Name="share">
+                  <Directory Id="_usr_share_swift" Name="swift">
+                  </Directory>
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
+      NOT INSTALLDIR
+    </SetDirectory>
+
+    <!-- Components -->
+    <ComponentGroup Id="binutils">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="llvm_dlltool.exe" Directory="_usr_bin" Guid="ba6008fe-9a23-4748-8453-1cc721e3fdb2">
+        <File Id="llvm_dlltool.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dlltool.exe" Checksum="yes" />
+      </Component>
+      <Component Id="lldb_lib.exe" Directory="_usr_bin" Guid="a77b22f9-6693-40cd-a855-528fe319c481">
+        <File Id="llvm_lib.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lib.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_ranlib.exe" Directory="_usr_bin" Guid="a04ff84e-05e7-4477-aac7-b460a10ad5c3">
+        <File Id="llvm_ranlib.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ranlib.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_readelf.exe" Directory="_usr_bin" Guid="da8e00d8-e382-401f-986c-a31e2d26f0fe">
+        <File Id="llvm_readelf.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readelf.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_strip.exe" Directory="_usr_bin" Guid="d7477159-f671-43ca-bed4-1fef09521dae">
+        <File Id="llvm_strip.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strip.exe" Checksum="yes" />
+      </Component>
+      <!--
+      TODO(compnerd) we should symlink addr2line.exe, ar.exe, c++filt.exe, dwp.exe, nm.exe, objcopy.exe, objdump.exe, ranlib.exe, readelf.exe, size.exe, strings.exe
+      -->
+
+      <Component Id="dsymutil.exe" Directory="_usr_bin" Guid="4463782c-bde6-4bf5-8dab-6e5fb1ffe9b9">
+        <File Id="dsymutil.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_ar.exe" Directory="_usr_bin" Guid="220b6d82-7219-43a2-8117-b2a0f347a4de">
+        <File Id="llvm_ar.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_cov.exe" Directory="_usr_bin" Guid="6ddfefc9-094a-45e5-b424-09ce22be04ae">
+        <File Id="llvm_cov.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_cvtres.exe" Directory="_usr_bin" Guid="b63251d7-0cb5-4605-b522-621e46255551">
+        <File Id="llvm_cvtres.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_cxxfilt.exe" Directory="_usr_bin" Guid="9cac4093-4a3a-485d-aaba-a3ed5379b60d">
+        <File Id="llvm_cxxfilt.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_dwarfdump.exe" Directory="_usr_bin" Guid="99cc4765-2001-4661-8979-dc9f8feaf9cd">
+        <File Id="llvm_dwarfdump.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_dwp.exe" Directory="_usr_bin" Guid="0b9dbda7-df42-4c3b-998f-4306119b1c71">
+        <File Id="llvm_dwp.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_lipo.exe" Directory="_usr_bin" Guid="9f474cbe-8ae3-425d-b2eb-ca7f1cd22fd7">
+        <File Id="llvm_lipo.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_mt.exe" Directory="_usr_bin" Guid="e3b6428e-a311-4a4a-97d0-b3d4bb455e31">
+        <File Id="llvm_mt.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_nm.exe" Directory="_usr_bin" Guid="c0410870-a838-43d1-9edf-3a5e3f009c4d">
+        <File Id="llvm_nm.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_objcopy.exe" Directory="_usr_bin" Guid="82724840-a73a-4b4f-b7fd-500ca5eb0f88">
+        <File Id="llvm_objcopy.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_objdump.exe" Directory="_usr_bin" Guid="777beee0-f7a8-4ff7-a5f4-c0009db96ad9">
+        <File Id="llvm_objdump.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_pdbutil.exe" Directory="_usr_bin" Guid="e5710152-e5d2-4033-a652-163753961844">
+        <File Id="llvm_pdbutil.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_profdata.exe" Directory="_usr_bin" Guid="0494d0f9-20f2-4db0-b34f-19d6500c54c0">
+        <File Id="llvm_profdata.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_rc.exe" Directory="_usr_bin" Guid="fd477ce8-8f82-44b0-b7c3-ee5ef5035db7">
+        <File Id="llvm_rc.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_readobj.exe" Directory="_usr_bin" Guid="053443f1-76a1-40cd-97f8-dc3e16331316">
+        <File Id="llvm_readobj.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_size.exe" Directory="_usr_bin" Guid="2986940f-1097-4090-bcf2-ef5196f7e397">
+        <File Id="llvm_size.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_strings.exe" Directory="_usr_bin" Guid="3ac3e5b8-ff23-4cf8-9ecb-171a1cc053f0">
+        <File Id="llvm_strings.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_symbolizer.exe" Directory="_usr_bin" Guid="e17ee592-e355-422e-af6f-744ea95d8f43">
+        <File Id="llvm_symbolizer.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.exe" Checksum="yes" />
+      </Component>
+      <Component Id="llvm_undname.exe" Directory="_usr_bin" Guid="dbcbc4ab-1020-4183-8b88-f93b570a37b5">
+        <File Id="llvm_undname.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="LTO.dll" Directory="_usr_bin" Guid="2d4cae99-dfb8-49b2-b9b3-8562b91a86d3">
+        <File Id="LTO.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="LTO.lib" Directory="_usr_lib" Guid="73c8822d-5711-4ac9-8c24-1d6d299a56b6">
+        <File Id="LTO.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\LTO.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="lto.h" Directory="_usr_include_llvm_c" Guid="f5630176-7faf-488b-9db3-428e0ad3a64f">
+        <File Id="lto.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\llvm-c\lto.h" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="binutilsDebugInfo">
+      <Component Id="dsymutil.pdb" Directory="_usr_bin" Guid="73c8822d-5711-4ac9-8c24-1d6d299a56b6">
+        <File Id="dsymutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_ar.pdb" Directory="_usr_bin" Guid="84e78011-23e8-4c9f-89ef-5257a3407966">
+        <File Id="llvm_ar.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_cov.pdb" Directory="_usr_bin" Guid="04bf4eec-d707-49ad-90ce-1d7c2e057cb6">
+        <File Id="llvm_cov.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_cvtres.pdb" Directory="_usr_bin" Guid="b40f1683-fd0d-4e91-8f09-41719acc1694">
+        <File Id="llvm_cvtres.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_cxxfilt.pdb" Directory="_usr_bin" Guid="e2f84ed3-25fd-4337-99c6-4dec94d18fa0">
+        <File Id="llvm_cxxfilt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_dwarfdump.pdb" Directory="_usr_bin" Guid="3d33ee41-0766-4644-a7b2-23eb37ec69db">
+        <File Id="llvm_dwarfdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_dwp.pdb" Directory="_usr_bin" Guid="141a8180-b655-4fcc-a9f5-b6df56007de9">
+        <File Id="llvm_dwp.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_lipo.pdb" Directory="_usr_bin" Guid="2bbe87ef-2598-4099-a64b-22b3fab16e45">
+        <File Id="llvm_lipo.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_mt.pdb" Directory="_usr_bin" Guid="d8df5263-37e0-45dd-be1b-1d58f6b26e1b">
+        <File Id="llvm_mt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_nm.pdb" Directory="_usr_bin" Guid="2a5ee43c-1c54-4a06-90c1-a408b04af75c">
+        <File Id="llvm_nm.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_objcopy.pdb" Directory="_usr_bin" Guid="cc50faea-b1ef-4169-a767-c2b58657df72">
+        <File Id="llvm_objcopy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_objdump.pdb" Directory="_usr_bin" Guid="ad547b72-b03d-4341-8ab9-c521913ab492">
+        <File Id="llvm_objdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_pdbutil.pdb" Directory="_usr_bin" Guid="5ec1cd38-13cb-4f0d-a87a-e4df5178e404">
+        <File Id="llvm_pdbutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_profdata.pdb" Directory="_usr_bin" Guid="e1506848-6ba7-49d3-9aff-698b89d99e3f">
+        <File Id="llvm_profdata.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_rc.pdb" Directory="_usr_bin" Guid="a3d95f6f-e763-4f38-a244-2a214f1d84f4">
+        <File Id="llvm_rc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_readobj.pdb" Directory="_usr_bin" Guid="a9ab57da-f803-46c3-a07e-014cc6916ba6">
+        <File Id="llvm_readobj.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_size.pdb" Directory="_usr_bin" Guid="96494ade-83cf-49b9-abc0-f7b9d4ceddb4">
+        <File Id="llvm_size.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_strings.pdb" Directory="_usr_bin" Guid="853cf1ae-186f-49df-a7a9-0bd95be5d03f">
+        <File Id="llvm_strings.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_symbolizer.pdb" Directory="_usr_bin" Guid="74cdda53-a1be-4a7d-8730-0afbe598bfa9">
+        <File Id="llvm_symbolizer.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="llvm_undname.pdb" Directory="_usr_bin" Guid="75d9ec7c-9f49-46cb-b593-5e9e0dc16485">
+        <File Id="llvm_undname.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+
+      <Component Id="LTO.pdb" Directory="_usr_bin" Guid="1f0e8bee-2049-4b77-a43b-8255f7371f0d">
+        <File Id="LTO.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="clang">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="clang_cl.exe" Directory="_usr_bin" Guid="6ad2751d-f1e6-47c2-82c7-4bd3c7c51e7b">
+        <File Id="clang_cl.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cl.exe" Checksum="yes" />
+      </Component>
+      <Component Id="clang_cpp.exe" Directory="_usr_bin" Guid="aef7f294-452d-4b57-8bcc-6a173ceaef6a">
+        <File Id="clang_cpp.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-cpp.exe" Checksum="yes" />
+      </Component>
+      <Component Id="clang__.exe" Directory="_usr_bin" Guid="c005b940-5e01-4cbb-aa04-a92cecb4673b">
+        <File Id="clang__.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang++.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="clang_format.exe" Directory="_usr_bin" Guid="36f54163-9ffe-4938-8b3c-1ac07aa07df1">
+        <File Id="clang_format.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.exe" Checksum="yes" />
+      </Component>
+      <Component Id="clang_tidy.exe" Directory="_usr_bin" Guid="84d065d1-445b-4a7d-9e3a-4ea4d080d812">
+        <File Id="clang_tidy.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.exe" Checksum="yes" />
+      </Component>
+      <Component Id="clang.exe" Directory="_usr_bin" Guid="c9a8f452-5dfe-456f-a3fd-3bf9bba688bf">
+        <File Id="clang.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.exe" Checksum="yes" />
+      </Component>
+      <!--
+      TODO(compnerd) we should include clang-offload-bundler, clang-refactor, clang-rename, optremarks.dll, scan-build, scan-view
+      -->
+
+      <Component Id="libclang.dll" Directory="_usr_bin" Guid="df18be1f-7bde-4f56-b856-84af407a9f1a">
+        <File Id="libclang.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.dll" Checksum="yes" />
+      </Component>
+      <Component Id="libIndexStore.dll" Directory="_usr_bin" Guid="7f26a821-e259-45ff-8533-77052e212e94">
+        <File Id="libIndexStore.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="libclang.lib" Directory="_usr_lib" Guid="fbc618fa-e5c1-44df-9ae8-d7ba428e9700">
+        <File Id="libclang.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libclang.lib" Checksum="yes" />
+      </Component>
+      <Component Id="libIndexStore.lib" Directory="_usr_lib" Guid="38456e68-3f3f-46bf-9dde-954e1dd48520">
+        <File Id="libIndexStore.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\libIndexStore.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="BuildSystem.h" Directory="_usr_include_clang_c" Guid="b2cef896-4642-42db-8477-0db1497d349e">
+        <File Id="BuildSystem.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\BuildSystem.h" Checksum="yes" />
+      </Component>
+      <Component Id="CXCompilationDatabase.h" Directory="_usr_include_clang_c" Guid="8a3c8f12-f79f-4235-ab33-75d8480fd9cd">
+        <File Id="CXCompilationDatabase.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXCompilationDatabase.h" Checksum="yes" />
+      </Component>
+      <Component Id="CXErrorCode.h" Directory="_usr_include_clang_c" Guid="2fb03adf-e64f-4aa8-bdc9-563e71177639">
+        <File Id="CXErrorCode.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXErrorCode.h" Checksum="yes" />
+      </Component>
+      <Component Id="CXString.h" Directory="_usr_include_clang_c" Guid="630b267f-014c-4720-9047-4d8947751c8c">
+        <File Id="CXString.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\CXString.h" Checksum="yes" />
+      </Component>
+      <Component Id="Documentation.h" Directory="_usr_include_clang_c" Guid="cdb0468b-0b86-4c8f-9180-6b857321bdd5">
+        <File Id="Documentation.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Documentation.h" Checksum="yes" />
+      </Component>
+      <Component Id="FatalErrorHandler.h" Directory="_usr_include_clang_c" Guid="e2bd6c56-13b9-42e4-b142-c42b77b1410a">
+        <File Id="FatalErrorHandler.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\FatalErrorHandler.h" Checksum="yes" />
+      </Component>
+      <Component Id="Index.h" Directory="_usr_include_clang_c" Guid="6a0cc957-3126-4736-96e5-5e985b6f5447">
+        <File Id="Index.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Index.h" Checksum="yes" />
+      </Component>
+      <Component Id="Platform.h" Directory="_usr_include_clang_c" Guid="935b862d-eb69-4854-a07c-7c651a0c1dbc">
+        <File Id="Platform.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Platform.h" Checksum="yes" />
+      </Component>
+      <Component Id="Refactor.h" Directory="_usr_include_clang_c" Guid="b85d459f-adff-4933-bf92-7ef921586628">
+        <File Id="Refactor.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\clang-c\Refactor.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="indexstore.h" Directory="_usr_include_indexstore" Guid="877c9471-aafb-4fd3-aa68-32c8c25bae61">
+        <File Id="indexstore.h" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\indexstore.h" Checksum="yes" />
+      </Component>
+      <Component Id="IndexStoreCXX.h" Directory="_usr_include_indexstore" Guid="222ac75d-2924-4231-b2b8-c79bbf08e808">
+        <File Id="IndexStoreCXX.h" Source="$(var.TOOLCHAIN_ROOT)\usr\local\include\indexstore\IndexStoreCXX.h" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="clangDebugInfo">
+      <Component Id="clang_format.pdb" Directory="_usr_bin" Guid="432d6998-0f0b-44ce-97a2-221e1e82e19f">
+        <File Id="clang_format.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+      <Component Id="clang_format.pdb" Directory="_usr_bin" Guid="b2dc1258-d664-4850-9c97-6eff66813c84">
+        <File Id="clang_tidy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+      <Component Id="clang.pdb" Directory="_usr_bin" Guid="737d7fd3-c932-494b-bfa6-0e3ac9b2820c">
+        <File Id="clang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+
+      <Component Id="libclang.pdb" Directory="_usr_bin" Guid="db1b1f54-5646-4e5a-98d2-ef524703bab3">
+        <File Id="libclang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+      <Component Id="libIndexStore.pdb" Directory="_usr_bin" Guid="0129ab89-71b6-4c52-afdd-c58fbe8792b2">
+        <File Id="libIndexStore.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.pdb" Checksum="yes" DiskId="3" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="lld">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="ld.lld.exe" Directory="_usr_bin" Guid="82fcce13-68e0-4048-a935-846111d9bbb2">
+        <File Id="ld.lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld.lld.exe" Checksum="yes" />
+      </Component>
+      <Component Id="ld64.lld.exe" Directory="_usr_bin" Guid="698fe474-d476-49da-91a4-79c2d9a08da0">
+        <File Id="ld64.lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\ld64.lld.exe" Checksum="yes" />
+      </Component>
+      <Component Id="lld_link.exe" Directory="_usr_bin" Guid="82200ec6-587b-4118-be73-b5fc734b6894">
+        <File Id="lld_link.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld-link.exe" Checksum="yes" />
+      </Component>
+      <Component Id="wasm_ld.exe" Directory="_usr_bin" Guid="7842cf43-8dc8-4ed1-9735-d45d4c4d8147">
+        <File Id="wasm_ld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\wasm-ld.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="lld.exe" Directory="_usr_bin" Guid="81956ef1-a3e9-4653-9352-f3aeaa5eec3b">
+        <File Id="lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.exe" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="lldDebugInfo">
+      <Component Id="lld.pdb" Directory="_usr_bin" Guid="e4709585-751e-4708-945c-7c1e4e415d16">
+        <File Id="lld.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.pdb" Checksum="yes" DiskId="4" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="lldb">
+      <Component Id="lldb_server.exe" Directory="_usr_bin" Guid="d9dbdd0f-9f0b-4aa6-84d0-75d96f4a71e7">
+        <File Id="lldb_server.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.exe" Checksum="yes" />
+      </Component>
+      <Component Id="lldb_vscode.exe" Directory="_usr_bin" Guid="6e8069aa-83a8-4881-97fc-698ed120b2a0">
+        <File Id="lldb_vscode.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.exe" Checksum="yes" />
+      </Component>
+      <Component Id="lldb.exe" Directory="_usr_bin" Guid="3bd1ebf0-3690-495a-8ce4-2ddfa6a31c9a">
+        <File Id="lldb.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.exe" Checksum="yes" />
+      </Component>
+      <Component Id="repl_swift.exe" Directory="_usr_bin" Guid="b6cef43d-e9e4-408e-82d0-4a09e0ad48e5">
+        <File Id="repl_swift.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\repl_swift.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="liblldb.dll" Directory="_usr_bin" Guid="d075aea8-9826-4b4e-83dd-75e9c17fd6b0">
+        <File Id="liblldb.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="liblldb.lib" Directory="_usr_lib" Guid="a72d9759-d08d-41e8-828f-8230d9975014">
+        <File Id="liblldb.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\liblldb.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="__init__.py_c31e016e2f8b4fba9eebd73d5009e919" Directory="_usr_lib_site_packages_lldb" Guid="c31e016e-2f8b-4fba-9eeb-d73d5009e919">
+        <File Id="___init__.py_c31e016e2f8b4fba9eebd73d5009e919" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\__init__.py" Checksum="yes" />
+      </Component>
+      <Component Id="_lldb.py" Directory="_usr_lib_site_packages_lldb" Guid="ff3413e0-e9f2-4605-89c1-43632c7b2291">
+        <File Id="_lldb.pyd" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\_lldb.pyd" Checksum="yes" />
+      </Component>
+      <Component Id="embedded_interpreter.py" Directory="_usr_lib_site_packages_lldb" Guid="b910189d-d22e-43a9-951a-033efe9e72fe">
+        <File Id="embedded_interpreter.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\embedded_interpreter.py" Checksum="yes" />
+      </Component>
+      <Component Id="lldb_argdumper.exe" Directory="_usr_lib_site_packages_lldb" Guid="5cca71eb-196b-4cc5-b986-fe003ae55158">
+        <File Id="lldb_argdumper.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\lldb-argdumper.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="logger.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="788726e1-dd3c-4721-ae4b-08e729102662">
+        <File Id="logger.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\Logger.py" Checksum="yes" />
+      </Component>
+      <Component Id="__init__.py_6124a6ee9e584275b153b0e1ddb4a2b2" Directory="_usr_lib_site_packages_lldb_formatters" Guid="6124a6ee-9e58-4275-b153-b0e1ddb4a2b2">
+        <File Id="___init__.py_6124a6ee9e584275b153b0e1ddb4a2b2" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\__init__.py" Checksum="yes" />
+      </Component>
+      <Component Id="attrib_fromdict.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="6324266f-1b6f-4c3b-8cdd-9e88da64c9ed">
+        <File Id="attrib_fromdict.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\attrib_fromdict.py" Checksum="yes" />
+      </Component>
+      <Component Id="cache.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="de68dfa7-9ca4-4119-9d19-0899ba134e4b">
+        <File Id="cache.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cache.py" Checksum="yes" />
+      </Component>
+      <Component Id="metrics.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="f5fbf56e-d395-459f-a6c9-fd932af0fb32">
+        <File Id="metrics.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\metrics.py" Checksum="yes" />
+      </Component>
+      <Component Id="synth.py" Directory="_usr_lib_site_packages_lldb_formatters" Guid="7bb6b96d-5190-4595-9422-329be9800426">
+        <File Id="synth.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\synth.py" Checksum="yes" />
+      </Component>
+
+      <Component Id="__init__.py_1bd1d2dc68b7417b83484f6183339af2" Directory="_usr_lib_site_packages_lldb_formatters_cpp" Guid="1bd1d2dc-68b7-417b-8348-4f6183339af2">
+        <File Id="___init__.py_1bd1d2dc68b7417b83484f6183339af2" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\__init__.py" Checksum="yes" />
+      </Component>
+      <Component Id="gnu_libstdcpp.py" Directory="_usr_lib_site_packages_lldb_formatters_cpp" Guid="c7b267dc-53a1-4639-8409-65ca9bd2f238">
+        <File Id="gnu_libstdcpp.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\gnu_libstdcpp.py" Checksum="yes" />
+      </Component>
+      <Component Id="libcxx.py" Directory="_usr_lib_site_packages_lldb_formatters_cpp" Guid="11041e50-1d58-4022-a5e8-5034bf0c3dbf">
+        <File Id="libcxx.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\libcxx.py" Checksum="yes" />
+      </Component>
+
+      <Component Id="__init__.py_52ef75ed702f4acc8272e6b2f8aa5392" Directory="_usr_lib_site_packages_lldb_utils" Guid="52ef75ed-702f-4acc-8272-e6b2f8aa5392">
+        <File Id="___init__.py_52ef75ed702f4acc8272e6b2f8aa5392" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\__init__.py" Checksum="yes" />
+      </Component>
+      <Component Id="in_call_stack.py" Directory="_usr_lib_site_packages_lldb_utils" Guid="41cfbf1f-0007-490b-aa41-85ba42e800a4">
+        <File Id="in_call_stack.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\in_call_stack.py" Checksum="yes" />
+      </Component>
+      <Component Id="symbolication.py" Directory="_usr_lib_site_packages_lldb_utils" Guid="1f3134e6-3b8b-47aa-9103-dfff71d9f953">
+        <File Id="symbolication.py" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\symbolication.py" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="lldbDebugInfo">
+      <Component Id="lldb_server.pdb" Directory="_usr_bin" Guid="6c5964a1-978c-4c07-b36b-95ace75fba56">
+        <File Id="lldb_server.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.pdb" Checksum="yes" DiskId="5" />
+      </Component>
+      <Component Id="lldb_vscode.pdb" Directory="_usr_bin" Guid="4cf41f68-7dfc-4b69-97c5-2c1591b80b40">
+        <File Id="lldb_vscode.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.pdb" Checksum="yes" DiskId="5" />
+      </Component>
+      <Component Id="lldb.pdb" Directory="_usr_bin" Guid="346dd53d-96b3-40c9-b1c9-d3bcbfb1fe9c">
+        <File Id="lldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.pdb" Checksum="yes" DiskId="5" />
+      </Component>
+
+      <Component Id="liblldb.pdb" Directory="_usr_bin" Guid="07a46aa1-620c-43d2-b762-c16b5e0219f3">
+        <File Id="liblldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.pdb" Checksum="yes" DiskId="5" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="BlocksRuntime">
+      <Component Id="BlocksRuntime.dll" Directory="_usr_bin" Guid="a5f1af33-9980-4b5d-a503-7b9aa6b28fae">
+        <File Id="BlocksRuntime.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
+      </Component>
+
+      <!-- TODO(compnerd) should we install the block headers and import libraries? -->
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="BlocksRuntimeDebugInfo">
+      <Component Id="BlocksRuntime.pdb" Directory="_usr_bin" Guid="431178b6-2f8a-4484-a012-9f8108613aa7">
+        <File Id="BlocksRuntime.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="dispatch">
+      <Component Id="dispatch.dll" Directory="_usr_bin" Guid="3ff2a2ed-6e2d-4065-8de5-aff556f9081c">
+        <File Id="dispatch.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
+      </Component>
+
+      <!-- TODO(compnerd) should we install the dispatch headers and import libraries? -->
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="dispatchDebugInfo">
+      <Component Id="dispatch.pdb" Directory="_usr_bin" Guid="1030bebe-2b44-4c47-98f4-0a9bdd9b5963">
+        <File Id="dispatch.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="7" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SourceKit">
+      <Component Id="sourcekitdInProc.dll" Directory="_usr_bin" Guid="56274f9b-be12-4140-a20b-2e2ae2ce0109">
+        <File Id="sourcekitdInProc.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="sourcekitd.h" Directory="_usr_include_SourceKit" Guid="bdb02d6c-b3f7-4109-bd41-fc04734484a4">
+        <File Id="sourcekitd.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\SourceKit\sourcekitd.h" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SourceKitDebugInfo">
+      <Component Id="sourcekitdInProc.pdb" Directory="_usr_bin" Guid="d21c977f-c567-4d5b-a53d-15bc841fd1d0">
+        <File Id="sourcekitdInProc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.pdb" Checksum="yes" DiskId="8" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="swift">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="swift_api_digester.exe" Directory="_usr_bin" Guid="da15592c-e034-44bf-be4c-8bcaecc9bf15">
+        <File Id="swift_api_digester.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-api-digester.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_autolink_extract.exe" Directory="_usr_bin" Guid="6cd96fba-64e9-45fa-82c1-606bdbe34774">
+        <File Id="swift_autolink_extract.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-autolink-extract.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_symbolgraph_extract.exe" Directory="_usr_bin" Guid="beef3d47-393f-4c85-a09d-8166b8ddce94">
+        <File Id="swift_symbolgraph_extract.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-symbolgraph-extract.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift_demangle.exe" Directory="_usr_bin" Guid="b7070111-d29a-4217-b26c-bd95b682dad6">
+        <File Id="swift_demangle.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_frontend.exe" Directory="_usr_bin" Guid="44511650-4571-40c5-b1cc-e4c8163c3568">
+        <File Id="swift_frontend.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDemangle.dll" Directory="_usr_bin" Guid="c3012101-ab54-46bc-9da8-7f721a27ab8c">
+        <File Id="swiftDemangle.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.dll" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftScan.dll" Directory="_usr_bin" Guid="61c41a5a-5cfe-4624-a437-4cc63526554b">
+        <File Id="_InternalSwiftScan.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.dll" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftSyntaxParser.dll" Directory="_usr_bin" Guid="07ea18c7-dcb1-442d-9079-ca1704e50f36">
+        <File Id="_InternalSwiftSyntaxParser.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftDemangle.lib" Directory="_usr_lib" Guid="074961b5-43c4-4d47-a71d-d5feeed174ed">
+        <File Id="swiftDemangle.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swiftDemangle.lib" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftScan.lib" Directory="_usr_lib" Guid="7b5611ec-98f0-4043-b69b-94274e68141c">
+        <File Id="_InternalSwiftScan.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftScan.lib" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftSyntaxParser.lib" Directory="_usr_lib" Guid="c1d75e75-026e-408b-b142-3344d4dc659c">
+        <File Id="_InternalSwiftSyntaxParser.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftSyntaxParser.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="SwiftSyntaxParser.h" Directory="_usr_include__InternalSwiftSyntaxParser" Guid="a5ce3a92-310b-437f-9167-967fbcc83f93">
+        <File Id="SwiftSyntaxParser.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxParser.h" Checksum="yes" />
+      </Component>
+      <Component Id="SwiftSyntaxCDataTypes.h" Directory="_usr_include__InternalSwiftSyntaxParser" Guid="66f3b179-8fa2-4388-9d42-dfb97c7d434e">
+        <File Id="SwiftSyntaxCDataTypes.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxCDataTypes.h" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftSyntaxParser.modulemap" Directory="_usr_include__InternalSwiftSyntaxParser" Guid="05effc98-9cba-4513-bab8-84a40a806684">
+        <File Id="_InternalSwiftSyntaxParser.modulemap" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\module.modulemap" Checksum="yes" />
+      </Component>
+
+      <Component Id="DependencyScan.h" Directory="_usr_include__InternalSwiftScan" Guid="44c94a09-383d-4493-9918-347db8cccdc0">
+        <File Id="DependencyScan.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScan.h" Checksum="yes" />
+      </Component>
+      <Component Id="DependencyScanMacros.h" Directory="_usr_include__InternalSwiftScan" Guid="340f436f-bdf9-4240-8051-5fd335603abf">
+        <File Id="DependencyScanMacros.h" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\DependencyScanMacros.h" Checksum="yes" />
+      </Component>
+      <Component Id="_InternalSwiftScan.modulemap" Directory="_usr_include__InternalSwiftScan" Guid="1aed210d-a34a-492e-b570-3e0cf95b653c">
+        <File Id="_InternalSwiftScan.modulemap" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftScan\module.modulemap" Checksum="yes" />
+      </Component>
+
+      <Component Id="ios4.json" Directory="_usr_lib_swift_migrator" Guid="86db2678-9f8b-446e-bfbc-eb45e725420e">
+        <File Id="ios4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\ios4.json" Checksum="yes" />
+      </Component>
+      <Component Id="ios42.json" Directory="_usr_lib_swift_migrator" Guid="06aa6c34-82b1-47a6-8e92-eca9b580df63">
+        <File Id="ios42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\ios42.json" Checksum="yes" />
+      </Component>
+      <Component Id="macos4.json" Directory="_usr_lib_swift_migrator" Guid="11d63a03-6e6d-4ed3-bc9e-7523317dd405">
+        <File Id="macos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\macos4.json" Checksum="yes" />
+      </Component>
+      <Component Id="macos42.json" Directory="_usr_lib_swift_migrator" Guid="09e60396-323c-4386-8173-adddea96e825">
+        <File Id="macos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\macos42.json" Checksum="yes" />
+      </Component>
+      <Component Id="ovarlay4.json" Directory="_usr_lib_swift_migrator" Guid="a2e5710c-a524-4df1-a093-3aa652ab15c0">
+        <File Id="ovarlay4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay4.json" Checksum="yes" />
+      </Component>
+      <Component Id="overlay42.json" Directory="_usr_lib_swift_migrator" Guid="1fd63a8d-1fa6-4887-a291-6f70dd4fc677">
+        <File Id="overlay42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\overlay42.json" Checksum="yes" />
+      </Component>
+      <Component Id="tvos4.json" Directory="_usr_lib_swift_migrator" Guid="e93f55cd-ebcf-4a5c-8937-454ad915d832">
+        <File Id="tvos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\tvos4.json" Checksum="yes" />
+      </Component>
+      <Component Id="tvos42.json" Directory="_usr_lib_swift_migrator" Guid="0b0e2f6f-e87d-4735-9a63-6472965575ea">
+        <File Id="tvos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\tvos42.json" Checksum="yes" />
+      </Component>
+      <Component Id="watchos4.json" Directory="_usr_lib_swift_migrator" Guid="8caa03fe-b523-482f-819d-f49fb8a7d068">
+        <File Id="watchos4.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos4.json" Checksum="yes" />
+      </Component>
+      <Component Id="watchos42.json" Directory="_usr_lib_swift_migrator" Guid="0b221d02-2fed-416e-89d2-b18b9c10d662">
+        <File Id="watchos42.json" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\migrator\watchos42.json" Checksum="yes" />
+      </Component>
+
+      <Component Id="features.json" Directory="_usr_share_swift" Guid="bee4269c-afab-431d-b32e-39cdfec6c5be">
+        <File Id="features.json" Source="$(var.TOOLCHAIN_ROOT)\usr\share\swift\features.json" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="swiftDebugInfo">
+      <Component Id="swift_demangle.pdb" Directory="_usr_bin" Guid="5ab65ead-31b4-4f87-b80a-c77f01375a0a">
+        <File Id="swift_demangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+      <Component Id="swift_frontend.pdb" Directory="_usr_bin" Guid="103fc70f-d6fa-4325-b13d-8b5678202431">
+        <File Id="swift_frontend.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+
+      <Component Id="swiftDemangle.pdb" Directory="_usr_bin" Guid="9234f831-2587-42f9-b257-7af1f9251816">
+        <File Id="swiftDemangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+      <Component Id="_InternalSwiftScan.pdb" Directory="_usr_bin" Guid="79269c96-4952-4028-b764-8cfbac6c2062">
+        <File Id="_InternalSwiftScan.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+      <Component Id="_InternalSwiftSyntaxParser.pdb" Directory="_usr_bin" Guid="989843e9-e396-4ab3-bf48-36cd6be9c3fc">
+        <File Id="_InternalSwiftSyntaxParser.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.pdb" Checksum="yes" DiskId="9" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="llbuild">
+      <Component Id="swift_build_tool.exe" Directory="_usr_bin" Guid="b5a61b2e-f18e-444c-8eac-e0401dac965f">
+        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="llbuild.dll" Directory="_usr_bin" Guid="5a20b6e2-6d0c-49c3-88fa-6179591a7df2">
+        <File Id="llbuild.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.dll" Checksum="yes" />
+      </Component>
+      <Component Id="llbuildSwift.dll" Directory="_usr_bin" Guid="93fd1e4e-7b70-4440-93fb-0889e50840f3">
+        <File Id="llbuildSwift.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" Checksum="yes" />
+      </Component>
+
+      <Component Id="BlocksRuntime.lib" Directory="_usr_lib" Guid="33221a05-d071-432c-b9a1-196b14d2ea19">
+        <File Id="BlocksRuntime.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\BlocksRuntime.lib" Checksum="yes" />
+      </Component>
+      <Component Id="dispatch.lib" Directory="_usr_lib" Guid="5a001bb8-4557-41eb-8d2d-38870cd2e9dc">
+        <File Id="dispatch.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\dispatch.lib" Checksum="yes" />
+      </Component>
+      <Component Id="sourcekitdInProc.lib" Directory="_usr_lib" Guid="f95bebbf-15ec-4cd5-9d1f-dd831ce34a9d">
+        <File Id="sourcekitdInProc.lib" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\sourcekitdInProc.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="llbuildDebugInfo">
+      <Component Id="swift_build_tool.pdb" Directory="_usr_bin" Guid="93a981d1-a4c4-4949-aee4-762a052212eb">
+        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" DiskId="10" />
+      </Component>
+
+      <Component Id="llbuild.pdb" Directory="_usr_bin" Guid="1ea909f5-2170-42af-b544-883566e905ac">
+        <File Id="llbuild.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuild.pdb" Checksum="yes" DiskId="10" />
+      </Component>
+      <Component Id="llbuildSwift.pdb" Directory="_usr_bin" Guid="07c8df77-4dd8-4081-90ba-28ebd2b4e560">
+        <File Id="llbuildSwift.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" DiskId="10" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftArgumentParser">
+      <Component Id="ArgumentParser.dll" Directory="_usr_bin" Guid="1c179884-b2b1-46c8-b359-ef4271001f44">
+        <File Id="ArgumentParser.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
+      </Component>
+      <Component Id="ArgumentParserToolInfo.dll" Directory="_usr_bin" Guid="90fdb69c-5dc3-4f91-8162-17b4967c5c79">
+        <File Id="ArgumentParserToolInfo.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftArgumentParserDebugInfo">
+      <Component Id="ArgumentParser.pdb" Directory="_usr_bin" Guid="4bd6bcaf-85be-4d3e-b952-4efee6a95f27">
+        <File Id="ArgumentParser.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" DiskId="11" />
+      </Component>
+      <Component Id="ArgumentParserToolInfo.pdb" Directory="_usr_bin" Guid="e253ba97-6252-4fba-a8e9-0d443bf3304d">
+        <File Id="ArgumentParserToolInfo.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParserToolInfo.pdb" Checksum="yes" DiskId="11" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftToolsSupportCore">
+      <Component Id="TSCBasic.dll" Directory="_usr_bin" Guid="62671622-472e-421d-80ea-39fcb8bf42d4">
+        <File Id="TSCBasic.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" Checksum="yes" />
+      </Component>
+      <Component Id="TSCLibc.dll" Directory="_usr_bin" Guid="39419473-0200-4511-826c-0d23d318f519">
+        <File Id="TSCLibc.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.dll" Checksum="yes" />
+      </Component>
+      <Component Id="TSCUtility.dll" Directory="_usr_bin" Guid="48e56d2f-928b-4c8e-955d-f4126fa70a83">
+        <File Id="TSCUtility.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftToolsSupportCoreDebugInfo">
+      <Component Id="TSCBasic.pdb" Directory="_usr_bin" Guid="c4cfe6d9-232c-47be-88f3-a84045d20b82">
+        <File Id="TSCBasic.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" DiskId="12" />
+      </Component>
+      <Component Id="TSCLibc.pdb" Directory="_usr_bin" Guid="2ce7667d-d502-42cb-af85-5e63e49c9a86">
+        <File Id="TSCLibc.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCLibc.pdb" Checksum="yes" DiskId="12" />
+      </Component>
+      <Component Id="TSCUtility.pdb" Directory="_usr_bin" Guid="c316113b-5459-4d27-b006-122e82687cf7">
+        <File Id="TSCUtility.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" DiskId="12" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="Yams">
+      <Component Id="Yams.dll" Directory="_usr_bin" Guid="d777b16f-f1e7-4ff7-a9d7-d723e5e6f3c5">
+        <File Id="Yams.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="YamsDebugInfo">
+      <Component Id="Yams.pdb" Directory="_usr_bin" Guid="3cc239b3-7f89-4802-9d88-4a48b5710c55">
+        <File Id="Yams.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" DiskId="13" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <ComponentGroup Id="SwiftDriver">
+      <!-- TODO(compnerd) can we use symbolic links instead? -->
+      <Component Id="swiftc.exe" Directory="_usr_bin" Guid="844e82b0-d6e9-45a2-a79f-dd117b1d6cd9">
+        <File Id="swiftc.exe" Name="swiftc.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="swift.exe" Directory="_usr_bin" Guid="dc2b9bff-0fbc-4cfc-b296-aca1afa6de7d">
+        <File Id="swift.exe" Name="swift.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_help.exe" Directory="_usr_bin" Guid="f3852440-8ba0-4cb3-9306-9d608c04e84e">
+        <File Id="swift_help.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-help.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_build_sdk_interfaces.exe" Directory="_usr_bin" Guid="d94bea7a-5ebf-4a1f-ac28-21d82e1859a5">
+        <File Id="swift_build_sdk_interfaces.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-sdk-interfaces.exe" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftOptions.dll" Directory="_usr_bin" Guid="17118b7d-0f41-4665-b3af-79698eb2b5a1">
+        <File Id="SwiftOptions.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDriver.dll" Directory="_usr_bin" Guid="4d8b774c-1e2b-4b88-b0fd-ff50d415d6a7">
+        <File Id="SwiftDriver.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
+      </Component>
+      <Component Id="swiftDriverExecution.dll" Directory="_usr_bin" Guid="d4a1a188-6ffc-4d4c-bacb-4baf43dc4340">
+        <File Id="SwiftDriverExecution.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriverExecution.dll" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <?ifdef INCLUDE_DEBUG_INFO ?>
+    <ComponentGroup Id="SwiftDriverDebugInfo">
+      <Component Id="swift.pdb" Directory="_usr_bin" Guid="1a279dbb-24d1-4025-82c9-b386e5434ae2">
+        <File Id="swift.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+      <Component Id="swift_help.pdb" Directory="_usr_bin" Guid="7e7ea69a-101f-47e3-a74d-b38d00639ad6">
+        <File Id="swift_help.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-help.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+      <Component Id="swift_build_sdk_interfaces.pdb" Directory="_usr_bin" Guid="ea1bcfbf-77a1-4b11-ab94-0981d2bbd2da">
+        <File Id="swift_build_sdk_interfaces.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-build-sdk-interfaces.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+
+      <Component Id="SwiftOptions.pdb" Directory="_usr_bin" Guid="57fbbc35-f028-483b-b976-de0f9c3fe1ad">
+        <File Id="SwiftOptions.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+      <Component Id="SwiftDriver.pdb" Directory="_usr_bin" Guid="f64ba7f7-dd9d-4009-b9ea-54cb4302f058">
+        <File Id="SwiftDriver.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+      <Component Id="SwiftDriverExecution.pdb" Directory="_usr_bin" Guid="477c115e-84cb-4452-8d6c-514ff7851952">
+        <File Id="SwiftDriverExecution.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.pdb" Checksum="yes" DiskId="14" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="EnvironmentVariables" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
+        <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer" />
+        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
+      </Component>
+    </DirectoryRef>
+
+    <Feature Id="Toolchain" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows aarch64" Level="1" Title="Swift Toolchain for Windows aarch64">
+      <ComponentGroupRef Id="binutils" />
+      <ComponentGroupRef Id="clang" />
+      <ComponentGroupRef Id="lld" />
+      <ComponentGroupRef Id="lldb" />
+      <ComponentGroupRef Id="BlocksRuntime" />
+      <ComponentGroupRef Id="dispatch" />
+      <ComponentGroupRef Id="SourceKit" />
+      <ComponentGroupRef Id="swift" />
+      <ComponentGroupRef Id="llbuild" />
+      <ComponentGroupRef Id="SwiftArgumentParser" />
+      <ComponentGroupRef Id="SwiftToolsSupportCore" />
+      <ComponentGroupRef Id="Yams" />
+      <ComponentGroupRef Id="SwiftDriver" />
+
+      <ComponentGroupRef Id="ClangResources" />
+      <!--
+      <ComponentGroupRef Id="SwiftShims" />
+      -->
+
+      <ComponentRef Id="EnvironmentVariables" />
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows aarch64" Level="0" Title="Debug Information">
+        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+        <ComponentGroupRef Id="binutilsDebugInfo" />
+        <ComponentGroupRef Id="clangDebugInfo" />
+        <ComponentGroupRef Id="lldDebugInfo" />
+        <ComponentGroupRef Id="lldbDebugInfo" />
+        <ComponentGroupRef Id="BlocksRuntimeDebugInfo" />
+        <ComponentGroupRef Id="dispatchDebugInfo" />
+        <ComponentGroupRef Id="SourceKitDebugInfo" />
+        <ComponentGroupRef Id="swiftDebugInfo" />
+        <ComponentGroupRef Id="llbuildDebugInfo" />
+        <ComponentGroupRef Id="SwiftArgumentParserDebugInfo" />
+        <ComponentGroupRef Id="SwiftToolsSupportCoreDebugInfo" />
+        <ComponentGroupRef Id="YamsDebugInfo" />
+        <ComponentGroupRef Id="SwiftDriverDebugInfo" />
+      </Feature>
+      <?endif?>
+    </Feature>
+
+    <!-- UI -->
+    <UI />
+  </Product>
+</Wix>


### PR DESCRIPTION
Add the manifests for the ARM64 toolchain which is required to actually produce
the ARM64 installer for the Windows toolchain.