### PR TITLE
WiX: Improvements to Windows packaging

### DIFF
--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -57,6 +57,9 @@
       <Component Id="swift_StringProcessing.dll" Guid="198f58ad-8797-40ee-b109-dec6f9b57b27">
         <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
       </Component>
+      <Component Id="swiftCxx.dll" Guid="f5af3d1d-bb5f-4fae-b61c-ade58a581aec">
+        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
+      </Component>
       <Component Id="swiftCore.dll" Guid="4098dff8-8b8d-48ee-a234-d29104d4c809">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
@@ -119,6 +122,9 @@
       </Component>
       <Component Id="swift_StringProcessing.pdb" Guid="d123c083-9dca-4814-875e-27458ae378d9">
         <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCxx.pdb" Guid="92375416-d9ac-46fc-810d-df566a9b925d">
+        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" />
       </Component>
       <Component Id="swiftCore.pdb" Guid="57d56adc-dc40-4d6f-b0d7-11d472f11dbe">
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -21,7 +21,7 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift">
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]Swift">
       NOT INSTALLDIR
     </SetDirectory>
 

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -21,7 +21,7 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift">
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]Swift">
       NOT INSTALLDIR
     </SetDirectory>
 

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -57,6 +57,9 @@
       <Component Id="swift_StringProcessing.dll" Guid="0e0dc47f-1e80-4ed1-8ee9-7de8139086ed">
         <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
       </Component>
+      <Component Id="swiftCxx.dll" Guid="d21a84bc-0dc3-4cf0-ad73-c5adb869e426">
+        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
+      </Component>
       <Component Id="swiftCore.dll" Guid="b11c37b0-b6ad-4e55-b4e7-0517ff7a161f">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
@@ -119,6 +122,9 @@
       </Component>
       <Component Id="swift_StringProcessing.pdb" Guid="6fd2d711-4452-4aca-91c0-34e240bcc2d0">
         <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCxx.pdb" Guid="36a3f6f8-c21c-4e4c-96f8-c71c122f19f5">
+        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" />
       </Component>
       <Component Id="swiftCore.pdb" Guid="ba858ada-58f6-499d-a9f3-fdad7e858e15">
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -56,6 +56,9 @@
       <Component Id="swift_StringProcessing.dll" Guid="e6070d4e-9e60-46cb-94a4-ec499c354099">
         <File Id="swift_StringProcessing.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.dll" Checksum="yes" />
       </Component>
+      <Component Id="swiftCxx.dll" Guid="a5d30abb-60b3-494f-b624-9e81849becc3">
+        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
+      </Component>
       <Component Id="swiftCore.dll" Guid="d816134d-2de1-4e50-90dd-a36675c09c3e">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
@@ -118,6 +121,9 @@
       </Component>
       <Component Id="swift_StringProcessing.pdb" Guid="e1d856db-107e-452b-95ba-d8b0c4bc4cbf">
         <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCxx.pdb" Guid="2d963676-077d-49ae-8f31-ddeab8bfcaba">
+        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" />
       </Component>
       <Component Id="swiftCore.pdb" Guid="abd0c880-8dcc-4c23-88d4-afb224d3433b">
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -20,7 +20,7 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFilesFolder]swift">
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFilesFolder]Swift">
       NOT INSTALLDIR
     </SetDirectory>
 

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -72,6 +72,8 @@
                             </Directory>
                             <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
                             </Directory>
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                            </Directory>
                             <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                             </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
@@ -315,6 +317,22 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="Cxx">
+      <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="570b8867-4493-4de2-bba4-b0b68e34a764">
+        <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftinterface" Directory="Cxx.swiftmodule" Guid="8ce04a24-5a7e-406d-aae3-ba082df6b6e5">
+        <File Id="Cxx.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftmodule" Directory="Cxx.swiftmodule" Guid="5b8f533c-5c54-4b71-8ccd-4b4c3a51b04a">
+        <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="d138824b-c3d7-402d-a420-a5a09c5a2dcf">
+        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="CRT">
       <Component Id="CRT.swiftdoc" Directory="CRT.swiftmodule" Guid="c38cbe87-7578-45e5-a3c7-3f235bd9c1a5">
         <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
@@ -471,6 +489,7 @@
       <ComponentGroupRef Id="Distributed" />
       <ComponentGroupRef Id="_RegexParser" />
       <ComponentGroupRef Id="_StringProcessing" />
+      <ComponentGroupRef Id="Cxx" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -72,6 +72,8 @@
                             </Directory>
                             <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
                             </Directory>
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                            </Directory>
                             <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                             </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
@@ -315,6 +317,22 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="Cxx">
+      <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="91cb4a1b-aa89-40a7-b16d-52f31c97f177">
+        <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftinterface" Directory="Cxx.swiftmodule" Guid="7fadfec5-50a4-43dd-a1ca-afd3c30bd222">
+        <File Id="Cxx.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftmodule" Directory="Cxx.swiftmodule" Guid="127bfbd1-63a1-471e-9d7f-1dd09f98fc9a">
+        <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="14a6d75c-4da2-4de2-9ed4-c0b3f50486b0">
+        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="CRT">
       <Component Id="CRT.swiftdoc" Directory="CRT.swiftmodule" Guid="cf15b306-ea72-467c-9d26-b7f279ff8b87">
         <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
@@ -471,6 +489,7 @@
       <ComponentGroupRef Id="Distributed" />
       <ComponentGroupRef Id="_RegexParser" />
       <ComponentGroupRef Id="_StringProcessing" />
+      <ComponentGroupRef Id="Cxx" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -72,6 +72,8 @@
                             </Directory>
                             <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
                             </Directory>
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                            </Directory>
                             <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                             </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
@@ -315,6 +317,22 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="Cxx">
+      <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="780d937d-5e4d-4b81-8a53-c09238dc9e15">
+        <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftinterface" Directory="Cxx.swiftmodule" Guid="977f9cd7-fa36-41d1-9436-19f0adce6354">
+        <File Id="Cxx.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftmodule" Directory="Cxx.swiftmodule" Guid="5c796d4a-d750-4e58-ba11-04b2cb50f113">
+        <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="c7b16543-e93b-4f66-ac67-800c6ad823fc">
+        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="CRT">
       <Component Id="CRT.swiftdoc" Directory="CRT.swiftmodule" Guid="925b5dec-5efc-4362-8760-12f1971ed90c">
         <File Id="CRT.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
@@ -465,6 +483,7 @@
       <ComponentGroupRef Id="Distributed" />
       <ComponentGroupRef Id="_RegexParser" />
       <ComponentGroupRef Id="_StringProcessing" />
+      <ComponentGroupRef Id="Cxx" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />


### PR DESCRIPTION
- Update Program Files entry name to `Swift`, as respecting Windows convention.
- Add missing `Cxx` library in SDK and runtime profiles.