### PR TITLE
WiX: integrate signing support into the MSBuild path

### DIFF
--- a/platforms/Windows/WiXCodeSigning.targets
+++ b/platforms/Windows/WiXCodeSigning.targets
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SignOutput Condition=" '$(SignOutput)' == '' ">false</SignOutput>
+    <SignOutput>$(SignOutput)</SignOutput>
+  </PropertyGroup>
+
+  <Target Name="FindSignTool">
+    <PropertyGroup>
+      <WindowsKitsRoot Condition=" '$(WindowsKitsRoot)' == '' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot10', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
+      <WindowsKitsRoot Condition=" '$(WindowsKitsRoot)' == '' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot81', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
+      <WindowsKitsRoot Condition=" '$(WindowsKitsRoot)' == '' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
+
+      <!-- Windows 11 SDKs -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.22621.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22621.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.22000.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22000.0\x64\</SignToolPath>
+      <!-- Windows 10 SDKs -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.20348.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.20348.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.19041.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.19041.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.18362.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.18362.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.17763.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.17763.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.17134.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.17134.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.16299.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.16299.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.15063.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.15063.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.14393.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.14393.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.10586.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10586.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.10240.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10240.0\x64\</SignToolPath>
+      <!-- Windows 8.1 SDKS -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\x64\signtool.exe')">$(WindowsKitsRoot)bin\x64\</SignToolPath>
+
+      <!-- Windows 11 SDKs -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.22621.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22621.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.22000.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22000.0\arm64\</SignToolPath>
+      <!-- Windows 10 SDKs -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.20348.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.20348.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.19041.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.19041.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.18362.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.18362.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.17763.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.17763.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.17134.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.17134.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.16299.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.16299.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.15063.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.15063.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.14393.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.14393.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.10586.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10586.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.10240.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10240.0\arm64\</SignToolPath>
+
+      <SignTool>"$(SignToolPath)signtool.exe" sign /f "$(CERTIFICATE)" /p "$(PASSPHRASE)" /tr http://timestamp.digicert.com /fd sha256 /td sha256</SignTool>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="SignCabs" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;%(SignCabs.FullPath)&quot;" />
+  </Target>
+
+  <Target Name="SignMsi" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;%(SignMsi.FullPath)&quot;" />
+  </Target>
+
+  <Target Name="SignMsm" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;%(SignMsm.FullPath)&quot;" />
+  </Target>
+
+  <Target Name="SignBundleEngine" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;@(SignBundleEngine)&quot;" />
+  </Target>
+
+  <Target Name="SignBundle">
+    <Exec Command="$(SignTool) &quot;@(SignBundle)&quot;" />
+  </Target>
+</Project>

--- a/platforms/Windows/devtools.wixproj
+++ b/platforms/Windows/devtools.wixproj
@@ -27,6 +27,8 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
   </Target>
 
+  <Import Project="WiXCodeSigning.targets" />
+
   <PropertyGroup>
     <DefineConstants>ProductVersion=$(ProductVersion);DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>

--- a/platforms/Windows/installer.wixproj
+++ b/platforms/Windows/installer.wixproj
@@ -30,6 +30,8 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
   </Target>
 
+  <Import Project="WiXCodeSigning.targets" />
+
   <PropertyGroup>
     <DefineConstants>ProductVersion=$(ProductVersion);RequiredChain=$(RequiredChain);OptionalChain=$(OptionalChain);MSI_LOCATION=$(MSI_LOCATION);</DefineConstants>
   </PropertyGroup>

--- a/platforms/Windows/runtime.wixproj
+++ b/platforms/Windows/runtime.wixproj
@@ -27,6 +27,8 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
   </Target>
 
+  <Import Project="WiXCodeSigning.targets" />
+
   <PropertyGroup>
     <DefineConstants>ProductVersion=$(ProductVersion);SDK_ROOT=$(SDK_ROOT);$(INCLUDE_DEBUG_INFO)</DefineConstants>
   </PropertyGroup>

--- a/platforms/Windows/sdk.wixproj
+++ b/platforms/Windows/sdk.wixproj
@@ -27,6 +27,8 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
   </Target>
 
+  <Import Project="WiXCodeSigning.targets" />
+
   <PropertyGroup>
     <DefineConstants>ProductVersion=$(ProductVersion);PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);SWIFT_SOURCE_DIR=$(SWIFT_SOURCE_DIR);SwiftShimsPath=$(SDK_ROOT)\usr\lib\swift\shims;</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>

--- a/platforms/Windows/toolchain.wixproj
+++ b/platforms/Windows/toolchain.wixproj
@@ -27,6 +27,8 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
   </Target>
 
+  <Import Project="WiXCodeSigning.targets" />
+
   <PropertyGroup>
     <DefineConstants>ProductVersion=$(ProductVersion);DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;$(INCLUDE_DEBUG_INFO)</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>


### PR DESCRIPTION
Rather than requiring external scripting to sign the installer components, add in integrated code-signing capability into the build. With this, a user can specify additional parameters when invoking the build: `-p:SignOutput=true -p:CERTIFICATE=... -p:PASSPHRASE=...`.  By default the output is not code-signed, allowing control over the build, which is also useful for CI usage.  This reduces some of the extra logic required for signing in the CI systems.