### PR TITLE
Allow overriding the XCTest directory in the Windows installer build

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -118,23 +118,23 @@
     <!-- Components -->
     <ComponentGroup Id="XCTest">
       <Component Id="XCTest.dll" Directory="XCTest_usr_bin64" Guid="11b12995-a7e6-4de3-954d-d4ddc977633f">
-        <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
+        <File Id="XCTest.dll" Source="$(var.XCTEST_ROOT)\usr\bin\XCTest.dll" Checksum="yes" />
       </Component>
       <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_x86_64" Guid="3debc3cd-3f48-4cd7-8e9a-7403b1d45b37">
-        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
+        <File Id="XCTest.lib" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="12731d72-ef57-4c29-a05e-a44534b331c2">
-        <File Id="XCTest.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftdoc" Checksum="yes" />
+        <File Id="XCTest.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\x86_64\XCTest.swiftdoc" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftmodule" Directory="XCTest.swiftmodule" Guid="62ecaad6-4f0f-4009-8b0c-cd5128e3615d">
-        <File Id="XCTest.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftmodule" Checksum="yes" />
+        <File Id="XCTest.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\x86_64\XCTest.swiftmodule" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
     <?ifdef INCLUDE_DEBUG_INFO ?>
     <ComponentGroup Id="XCTestDebugInfo">
       <Component Id="XCTest.pdb" Directory="XCTest_usr_bin64" Guid="6ad780c3-7245-4b63-b0b0-ba04e65f1638">
-        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
+        <File Id="XCTest.pdb" Source="$(var.XCTEST_ROOT)\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
       </Component>
     </ComponentGroup>
     <?endif?>

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -118,23 +118,23 @@
     <!-- Components -->
     <ComponentGroup Id="XCTest">
       <Component Id="XCTest.dll" Directory="XCTest_usr_bin64a" Guid="1a0dd34e-71eb-4441-af98-fed53631e34d">
-        <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
+        <File Id="XCTest.dll" Source="$(var.XCTEST_ROOT)\usr\bin\XCTest.dll" Checksum="yes" />
       </Component>
       <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_aarch64" Guid="bce787dd-393e-4285-aa81-448557385d40">
-        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
+        <File Id="XCTest.lib" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="b2b83f97-6639-4b7b-8d32-2396463dfe71">
-        <File Id="XCTest.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\aarch64\XCTest.swiftdoc" Checksum="yes" />
+        <File Id="XCTest.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\aarch64\XCTest.swiftdoc" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftmodule" Directory="XCTest.swiftmodule" Guid="51ce13c0-ca04-4ee4-bb72-c0804cbbe405">
-        <File Id="XCTest.swiftmodule" Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\aarch64\XCTest.swiftmodule" Checksum="yes" />
+        <File Id="XCTest.swiftmodule" Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\aarch64\XCTest.swiftmodule" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
     <?ifdef INCLUDE_DEBUG_INFO ?>
     <ComponentGroup Id="XCTestDebugInfo">
       <Component Id="XCTest.pdb" Directory="XCTest_usr_bin64a" Guid="92e52a04-6193-4a0f-bd4d-8ae3c30a2901">
-        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
+        <File Id="XCTest.pdb" Source="$(var.XCTEST_ROOT)\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
       </Component>
     </ComponentGroup>
     <?endif?>

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -118,23 +118,23 @@
     <!-- Components -->
     <ComponentGroup Id="XCTest">
       <Component Id="XCTest.dll" Directory="XCTest_usr_bin32" Guid="bbd2f8c3-52a1-49e4-898e-2bfafb9d5985">
-        <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
+        <File Id="XCTest.dll" Source="$(var.XCTEST_ROOT)\usr\bin\XCTest.dll" Checksum="yes" />
       </Component>
       <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_i686" Guid="76f535ad-b9c7-48d9-baf7-033a5c023a23">
-        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
+        <File Id="XCTest.lib" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="e07c62a7-8463-4dd7-b198-73ffd52d00fa">
-        <File Id="XCTest.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\i686\XCTest.swiftdoc" Checksum="yes" />
+        <File Id="XCTest.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\i686\XCTest.swiftdoc" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftmodule" Directory="XCTest.swiftmodule" Guid="39ac696e-f50c-4261-bbb0-7f171ccd969d">
-        <File Id="XCTest.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\i686\XCTest.swiftmodule" Checksum="yes" />
+        <File Id="XCTest.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.XCTEST_ROOT)\usr\lib\swift\windows\i686\XCTest.swiftmodule" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
     <?ifdef INCLUDE_DEBUG_INFO ?>
     <ComponentGroup Id="XCTestDebugInfo">
       <Component Id="XCTest.pdb" Directory="XCTest_usr_bin32" Guid="f9f54891-8fe4-444b-b7a1-dc4787e069ee">
-        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
+        <File Id="XCTest.pdb" Source="$(var.XCTEST_ROOT)\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
       </Component>
     </ComponentGroup>
     <?endif?>

--- a/platforms/Windows/sdk.wixproj
+++ b/platforms/Windows/sdk.wixproj
@@ -13,6 +13,8 @@
 
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
     <ProductVersion>$(ProductVersion)</ProductVersion>
+
+    <XCTEST_ROOT Condition=" '$(XCTEST_ROOT)' == '' ">$(PLATFORM_ROOT)\Developer\Library\XCTest-development</XCTEST_ROOT>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -30,7 +32,7 @@
   <Import Project="WiXCodeSigning.targets" />
 
   <PropertyGroup>
-    <DefineConstants>ProductVersion=$(ProductVersion);PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);SwiftShimsPath=$(SDK_ROOT)\usr\lib\swift\shims;</DefineConstants>
+    <DefineConstants>ProductVersion=$(ProductVersion);PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);XCTEST_ROOT=$(XCTEST_ROOT);SwiftShimsPath=$(SDK_ROOT)\usr\lib\swift\shims;</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
     <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>


### PR DESCRIPTION
The paths where the Windows installer expects to finds XCTest binaries would conflict between architectures. This msbuild property allows us to have parallel XCTest cmake install trees so the `usr\lib\swift\windows\XCTest.lib` path does not collide.

Related changes:
- https://github.com/apple/swift/pull/64425
- https://github.com/compnerd/swift-build/pull/480