### PR TITLE
Stop packaging swiftReflection and swift_Runtime in the Windows installer.

### DIFF
--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -108,12 +108,6 @@
       <Component Id="FoundationXML.pdb" Guid="97bc6b02-8ac0-4a28-a032-7ebe1dd0d496">
         <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
       </Component>
-      <Component Id="swiftReflection.pdb" Guid="2151438b-4ae9-4ca1-823a-c18e3229f2e1">
-        <File Id="swiftReflection.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftReflection.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_Runtime.pdb" Guid="21e51dd8-234d-4a98-b920-436086758074">
-        <File Id="swift_Runtime.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Runtime.pdb" Checksum="yes" DiskId="2" />
-      </Component>
       <Component Id="swift_Concurrency.pdb" Guid="433dd15e-f72c-4294-9bf5-0be4771d1c10">
         <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
       </Component>

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -42,12 +42,6 @@
       <Component Id="FoundationXML.dll" Guid="959fd680-b5b7-4c1d-bdd2-6c019a611874">
         <File Id="FoundationXML.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
       </Component>
-      <Component Id="swiftReflection.dll" Guid="a02ca3fb-0f04-416a-8702-982c3cce58b2">
-        <File Id="swiftReflection.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftReflection.dll" Checksum="yes" />
-      </Component>
-      <Component Id="swift_Runtime.dll" Guid="07de8108-867a-4992-8ca7-91e9a98c6b73">
-        <File Id="swift_Runtime.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Runtime.dll" Checksum="yes" />
-      </Component>
       <Component Id="swift_Concurrency.dll" Guid="67373728-5a66-401f-b62d-dc7ced8b87e8">
         <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -41,12 +41,6 @@
       <Component Id="FoundationXML.dll" Guid="154951da-1a4a-4034-b318-51aa3069a512">
         <File Id="FoundationXML.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
       </Component>
-      <Component Id="swiftReflection.dll" Guid="2d718d10-4286-4343-a440-4757acf0f801">
-        <File Id="swiftReflection.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftReflection.dll" Checksum="yes" />
-      </Component>
-      <Component Id="swift_Runtime.dll" Guid="3b8a6626-28c4-4ddc-9085-07963027144b">
-        <File Id="swift_Runtime.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Runtime.dll" Checksum="yes" />
-      </Component>
       <Component Id="swift_Concurrency.dll" Guid="08d4e353-00af-4db0-9c55-2ea50eeddeb7">
         <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -152,7 +152,7 @@
         <File Id="SwiftRemoteMirror.modulemap" Source="$(var.SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\module.modulemap" Checksum="yes" />
       </Component>
 
-      <Component Id="wwiftRemoteMirror.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="3d429d95-1f9d-4b59-85f2-2676ae95539b">
+      <Component Id="swiftRemoteMirror.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="3d429d95-1f9d-4b59-85f2-2676ae95539b">
         <File Id="swiftRemoteMirror.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftRemoteMirror.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>


### PR DESCRIPTION
These dlls and their pdbs do not exist anymore but were still inconsistently getting packaged for some architectures on Windows. Sometimes only the pdb, sometimes only the dll. Presumably this didn't fail in the CI because old files were still present on the machine.

Also fixes a typo: `wwiftRemoteMirror` > `swiftRemoteMirror`