### PR TITLE
Add DependsOnTargets to SignBundle insignia target

### DIFF
--- a/platforms/Windows/WiXCodeSigning.targets
+++ b/platforms/Windows/WiXCodeSigning.targets
@@ -63,7 +63,7 @@
     <Exec Command="$(SignTool) &quot;@(SignBundleEngine)&quot;" />
   </Target>
 
-  <Target Name="SignBundle">
+  <Target Name="SignBundle" DependsOnTargets="FindSignTool">
     <Exec Command="$(SignTool) &quot;@(SignBundle)&quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
While looking through this file I noticed that only the "SignBundle" target was missing a DependsOnTarget clause. All the others had it so seems reasonable for "SignBundle" to also.