### PR TITLE
Expect XCTest.lib in arch-disambiguated directory in the Windows installer

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -121,7 +121,7 @@
         <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
       </Component>
       <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_x86_64" Guid="3debc3cd-3f48-4cd7-8e9a-7403b1d45b37">
-        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
+        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.lib" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="12731d72-ef57-4c29-a05e-a44534b331c2">
         <File Id="XCTest.swiftdoc" Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftdoc" Checksum="yes" />

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -121,7 +121,7 @@
         <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
       </Component>
       <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_aarch64" Guid="bce787dd-393e-4285-aa81-448557385d40">
-        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
+        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\aarch64\XCTest.lib" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="b2b83f97-6639-4b7b-8d32-2396463dfe71">
         <File Id="XCTest.swiftdoc" Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\aarch64\XCTest.swiftdoc" Checksum="yes" />

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -121,7 +121,7 @@
         <File Id="XCTest.dll" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.dll" Checksum="yes" />
       </Component>
       <Component Id="XCTest.lib" Directory="XCTest_usr_lib_swift_windows_i686" Guid="76f535ad-b9c7-48d9-baf7-033a5c023a23">
-        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\XCTest.lib" Checksum="yes" />
+        <File Id="XCTest.lib" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\i686\XCTest.lib" Checksum="yes" />
       </Component>
       <Component Id="XCTest.swiftdoc" Directory="XCTest.swiftmodule" Guid="e07c62a7-8463-4dd7-b198-73ffd52d00fa">
         <File Id="XCTest.swiftdoc" Name="i686-unknown-windows-msvc.swiftdoc" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\i686\XCTest.swiftdoc" Checksum="yes" />


### PR DESCRIPTION
Updates the Windows installer to account for https://github.com/apple/swift-corelibs-xctest/pull/434