### PR TITLE
WiX: repair ARM64 SDK packaging

### DIFF
--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -437,12 +437,12 @@
     </ComponentGroup>
 
     <ComponentGroup Id="CXXShims">
-      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="d579019d-d999-47f7-8b35-1d714874de80">
-        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.h" Checksum="yes" />
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="d579019d-d999-47f7-8b35-1d714874de80">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\libcxxshim.h" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="b5f65b19-cf8f-4862-b378-3e299887afa3">
-        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.modulemap" Checksum="yes" />
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="b5f65b19-cf8f-4862-b378-3e299887afa3">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\libcxxshim.modulemap" Checksum="yes" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
Correct copy-paste errors that prevented the ARM64 SDK from being packaged.