### PR TITLE
Adjusts Ubuntu related patches to build 5.7.1

### DIFF
--- a/platforms/Linux/DEB/Shared/build_deb.sh
+++ b/platforms/Linux/DEB/Shared/build_deb.sh
@@ -36,7 +36,7 @@ mk-build-deps --install ${package_dir}/debian/control.in --tool 'apt-get -y -o D
 # build the installable package
 # TODO: add signing key information
 cd ${package_dir}
-DEB_BUILD_OPTIONS=parallel=64 debuild
+DEB_BUILD_OPTIONS=parallel=64 debuild -sa
 
 # copy the final packages to /output
 cd ${staging_dir}

--- a/platforms/Linux/DEB/Shared/versions.sh
+++ b/platforms/Linux/DEB/Shared/versions.sh
@@ -4,7 +4,7 @@ debversion=5.7.1
 
 swift_version=5.7.1-RELEASE
 icu_version=65-1
-yams_version=4.0.2
+yams_version=5.0.1
 swift_argument_parser_version=1.0.3
 swift_crypto_version=1.1.5
 ninja_version=1.10.2

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/changelog
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/changelog
@@ -2,4 +2,4 @@ swiftlang (5.7.1-1) focal; urgency=medium
 
   * Debian packaging updated for Swift 5.7.1.
 
- -- Matias Piipari <matias.piipari@gmail.com>  Tue, 15 Mar 2022 16:36:34 -0700
+ -- Matias Piipari <matias.piipari@gmail.com>  Tue, 6 Dec 2022 15:53:00 +000

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/changelog
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/changelog
@@ -1,5 +1,5 @@
 swiftlang (5.7.1-1) focal; urgency=medium
 
-  * Debian packaging introduction for Swift 5.7.1.
+  * Debian packaging updated for Swift 5.7.1.
 
- -- Julien Blache <matias.piipari@gmail.com>  Tue, 15 Mar 2022 16:36:34 -0700
+ -- Matias Piipari <matias.piipari@gmail.com>  Tue, 15 Mar 2022 16:36:34 -0700

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/changelog
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/changelog
@@ -1,5 +1,5 @@
-swiftlang (5.6.0-1) focal; urgency=medium
+swiftlang (5.7.1-1) focal; urgency=medium
 
-  * Debian packaging introduction for Swift 5.6.
+  * Debian packaging introduction for Swift 5.7.1.
 
- -- Julien Blache <jblache@apple.com>  Tue, 15 Mar 2022 16:36:34 -0700
+ -- Julien Blache <matias.piipari@gmail.com>  Tue, 15 Mar 2022 16:36:34 -0700

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/patches/build-preset-install-dir
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/patches/build-preset-install-dir
@@ -7,13 +7,14 @@ Index: swiftlang-5.7.1/swift/utils/build-presets.ini
 ===================================================================
 --- swiftlang-5.7.1.orig/swift/utils/build-presets.ini
 +++ swiftlang-5.7.1/swift/utils/build-presets.ini
-@@ -824,7 +824,8 @@ install-swiftpm
+@@ -824,7 +824,9 @@ install-swiftpm
  install-swift-driver
  install-xctest
  install-libicu
 -install-prefix=/usr
 +install-prefix=%(install_prefix)s
 +skip-early-swift-driver
++skip-build-benchmarks
  install-sourcekit-lsp
  install-swiftdocc
  build-swift-static-stdlib

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/patches/build-preset-install-dir
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/patches/build-preset-install-dir
@@ -13,6 +13,7 @@ Index: swiftlang-5.7.1/swift/utils/build-presets.ini
  install-libicu
 -install-prefix=/usr
 +install-prefix=%(install_prefix)s
++skip-early-swift-driver
  install-sourcekit-lsp
  install-swiftdocc
  build-swift-static-stdlib

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/patches/build-preset-install-dir
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/patches/build-preset-install-dir
@@ -3,16 +3,16 @@ Description: Make target installation directory a command line option
  time on the command line.
 Author: Julien Blache <jblache@apple.com>
 
-Index: swiftlang-5.6.3/swift/utils/build-presets.ini
+Index: swiftlang-5.7.1/swift/utils/build-presets.ini
 ===================================================================
---- swiftlang-5.6.3.orig/swift/utils/build-presets.ini
-+++ swiftlang-5.6.3/swift/utils/build-presets.ini
-@@ -831,7 +831,7 @@ install-swiftpm
+--- swiftlang-5.7.1.orig/swift/utils/build-presets.ini
++++ swiftlang-5.7.1/swift/utils/build-presets.ini
+@@ -824,7 +824,7 @@ install-swiftpm
  install-swift-driver
  install-xctest
  install-libicu
 -install-prefix=/usr
 +install-prefix=%(install_prefix)s
- install-libcxx
  install-sourcekit-lsp
  install-swiftdocc
+ build-swift-static-stdlib

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/patches/build-preset-install-dir
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/patches/build-preset-install-dir
@@ -7,7 +7,7 @@ Index: swiftlang-5.7.1/swift/utils/build-presets.ini
 ===================================================================
 --- swiftlang-5.7.1.orig/swift/utils/build-presets.ini
 +++ swiftlang-5.7.1/swift/utils/build-presets.ini
-@@ -824,7 +824,7 @@ install-swiftpm
+@@ -824,7 +824,8 @@ install-swiftpm
  install-swift-driver
  install-xctest
  install-libicu

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/patches/fix-toolchain-path
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/patches/fix-toolchain-path
@@ -3,11 +3,11 @@ Description: Fix toolchain path for build-script-helper.py
  assumption that /usr is used.
 Author: Julien Blache <jblache@apple.com>
 
-Index: swiftlang-5.6.3/swift/benchmark/scripts/build_script_helper.py
+Index: swiftlang-5.7.1/swift/benchmark/scripts/build_script_helper.py
 ===================================================================
---- swiftlang-5.6.3.orig/swift/benchmark/scripts/build_script_helper.py
-+++ swiftlang-5.6.3/swift/benchmark/scripts/build_script_helper.py
-@@ -53,7 +53,7 @@ def main():
+--- swiftlang-5.7.1.orig/swift/benchmark/scripts/build_script_helper.py
++++ swiftlang-5.7.1/swift/benchmark/scripts/build_script_helper.py
+@@ -51,7 +51,7 @@ def main():
      if not os.path.isdir(bin_dir):
          os.makedirs(bin_dir)
  
@@ -16,11 +16,11 @@ Index: swiftlang-5.6.3/swift/benchmark/scripts/build_script_helper.py
      perform_build(args, swiftbuild_path, "debug", "Benchmark_Onone", "-Onone")
      perform_build(args, swiftbuild_path, "release", "Benchmark_Osize", "-Osize")
      perform_build(args, swiftbuild_path, "release", "Benchmark_O", "-O")
-Index: swiftlang-5.6.3/swift/utils/swift_build_support/swift_build_support/products/benchmarks.py
+Index: swiftlang-5.7.1/swift/utils/swift_build_support/swift_build_support/products/benchmarks.py
 ===================================================================
---- swiftlang-5.6.3.orig/swift/utils/swift_build_support/swift_build_support/products/benchmarks.py
-+++ swiftlang-5.6.3/swift/utils/swift_build_support/swift_build_support/products/benchmarks.py
-@@ -100,13 +100,17 @@ class Benchmarks(product.Product):
+--- swiftlang-5.7.1.orig/swift/utils/swift_build_support/swift_build_support/products/benchmarks.py
++++ swiftlang-5.7.1/swift/utils/swift_build_support/swift_build_support/products/benchmarks.py
+@@ -100,11 +100,17 @@ class Benchmarks(product.Product):
  
  
  def _get_toolchain_path(host_target, product, args):
@@ -28,9 +28,7 @@ Index: swiftlang-5.6.3/swift/utils/swift_build_support/swift_build_support/produ
      # this logic initially was inside run_build_script_helper
      # and was factored out so it can be used in testing as well
  
--    toolchain_path = swiftpm.SwiftPM.get_install_destdir(args,
--                                                         host_target,
--                                                         product.build_dir)
+-    toolchain_path = product.host_install_destdir(host_target)
 +    install_destdir = args.install_destdir
 +    if swiftpm.SwiftPM.has_cross_compile_hosts(args):
 +        install_destdir = swiftpm.SwiftPM.get_install_destdir(args,

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/rules
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/rules
@@ -68,7 +68,7 @@ override_dh_dwz:
 	# need to investigate whether or not it is suitable for us.
 
 override_dh_auto_build:
-	swift/utils/build-script $(BUILD_SCRIPT_ARGS) --skip-early-swift-driver --preset=buildbot_linux,no_assertions,no_test \
+	swift/utils/build-script $(BUILD_SCRIPT_ARGS) --preset=buildbot_linux,no_assertions,no_test \
 		install_prefix=/opt/swift/$(SWIFTLANG_PKG_VER) \
 		install_destdir=$(SWIFT_BUILDDIR)/discard \
 		installable_package=$(SWIFT_BUILDDIR)/swiftdeb-$(SWIFTLANG_PKG_VER).tar.gz

--- a/platforms/Linux/DEB/Ubuntu/focal/debian/rules
+++ b/platforms/Linux/DEB/Ubuntu/focal/debian/rules
@@ -68,7 +68,7 @@ override_dh_dwz:
 	# need to investigate whether or not it is suitable for us.
 
 override_dh_auto_build:
-	swift/utils/build-script $(BUILD_SCRIPT_ARGS) --preset=buildbot_linux,no_assertions,no_test \
+	swift/utils/build-script $(BUILD_SCRIPT_ARGS) --skip-early-swift-driver --preset=buildbot_linux,no_assertions,no_test \
 		install_prefix=/opt/swift/$(SWIFTLANG_PKG_VER) \
 		install_destdir=$(SWIFT_BUILDDIR)/discard \
 		installable_package=$(SWIFT_BUILDDIR)/swiftdeb-$(SWIFTLANG_PKG_VER).tar.gz


### PR DESCRIPTION
I noticed the work done to make 5.7.1 on the main branch is only partial: it got mentioned somewhere, but the changelog entry didn't note 5.7.1 so the package was attempted to be built with the old 5.6.2 as its name, and some further patching seems to be necessary to make this package build work on 5.7.1 in the first place?

I am unable to get the build passing in the current state though, posting the current error message into the comment thread on this draft PR in follow-up.