### PR TITLE
WiX: repair the x86 SDK packaging

### DIFF
--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -74,7 +74,7 @@
                             </Directory>
                             <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                             </Directory>
-                            <Directory Id="Cxx.swiftmdoule" Name="Cxx.swiftmodule">
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
                             </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                             </Directory>

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -74,7 +74,7 @@
                             </Directory>
                             <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
                             </Directory>
-                            <Directory Id="Cxx.swiftmdoule" Name="Cxx.swiftmdoule">
+                            <Directory Id="Cxx.swiftmdoule" Name="Cxx.swiftmodule">
                             </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                             </Directory>
@@ -437,12 +437,12 @@
     </ComponentGroup>
 
     <ComponentGroup Id="CXXShims">
-      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="d9653245-ca31-442a-b122-f5df3a3ad752">
-        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.h" Checksum="yes" />
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="d9653245-ca31-442a-b122-f5df3a3ad752">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\libcxxshim.h" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="52c178a4-f65b-46a4-9089-c686c755bf2e">
-        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.modulemap" Checksum="yes" />
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="52c178a4-f65b-46a4-9089-c686c755bf2e">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\libcxxshim.modulemap" Checksum="yes" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
The changes in 4b08ef66638e0af99137c0b287a1d509e1a7fc6d failed to adjust the i686 paths due to copy-paste replication from the x86_64 target. Additionally, a typo would further fail to resolve locations.  This allows packaging the x86 SDK once again.