### PR TITLE
WiX: _Distributed and swift-collections are not part of 5.5

### DIFF
--- a/platforms/Windows/devtools.wxs
+++ b/platforms/Windows/devtools.wxs
@@ -135,21 +135,6 @@
       </Component>
       <?endif?>
 
-      <!-- swift-collections -->
-      <Component Id="SWIFT_COLLECTIONS_BINS" Guid="f4634058-6477-4f8f-aa99-76a074056c2f">
-        <File Id="COLLECTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
-        <File Id="DEQUE_MODULE_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.dll" Checksum="yes" />
-        <File Id="ORDERED_COLLECTIONS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.dll" Checksum="yes" />
-      </Component>
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_COLLECTIONS_DEBUGINFO" Guid="3c709129-5383-47c8-a86a-38d44a575095">
-        <File Id="COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
-        <File Id="DEQUE_MODULE_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
-        <File Id="ORDERED_COLLECTIONS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
-      </Component>
-      <?endif?>
-
       <!-- swift-driver -->
       <Component Id="SWIFT_DRIVER_BINS" Guid="6108d465-9eb5-441f-8cde-5437457fb539">
         <File Id="SWIFT_DRIVER_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" Checksum="yes" />
@@ -264,7 +249,6 @@
       <ComponentRef Id="SOURCEKIT_LSP_BINS" />
       <ComponentRef Id="SWIFT_ARGUMENT_PARSER_BINS" />
       <ComponentRef Id="SWIFT_CRYPTO_BINS" />
-      <ComponentRef Id="SWIFT_COLLECTIONS_BINS" />
       <ComponentRef Id="SWIFT_DRIVER_BINS" />
       <ComponentRef Id="SWIFT_PACKAGE_MANAGER_BINS" />
       <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_BINS" />
@@ -280,7 +264,6 @@
       <ComponentRef Id="SOURCEKIT_LSP_DEBUGINFO" />
       <ComponentRef Id="SWIFT_ARGUMENT_PARSER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_CRYPTO_DEBUGINFO" />
-      <ComponentRef Id="SWIFT_COLLECTIONS_DEBUGINFO" />
       <ComponentRef Id="SWIFT_DRIVER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_PACKAGE_MANAGER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_DEBUGINFO" />

--- a/platforms/Windows/runtime.wxs
+++ b/platforms/Windows/runtime.wxs
@@ -33,7 +33,6 @@
         <File Id="FOUNDATION_XML_DLL" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
         <File Id="SWIFT_CONCURRENCY_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
         <File Id="SWIFT_DIFFERENTIATION_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.dll" Checksum="yes" />
-        <File Id="SWIFT_DISTRIBUTED_DLL" Source="$(var.SDK_ROOT)\usr\bin\swift_Distributed.dll" Checksum="yes" />
         <File Id="SWIFTCORE_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
         <File Id="SWIFTDISPATCH_DLL" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
         <!-- <File Id="SWIFTDEMANGLE_DLL" Source="$(var.SDK_ROOT)\bin\swiftDemangle.dll" Checksum="yes" /> -->
@@ -54,7 +53,6 @@
         <File Id="FOUNDATION_XML_PDB" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
         <File Id="SWIFT_CONCURRENCY_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
         <File Id="SWIFT_DIFFERENTIATION_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
-        <File Id="SWIFT_DISTRIBUTED_PDB" Source="$(var.SDK_ROOT)\usr\bin\swift_Distributed.pdb" Checksum="yes" DiskId="2" />
         <File Id="SWIFTCORE_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
         <File Id="SWIFTDISPATCH_PDB" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
         <!-- <File Id="SWIFTDEMANGLE_PDB" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" /> -->

--- a/platforms/Windows/sdk.wxs
+++ b/platforms/Windows/sdk.wxs
@@ -62,8 +62,6 @@
                                 </Directory>
                                 <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__DIFFERENTIATION_SWIFTMODULE" Name="_Differentiation.swiftmodule">
                                 </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__DISTRIBUTED_SWIFTMODULE" Name="_Distributed.swiftmodule">
-                                </Directory>
                                 <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_CRT_SWIFTMODULE" Name="CRT.swiftmodule">
                                 </Directory>
                                 <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_DISPATCH_SWIFTMODULE" Name="dispatch.swiftmodule">
@@ -180,14 +178,6 @@
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64__DISTRIBUTED_SWIFTMODULE">
-      <Component Id="_DISTRIBUTED_SWIFTMODULE" Guid="63ea424f-ae9f-4e47-b5d4-cdd04ebc5fdd">
-        <File Id="_DISTRIBUTED_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-        <File Id="_DISTRIBUTED_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-        <File Id="_DISTRIBUTED_SWIFTMODULE_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
-
     <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_CRT_SWIFTMODULE">
       <Component Id="CRT_SWIFTMODULE" Guid="fef33579-241c-44a6-b772-cfdc5721fcc7">
         <File Id="CRT_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
@@ -259,10 +249,6 @@
 
       <Component Id="_DIFFERENTIATION_IMPORT_LIBS" Guid="a240db64-c797-4e43-9c52-ec5e16a36bf9">
         <File Id="SWIFT_DIFFERENTIATION_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Differentiation.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="_DISTRIBUTED_IMPORT_LIBS" Guid="c3d65ddc-89e9-4ff9-bf1f-ef91bc0b1009">
-        <File Id="SWIFT_DISTRIBUTED_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Distributed.lib" Checksum="yes" />
       </Component>
 
       <Component Id="BLOCKS_RUNTIME_IMPORT_LIBS" Guid="c521f7e9-179a-49ed-a643-035d8a96be56">
@@ -348,7 +334,6 @@
 
       <ComponentRef Id="_CONCURRENCY_SWIFTMODULE" />
       <ComponentRef Id="_DIFFERENTIATION_SWIFTMODULE" />
-      <ComponentRef Id="_DISTRIBUTED_SWIFTMODULE" />
       <ComponentRef Id="CRT_SWIFTMODULE" />
       <ComponentRef Id="DISPATCH_SWIFTMODULE" />
       <ComponentRef Id="FOUNDATION_SWIFTMODULE" />
@@ -360,7 +345,6 @@
 
       <ComponentRef Id="_CONCURRENCY_IMPORT_LIBS" />
       <ComponentRef Id="_DIFFERENTIATION_IMPORT_LIBS" />
-      <ComponentRef Id="_DISTRIBUTED_IMPORT_LIBS" />
       <!-- <ComponentRef Id="CRT_IMPORT_LIBS" /> -->
       <!-- <ComponentRef Id="DISPATCH_IMPORT_LIBS" /> -->
       <ComponentRef Id="FOUNDATION_IMPORT_LIBS" />


### PR DESCRIPTION
WiX project for Swift 5.5 for Windows refers to some components which are not present in a 5.5 snapshot. This patch removes nonexistent components and allows us to build the complete installer.