### PR TITLE
Revert "Update Installer Scripts for sourcekit-lsp to Include SwiftSyntax"

### DIFF
--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -210,20 +210,6 @@
     </ComponentGroup>
     <?endif?>
 
-    <ComponentGroup Id="SwiftSyntax">
-      <Component Id="SwiftSyntax.dll" Directory="_usr_bin" Guid="993a205e-3f9c-4033-8004-5ecd28141b1f">
-        <File Id="SwiftSyntax.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftSyntax.dll" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftSyntaxDebugInfo">
-      <Component Id="SwiftSyntax.pdb" Directory="_usr_bin" Guid="8973f7dc-06d8-49fc-b5bf-51368dbea1d4">
-        <File Id="SwiftSyntax.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftSyntax.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="IndexStoreDB">
       <Component Id="IndexStoreDB.dll" Directory="_usr_bin" Guid="cc64657d-581f-4295-9834-5471d6cd8aaa">
         <File Id="IndexStoreDB.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\IndexStoreDB.dll" Checksum="yes" />
@@ -259,7 +245,6 @@
       <ComponentGroupRef Id="SwiftPackageManager" />
       <ComponentGroupRef Id="SourceKitLSP" />
       <ComponentGroupRef Id="IndexStoreDB" />
-      <ComponentGroupRef Id="SwiftSyntax" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows x86_64" Level="0" Title="Debug Info">
@@ -270,7 +255,6 @@
         <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />
         <ComponentGroupRef Id="SourceKitLSPDebugInfo" />
         <ComponentGroupRef Id="IndexStoreDBDebugInfo" />
-        <ComponentGroupRef Id="SwiftSyntaxDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -224,20 +224,6 @@
     </ComponentGroup>
     <?endif?>
 
-    <ComponentGroup Id="SwiftSyntax">
-      <Component Id="SwiftSyntax.dll" Directory="_usr_bin" Guid="e531a79d-187f-4b2d-80bc-a2267a953c60">
-        <File Id="SwiftSyntax.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftSyntax.dll" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftSyntaxDebugInfo">
-      <Component Id="SwiftSyntax.pdb" Directory="_usr_bin" Guid="c95d81d7-d6f9-423c-933e-b59b99006218">
-        <File Id="SwiftSyntax.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SwiftSyntax.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SourceKitLSP">
       <Component Id="sourcekit_lsp.exe" Directory="_usr_bin" Guid="1e4d7fbd-a435-4d11-bd17-2dec0b235c28">
         <File Id="sourcekit_lsp.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
@@ -259,7 +245,6 @@
       <ComponentGroupRef Id="SwiftPackageManager" />
       <ComponentGroupRef Id="SourceKitLSP" />
       <ComponentGroupRef Id="IndexStoreDB" />
-      <ComponentGroupRef Id="SwiftSyntax" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows aarch64" Level="0" Title="Debug Info">
@@ -270,7 +255,6 @@
         <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />
         <ComponentGroupRef Id="SourceKitLSPDebugInfo" />
         <ComponentGroupRef Id="IndexStoreDBDebugInfo" />
-        <ComponentGroupRef Id="SwiftSyntaxDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>


### PR DESCRIPTION
Reverts apple/swift-installer-scripts#145

This is currently forcefully being built as static, revert the packaging change.