### PR TITLE
WiX: remove _Runtime and Reflection packaging

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -62,10 +62,6 @@
                           <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
                           </Directory>
                           <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="Reflection.swiftmodule" Name="Reflection.swiftmodule">
-                            </Directory>
-                            <Directory Id="_Runtime.swiftmodule" Name="_Runtime.swiftmodule">
-                            </Directory>
                             <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
                             </Directory>
                             <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
@@ -241,38 +237,6 @@
 
       <Component Id="swiftDispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="b3e67468-2c5d-40cd-b332-7b21a0df301f">
         <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="Reflection">
-      <Component Id="Reflection.swiftdoc" Directory="Reflection.swiftmodule" Guid="98d36176-7410-4a95-93d4-41360531e782">
-        <File Id="Reflection.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-      </Component>
-      <Component Id="Reflection.swiftinterface" Directory="Reflection.swiftmodule" Guid="8b01ffe8-4119-4ddf-9b45-9a66c33965d5">
-        <File Id="Reflection.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-      </Component>
-      <Component Id="Reflection.swiftmodule" Directory="Reflection.swiftmodule" Guid="c06e5076-aa5a-4eb4-8b01-de9b2d457b5f">
-        <File Id="Reflection.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-
-      <Component Id="swiftReflection.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="a87d749e-f9ef-446f-b34a-25af295abebc">
-        <File Id="swiftReflection.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftReflection.lib" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="_Runtime">
-      <Component Id="_Runtime.swiftdoc" Directory="_Runtime.swiftmodule" Guid="e66c5343-54b8-4be9-9fc2-26b5d634944f">
-        <File Id="_Runtime.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-      </Component>
-      <Component Id="_Runtime.swiftinterface" Directory="_Runtime.swiftmodule" Guid="2ca3764f-2c1e-4f0f-85a8-b8f14ed4db5f">
-        <File Id="_Runtime.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-      </Component>
-      <Component Id="_Runtime.swiftmodule" Directory="_Runtime.swiftmodule" Guid="5923b211-b0bf-4e0d-9d80-425c5b12383f">
-        <File Id="_Runtime.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-
-      <Component Id="swift_Runtime.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="44c6e16b-46c0-4578-8fb4-ef26f0646168">
-        <File Id="swift_Runtime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Runtime.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
@@ -536,7 +500,6 @@
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
       <ComponentGroupRef Id="FoundationXML" />
-      <ComponentGroupRef Id="Reflection" />
       <ComponentGroupRef Id="Swift" />
       <ComponentGroupRef Id="SwiftOnoneSupport" />
       <ComponentGroupRef Id="SwiftRemoteMirror" />
@@ -545,7 +508,6 @@
       <ComponentGroupRef Id="_Concurrency" />
       <ComponentGroupRef Id="_Differentiation" />
       <ComponentGroupRef Id="_RegexParser" />
-      <ComponentGroupRef Id="_Runtime" />
       <ComponentGroupRef Id="_StringProcessing" />
       <ComponentGroupRef Id="dispatch" />
 

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -62,10 +62,6 @@
                           <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
                           </Directory>
                           <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="Reflection.swiftmodule" Name="Reflection.swiftmodule">
-                            </Directory>
-                            <Directory Id="_Runtime.swiftmodule" Name="_Runtime.swiftmodule">
-                            </Directory>
                             <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
                             </Directory>
                             <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
@@ -241,38 +237,6 @@
 
       <Component Id="swiftDispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="9800dd9e-9f94-4350-8e41-f18f19ac610d">
         <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="Reflection">
-      <Component Id="Reflection.swiftdoc" Directory="Reflection.swiftmodule" Guid="dbfe23ed-3137-42c3-805c-5395a96a3f27">
-        <File Id="Reflection.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-      </Component>
-      <Component Id="Reflection.swiftinterface" Directory="Reflection.swiftmodule" Guid="48e0bfb3-73e6-4f54-8cf7-13611f576f84">
-        <File Id="Reflection.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-      </Component>
-      <Component Id="Reflection.swiftmodule" Directory="Reflection.swiftmodule" Guid="a3d092dd-4d8f-4b85-b1e6-778099be6880">
-        <File Id="Reflection.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-
-      <Component Id="swiftReflection.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="0e494f73-0b59-4ddf-afe2-3084b6c8a1b7">
-        <File Id="swiftReflection.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftReflection.lib" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="_Runtime">
-      <Component Id="_Runtime.swiftdoc" Directory="_Runtime.swiftmodule" Guid="395104b1-03c0-4a31-9d67-0fb4a2ebbd77">
-        <File Id="_Runtime.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-      </Component>
-      <Component Id="_Runtime.swiftinterface" Directory="_Runtime.swiftmodule" Guid="2125240d-1be9-46c3-b99a-c4e84f888b82">
-        <File Id="_Runtime.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-      </Component>
-      <Component Id="_Runtime.swiftmodule" Directory="_Runtime.swiftmodule" Guid="5e8a00f0-eb62-4473-b61c-82e8185140a3">
-        <File Id="_Runtime.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-
-      <Component Id="swift_Runtime.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="7be7efd9-0f81-4fe0-b765-b4e6c6c918dc">
-        <File Id="swift_Runtime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swift_Runtime.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
@@ -536,7 +500,6 @@
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
       <ComponentGroupRef Id="FoundationXML" />
-      <ComponentGroupRef Id="Reflection" />
       <ComponentGroupRef Id="Swift" />
       <ComponentGroupRef Id="SwiftOnoneSupport" />
       <ComponentGroupRef Id="SwiftRemoteMirror" />
@@ -545,7 +508,6 @@
       <ComponentGroupRef Id="_Concurrency" />
       <ComponentGroupRef Id="_Differentiation" />
       <ComponentGroupRef Id="_RegexParser" />
-      <ComponentGroupRef Id="_Runtime" />
       <ComponentGroupRef Id="_StringProcessing" />
       <ComponentGroupRef Id="dispatch" />
 

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -62,10 +62,6 @@
                           <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
                           </Directory>
                           <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="Reflection.swiftmodule" Name="Reflection.swiftmodule">
-                            </Directory>
-                            <Directory Id="_Runtime.swiftmodule" Name="_Runtime.swiftmodule">
-                            </Directory>
                             <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
                             </Directory>
                             <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
@@ -241,38 +237,6 @@
 
       <Component Id="swiftDispatch.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="97e1a280-673c-4eb3-8c79-e0d82c6bc9c9">
         <File Id="swiftDispatch.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="Reflection">
-      <Component Id="Reflection.swiftdoc" Directory="Reflection.swiftmodule" Guid="7d20d217-c642-44cd-8774-5d13d5d1d440">
-        <File Id="Reflection.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-      </Component>
-      <Component Id="Reflection.swiftinterface" Directory="Reflection.swiftmodule" Guid="2050a6e5-42fe-401d-bec9-cbb3dbf44e89">
-        <File Id="Reflection.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-      </Component>
-      <Component Id="Reflection.swiftmodule" Directory="Reflection.swiftmodule" Guid="0ca35b3e-1b9b-42b5-ba7a-59c95a92fa55">
-        <File Id="Reflection.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Reflection.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-
-      <Component Id="swiftReflection.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="304f413d-6640-4a06-aa64-8a9c33c7dd73">
-        <File Id="swiftReflection.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftReflection.lib" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="_Runtime">
-      <Component Id="_Runtime.swiftdoc" Directory="_Runtime.swiftmodule" Guid="e4001f72-392e-4205-ba92-ed4b5a477cc1">
-        <File Id="_Runtime.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
-      </Component>
-      <Component Id="_Runtime.swiftinterface" Directory="_Runtime.swiftmodule" Guid="6aa0d039-bf3e-4cc9-8364-4b8a2e88c84e">
-        <File Id="_Runtime.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
-      </Component>
-      <Component Id="_Runtime.swiftmodule" Directory="_Runtime.swiftmodule" Guid="f9f10cf0-d59b-4f60-9efc-a17226f5f590">
-        <File Id="_Runtime.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\_Runtime.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
-      </Component>
-
-      <Component Id="swift_Runtime.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="f4462968-709d-44bc-8657-16e654946e3e">
-        <File Id="swift_Runtime.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swift_Runtime.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
@@ -530,7 +494,6 @@
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
       <ComponentGroupRef Id="FoundationXML" />
-      <ComponentGroupRef Id="Reflection" />
       <ComponentGroupRef Id="Swift" />
       <ComponentGroupRef Id="SwiftOnoneSupport" />
       <ComponentGroupRef Id="SwiftRemoteMirror" />
@@ -539,7 +502,6 @@
       <ComponentGroupRef Id="_Concurrency" />
       <ComponentGroupRef Id="_Differentiation" />
       <ComponentGroupRef Id="_RegexParser" />
-      <ComponentGroupRef Id="_Runtime" />
       <ComponentGroupRef Id="_StringProcessing" />
       <ComponentGroupRef Id="dispatch" />
 


### PR DESCRIPTION
This was removed on main, remove this here as well.