### PR TITLE
WiX: repair the Windows packaging for SPM

### DIFF
--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -104,6 +104,12 @@
       <Component Id="Commands.dll" Directory="_usr_bin" Guid="5648becc-7676-4f6e-a60e-6967f9b0ba4f">
         <File Id="Commands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
       </Component>
+      <Component Id="CoreCommands.dll" Director="_usr_bin" Guid="03cf68fb-da2b-47b8-8417-a44e4ece5438">
+        <File Id="CoreCommands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CoreCommands.dll" Checksum="yes" />
+      </Component>
+      <Component Id="DriverSupport.dll" Directory="_usr_bin" Guid="43b50a02-5180-49c9-b0a4-86273c822f87">
+        <File Id="DriverSUpport.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.dll" Checksum="yes" />
+      </COmponent>
       <Component Id="PackageGraph.dll" Directory="_usr_bin" Guid="254500b8-b2ac-4c9f-add3-6511b0e5bfa7">
         <File Id="PackageGraph.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -104,7 +104,7 @@
       <Component Id="Commands.dll" Directory="_usr_bin" Guid="5648becc-7676-4f6e-a60e-6967f9b0ba4f">
         <File Id="Commands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
       </Component>
-      <Component Id="CoreCommands.dll" Director="_usr_bin" Guid="03cf68fb-da2b-47b8-8417-a44e4ece5438">
+      <Component Id="CoreCommands.dll" Directory="_usr_bin" Guid="03cf68fb-da2b-47b8-8417-a44e4ece5438">
         <File Id="CoreCommands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CoreCommands.dll" Checksum="yes" />
       </Component>
       <Component Id="DriverSupport.dll" Directory="_usr_bin" Guid="43b50a02-5180-49c9-b0a4-86273c822f87">
@@ -176,6 +176,12 @@
       </Component>
       <Component Id="Commands.pdb" Directory="_usr_bin" Guid="949a08c5-ec4e-4d69-a18a-d8547a66c50a">
         <File Id="Commands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="CoreCommands.pdb" Directory="_usr_bin" Guid="39e660e2-e428-4828-848a-c11bccb727e2">
+        <File Id="CoreCommands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CoreCommands.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="DriverSupport.pdb" Directory="_usr_bin" Guid="e228fd9f-13df-4ec5-b989-cca47925f272">
+        <File Id="DriverSupport.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.pdb" Checksum="yes" />
       </Component>
       <Component Id="PackageGraph.pdb" Directory="_usr_bin" Guid="07b49917-5bdd-4491-a151-cb180a04aa90">
         <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />

--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -109,7 +109,7 @@
       </Component>
       <Component Id="DriverSupport.dll" Directory="_usr_bin" Guid="43b50a02-5180-49c9-b0a4-86273c822f87">
         <File Id="DriverSUpport.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.dll" Checksum="yes" />
-      </COmponent>
+      </Component>
       <Component Id="PackageGraph.dll" Directory="_usr_bin" Guid="254500b8-b2ac-4c9f-add3-6511b0e5bfa7">
         <File Id="PackageGraph.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -177,6 +177,12 @@
       <Component Id="Commands.pdb" Directory="_usr_bin" Guid="345f96d2-f9ac-4c83-8722-855686401a9d">
         <File Id="Commands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
       </Component>
+      <Component Id="CoreCommands.pdb" Directory="_usr_bin" Guid="8925173e-f45d-44ea-bc8f-a936b1a883ad">
+        <File Id="CoreCommands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CoreCommands.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="DriverSupport.pdb" Directory="_usr_bin" Guid="f8f8cb75-8f42-4522-bdd7-89499943ef32">
+        <File Id="DriverSupport.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.pdb" Checksum="yes" />
+      </Component>
       <Component Id="PackageGraph.pdb" Directory="_usr_bin" Guid="71a32056-bb8d-4d9b-ab76-e25ee6fd04bc">
         <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
       </Component>

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -104,6 +104,12 @@
       <Component Id="Commands.dll" Directory="_usr_bin" Guid="b5a08920-f173-4a1b-8b80-dae0c3d21975">
         <File Id="Commands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.dll" Checksum="yes" />
       </Component>
+      <Component Id="CoreCommands.dll" Directory="_usr_bin" Guid="d3434998-9fa8-46e3-9a94-11d3bf34462d">
+        <File Id="CoreCommands.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CoreCommands.dll" Checksum="yes" />
+      </Component>
+      <Component Id="DriverSupport.dll" Directory="_usr_bin" Guid="2c8f8a23-e0f3-4535-9c25-0e1300c24c32">
+        <File Id="DriverSupport.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.dll" Checksum="yes" />
+      </Component>
       <Component Id="PackageGraph.dll" Directory="_usr_bin" Guid="0f4cd16f-a931-401c-9b49-9fc988e8d87e">
         <File Id="PackageGraph.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
       </Component>


### PR DESCRIPTION
SPM introduced new libraries in
apple/swift-package-manager@e26417cfa1ee117cf789b195c82459189e62ca70 and apple/swift-package-manager@b30ba0bc97eae2a0bb75cf491272c99926f1bc51 but failed to update the packaging rules resulting in an unusable distribution of SPM.  Update the manifest to include the libraries.