### PR TITLE
shared: Add `vcpkg` manifests

### DIFF
--- a/shared/Foundation/vcpkg.json
+++ b/shared/Foundation/vcpkg.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "swift-foundation",
+    "version-string": "main",
+    "builtin-baseline": "44d94c2edbd44f0c01d66c2ad95eb6982a9a61bc",
+    "dependencies": [
+        { "name": "curl", "default-features": false },
+        "libxml2"
+    ],
+    "overrides": [
+        { "name": "curl", "version": "7.78.0" },
+        { "name": "libxml2", "version": "2.9.12" }
+    ]
+}

--- a/shared/LLBuild/vcpkg.json
+++ b/shared/LLBuild/vcpkg.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "swift-llbuild",
+    "version-string": "main",
+    "builtin-baseline": "44d94c2edbd44f0c01d66c2ad95eb6982a9a61bc",
+    "dependencies": ["sqlite3"],
+    "overrides": [
+        { "name": "sqlite3", "version": "3.36.0" }
+    ]
+}

--- a/shared/TSC/vcpkg.json
+++ b/shared/TSC/vcpkg.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "swift-tools-support-core",
+    "version-string": "main",
+    "builtin-baseline": "44d94c2edbd44f0c01d66c2ad95eb6982a9a61bc",
+    "dependencies": ["sqlite3"],
+    "overrides": [
+        { "name": "sqlite3", "version": "3.36.0" }
+    ]
+}


### PR DESCRIPTION
`vcpkg` uses a JSON manifest file to specify dependencies, and we keep all the manifests here as part of build infrastructure. Initially `vcpkg` is intended to be used on Windows, because these libraries are provided by the system on Linux and macOS, but it can be used on these platforms too.

This follows the pattern of #21 but has a different context.

- Closes apple/swift-corelibs-foundation#3145
- Closes apple/swift-tools-support-core#293