### PR TITLE
WiX: package Cxx into the runtime

### DIFF
--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -60,6 +60,9 @@
       <Component Id="swiftCore.dll" Guid="4098dff8-8b8d-48ee-a234-d29104d4c809">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
+      <Component Id="swiftCxx.dll" Guid="45eb46fc-a006-4fe9-abf0-42e26e3d3c87">
+        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
+      </Component>
       <Component Id="swiftDispatch.dll" Guid="312ffb9e-7ecf-423f-8f59-3041d2776e4a">
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
       </Component>
@@ -122,6 +125,9 @@
       </Component>
       <Component Id="swiftCore.pdb" Guid="57d56adc-dc40-4d6f-b0d7-11d472f11dbe">
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCxx.pdb" Guid="d2fdd831-3da3-4f74-8a19-94cdb80eaf4b">
+        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" DiskId="2" />
       </Component>
       <Component Id="swiftDispatch.pdb" Guid="155ba810-d2a9-420e-890b-08dfb966daa6">
         <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -60,6 +60,9 @@
       <Component Id="swiftCore.dll" Guid="b11c37b0-b6ad-4e55-b4e7-0517ff7a161f">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
+      <Component Id="swiftCxx.dll" Guid="7bbf8fd4-769d-4e4f-8d62-f1d07d568ccf">
+        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
+      </Component>
       <Component Id="swiftDispatch.dll" Guid="ce50982a-4bb3-43fc-a5ce-9fc709143b47">
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
       </Component>
@@ -122,6 +125,9 @@
       </Component>
       <Component Id="swiftCore.pdb" Guid="ba858ada-58f6-499d-a9f3-fdad7e858e15">
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCxx.pdb" Guid="3e1ebd5a-e9e0-4a8d-bd02-519d93b3e9c8">
+        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" DiskId="2" />
       </Component>
       <Component Id="swiftDispatch.pdb" Guid="3a9c9745-99bb-42c8-9a6d-1da25c0365e0">
         <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -59,6 +59,9 @@
       <Component Id="swiftCore.dll" Guid="d816134d-2de1-4e50-90dd-a36675c09c3e">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
+      <Component Id="swiftCxx.dll" Guid="9752dfcf-b9fd-457d-b983-e2f346f97c3d">
+        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
+      </Component>
       <Component Id="swiftDispatch.dll" Guid="fd38df32-2bcd-4da4-98b3-f26abd1ac6de">
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
       </Component>
@@ -121,6 +124,9 @@
       </Component>
       <Component Id="swiftCore.pdb" Guid="abd0c880-8dcc-4c23-88d4-afb224d3433b">
         <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
+      </Component>
+      <Component Id="swiftCxx.pdb" Guid="e41ad064-6cb2-4fbc-9b7e-44ba17bf8264">
+        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" DiskId="2" />
       </Component>
       <Component Id="swiftDispatch.pdb" Guid="cff0a63a-a76a-4785-92b0-4894ffa19a7d">
         <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />


### PR DESCRIPTION
Add the swiftCxx module into the runtime.  This is required by any code which imports `Cxx`.