### PR TITLE
Move installed XCTest.swiftmodule up one directory on Windows

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -30,8 +30,8 @@
                         <Directory Id="XCTest_usr_lib_swift" Name="swift">
                           <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
                             <Directory Id="XCTest_usr_lib_swift_windows_x86_64" Name="x86_64">
-                              <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
-                              </Directory>
+                            </Directory>
+                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
                             </Directory>
                           </Directory>
                         </Directory>

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -30,8 +30,8 @@
                         <Directory Id="XCTest_usr_lib_swift" Name="swift">
                           <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
                             <Directory Id="XCTest_usr_lib_swift_windows_aarch64" Name="aarch64">
-                              <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
-                              </Directory>
+                            </Directory>
+                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
                             </Directory>
                           </Directory>
                         </Directory>

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -30,8 +30,8 @@
                         <Directory Id="XCTest_usr_lib_swift" Name="swift">
                           <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
                             <Directory Id="XCTest_usr_lib_swift_windows_i686" Name="i686">
-                              <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
-                              </Directory>
+                            </Directory>
+                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
                             </Directory>
                           </Directory>
                         </Directory>


### PR DESCRIPTION
The layout of the XCTest directories on Windows is currently inconsistent between local builds and installed builds. This change resolves the inconsistency by updating swiftmodule directory location for XCTest from:

`XCTest\usr\lib\swift\windows\%ARCH%\XCTest.swiftmodule`
To
`XCTest\usr\lib\swift\windows\XCTest.swiftmodule`

This allows us to use the same include path on all architectures and matches other standard modules. SPM was previously updated accordingly here: https://github.com/apple/swift-package-manager/pull/4300 but the related #119 did not update the paths for `XCTest`.