### PR TITLE
WiX: package Cxx and CxxShims in the SDK

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -74,6 +74,8 @@
                             </Directory>
                             <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                             </Directory>
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                            </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                             </Directory>
                             <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
@@ -331,6 +333,22 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="CXX">
+      <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="b170a09f-0483-486f-b7de-1e8f4e1644a4">
+        <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftinterface" Directory="Cxx.swiftmodule" Guid="49971c71-8cb4-4eac-898d-71bb14d7280e">
+        <File Id="Cxx.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftmodule" Directory="Cxx.swiftmodule" Guid="911e165b-21e9-438e-b453-1d0aa1fdf4fe">
+        <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="a90ba944-b9f6-40a6-8184-f59ae23598fe">
+        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Foundation">
       <Component Id="Foundation.swiftdoc" Directory="Foundation.swiftmodule" Guid="d5ace934-794c-416f-886e-b9ae39eb8208">
         <File Id="Foundation.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Foundation.swiftdoc" Checksum="yes" />
@@ -418,6 +436,16 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="CXXShims">
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="77450677-ce9e-43f9-9db1-35231dcf563e">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="e4fa6e5c-3dd5-49fd-9f27-a72d58c8d156">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.modulemap" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_x86_64">
       <Component Id="swiftrt.obj" Guid="e546282a-79c8-4555-a45a-68a1447fa5d8">
         <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftrt.obj" Checksum="yes" />
@@ -472,6 +500,7 @@
       <ComponentGroupRef Id="_RegexParser" />
       <ComponentGroupRef Id="_StringProcessing" />
       <ComponentGroupRef Id="CRT" />
+      <ComponentGroupRef Id="CXX" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
       <ComponentGroupRef Id="FoundationXML" />
@@ -480,6 +509,7 @@
       <ComponentGroupRef Id="WinSDK" />
 
       <ComponentGroupRef Id="SwiftShims" />
+      <ComponentGroupRef Id="CXXShims" />
 
       <ComponentGroupRef Id="Registrar" />
       <ComponentGroupRef Id="SupportFiles" />

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -74,6 +74,8 @@
                             </Directory>
                             <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                             </Directory>
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                            </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                             </Directory>
                             <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
@@ -331,6 +333,22 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="CXX">
+      <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="2decbe47-1209-4abb-b94e-1bf6a83e2028">
+        <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftinterface" Directory="Cxx.swiftmodule" Guid="3ad27fe2-031c-42de-a4ba-b2aa7bf79aa6">
+        <File Id="Cxx.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftmodule" Directory="Cxx.swiftmodule" Guid="e5bd9840-0430-46b8-b3c4-5ab389ac8c07">
+        <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="f7bcc956-462e-43df-ae25-c5f4636b27d1">
+        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Foundation">
       <Component Id="Foundation.swiftdoc" Directory="Foundation.swiftmodule" Guid="b77de995-ebe7-409b-bfe6-2ae6c24e4d8d">
         <File Id="Foundation.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\Foundation.swiftdoc" Checksum="yes" />
@@ -418,6 +436,16 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="CXXShims">
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="d579019d-d999-47f7-8b35-1d714874de80">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="b5f65b19-cf8f-4862-b378-3e299887afa3">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.modulemap" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_aarch64">
       <Component Id="swiftrt.obj" Guid="7daf0d39-db9e-4ee7-913b-7815b04f30ee">
         <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftrt.obj" Checksum="yes" />
@@ -472,6 +500,7 @@
       <ComponentGroupRef Id="_RegexParser" />
       <ComponentGroupRef Id="_StringProcessing" />
       <ComponentGroupRef Id="CRT" />
+      <ComponentGroupRef Id="CXX" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
       <ComponentGroupRef Id="FoundationXML" />
@@ -480,6 +509,7 @@
       <ComponentGroupRef Id="WinSDK" />
 
       <ComponentGroupRef Id="SwiftShims" />
+      <ComponentGroupRef Id="CXXShims" />
 
       <ComponentGroupRef Id="Registrar" />
       <ComponentGroupRef Id="SupportFiles" />

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -74,6 +74,8 @@
                             </Directory>
                             <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                             </Directory>
+                            <Directory Id="Cxx.swiftmdoule" Name="Cxx.swiftmdoule">
+                            </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                             </Directory>
                             <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
@@ -331,6 +333,22 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="CXX">
+      <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="a7c78d68-abed-4065-ba82-08d4773bf4d8">
+        <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftinterface" Directory="Cxx.swiftmodule" Guid="4f795ac4-f731-4115-984f-237f044540a0">
+        <File Id="Cxx.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="Cxx.swiftmodule" Directory="Cxx.swiftmodule" Guid="a9acf7c6-7ad7-4176-a280-ec0d534215b9">
+        <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="b2897a7a-65c2-4f0f-b14c-6b466d2e3d34">
+        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Foundation">
       <Component Id="Foundation.swiftdoc" Directory="Foundation.swiftmodule" Guid="345d3a2b-7b55-4413-82b7-7e7b7ce17798">
         <File Id="Foundation.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\Foundation.swiftdoc" Checksum="yes" />
@@ -418,6 +436,16 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="CXXShims">
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="d9653245-ca31-442a-b122-f5df3a3ad752">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.h" Checksum="yes" />
+      </Component>
+
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="52c178a4-f65b-46a4-9089-c686c755bf2e">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.modulemap" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_i686">
       <Component Id="swiftrt.obj" Guid="a3da165c-3b42-4ad2-a412-a0bb4e31cba5">
         <File Id="swiftrt.obj" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftrt.obj" Checksum="yes" />
@@ -466,6 +494,7 @@
       <ComponentGroupRef Id="_RegexParser" />
       <ComponentGroupRef Id="_StringProcessing" />
       <ComponentGroupRef Id="CRT" />
+      <ComponentGroupRef Id="CXX" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
       <ComponentGroupRef Id="FoundationXML" />
@@ -474,6 +503,7 @@
       <ComponentGroupRef Id="WinSDK" />
 
       <ComponentGroupRef Id="SwiftShims" />
+      <ComponentGroupRef Id="CXXShims" />
 
       <ComponentGroupRef Id="Registrar" />
       <ComponentGroupRef Id="SupportFiles" />


### PR DESCRIPTION
Package up the SDK contents for the C++ support module. This is required to enable use of the C++ interop functionality.