### PR TITLE
WiX: correct substitution for product version

### DIFF
--- a/platforms/Windows/devtools.wixproj
+++ b/platforms/Windows/devtools.wixproj
@@ -12,7 +12,7 @@
     <ProductArchitecture>$(ProductArchitecture)</ProductArchitecture>
 
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
-    <ProductVersion>0.0.0</ProductVersion>
+    <ProductVersion>$(ProductVersion)</ProductVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Ensure that we encode the correct value for the product for the devtools MSI.