### PR TITLE
Migrate the Windows installer to WiX v4

### DIFF
--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Developer Tools for Windows x86_64" UpgradeCode="5778fa7a-f1a6-4133-b4e0-fc0d9caf4544" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Developer Tools for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift Developer Tools for Windows x86_64"
+      UpgradeCode="5778fa7a-f1a6-4133-b4e0-fc0d9caf4544"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Developer Tools for Windows x86_64" />
 
     <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -9,22 +14,20 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Toolchains" Name="Toolchains">
-            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-              <Directory Id="_usr" Name="usr">
-                <Directory Id="_usr_bin" Name="bin">
-                </Directory>
-                <Directory Id="_usr_lib" Name="lib">
-                  <!-- FIXME(compnerd) should we include the SPM import libraries? -->
-                  <Directory Id="_usr_lib_swift" Name="swift">
-                    <Directory Id="_usr_lib_swift_pm" Name="pm">
-                      <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
-                      </Directory>
-                      <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
-                      </Directory>
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="Toolchains" Name="Toolchains">
+          <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+            <Directory Id="_usr" Name="usr">
+              <Directory Id="_usr_bin" Name="bin">
+              </Directory>
+              <Directory Id="_usr_lib" Name="lib">
+                <!-- FIXME(compnerd) should we include the SPM import libraries? -->
+                <Directory Id="_usr_lib_swift" Name="swift">
+                  <Directory Id="_usr_lib_swift_pm" Name="pm">
+                    <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
+                    </Directory>
+                    <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
                     </Directory>
                   </Directory>
                 </Directory>
@@ -35,9 +38,7 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftCollections">
@@ -222,15 +223,15 @@
     </ComponentGroup>
     <?endif?>
 
-    <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows x86_64" Level="1" Title="Swift Developer Tools (Windows x86_64)">
+    <Feature Id="DeveloperTools" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows x86_64" Level="1" Title="Swift Developer Tools (Windows x86_64)">
       <ComponentGroupRef Id="SwiftCollections" />
       <ComponentGroupRef Id="SwiftSystem" />
       <ComponentGroupRef Id="SwiftPackageManager" />
       <ComponentGroupRef Id="SourceKitLSP" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows x86_64" Level="0" Title="Debug Info">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows x86_64" Level="0" Title="Debug Info">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftCollectionsDebugInfo" />
         <ComponentGroupRef Id="SwiftSystemDebugInfo" />
         <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />
@@ -240,13 +241,13 @@
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
 
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Developer Tools for Windows aarch64" UpgradeCode="" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Developer Tools for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift Developer Tools for Windows aarch64"
+      UpgradeCode=""
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Developer Tools for Windows aarch64" />
 
     <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -9,22 +14,20 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Toolchains" Name="Toolchains">
-            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-              <Directory Id="_usr" Name="usr">
-                <Directory Id="_usr_bin" Name="bin">
-                </Directory>
-                <Directory Id="_usr_lib" Name="lib">
-                  <!-- FIXME(compnerd) should we include the SPM import libraries? -->
-                  <Directory Id="_usr_lib_swift" Name="swift">
-                    <Directory Id="_usr_lib_swift_pm" Name="pm">
-                      <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
-                      </Directory>
-                      <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
-                      </Directory>
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="Toolchains" Name="Toolchains">
+          <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+            <Directory Id="_usr" Name="usr">
+              <Directory Id="_usr_bin" Name="bin">
+              </Directory>
+              <Directory Id="_usr_lib" Name="lib">
+                <!-- FIXME(compnerd) should we include the SPM import libraries? -->
+                <Directory Id="_usr_lib_swift" Name="swift">
+                  <Directory Id="_usr_lib_swift_pm" Name="pm">
+                    <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
+                    </Directory>
+                    <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
                     </Directory>
                   </Directory>
                 </Directory>
@@ -35,9 +38,7 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftCollections">
@@ -222,15 +223,15 @@
     </ComponentGroup>
     <?endif?>
 
-    <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows aarch64" Level="1" Title="Swift Developer Tools (Windows aarch64)">
+    <Feature Id="DeveloperTools" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows aarch64" Level="1" Title="Swift Developer Tools (Windows aarch64)">
       <ComponentGroupRef Id="SwiftCollections" />
       <ComponentGroupRef Id="SwiftSystem" />
       <ComponentGroupRef Id="SwiftPackageManager" />
       <ComponentGroupRef Id="SourceKitLSP" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows aarch64" Level="0" Title="Debug Info">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows aarch64" Level="0" Title="Debug Info">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftCollectionsDebugInfo" />
         <ComponentGroupRef Id="SwiftSystemDebugInfo" />
         <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />
@@ -240,13 +241,13 @@
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
 
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/devtools.wixproj
+++ b/platforms/Windows/devtools.wixproj
@@ -1,10 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTarget="Build">
+<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
   <PropertyGroup>
-    <OutputName>devtools</OutputName>
-    <OutputType>Package</OutputType>
-    <ProjectGuid>0a266072-af7c-43f2-b192-dd86995c2e82</ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -18,14 +14,7 @@
   <PropertyGroup>
     <OutputPath>build\</OutputPath>
     <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
-    <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
-
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <Target Name="EnsureWiXToolsetInstalled" Condition="">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
-  </Target>
 
   <Import Project="WiXCodeSigning.targets" />
 
@@ -41,12 +30,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <WixExtension Include="WixUIExtension">
-      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
-      <Name>WixUIExtension</Name>
-    </WixExtension>
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <Compile Include="devtools-$(ProductArchitecture).wxs" />
   </ItemGroup>

--- a/platforms/Windows/installer.wixproj
+++ b/platforms/Windows/installer.wixproj
@@ -1,10 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
   <PropertyGroup>
-    <OutputName>installer</OutputName>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <OutputType>Bundle</OutputType>
-    <ProjectGuid>8ae3ad4d-2df4-42b7-890e-decdd5cead0b</ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,14 +18,7 @@
   <PropertyGroup>
     <OutputPath>build\</OutputPath>
     <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
-    <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
-
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <Target Name="EnsureWiXToolsetInstalled" Condition="">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
-  </Target>
 
   <Import Project="WiXCodeSigning.targets" />
 
@@ -37,10 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <WixExtension Include="WixBalExtension">
-      <HintPath>$(WixExtDir)\WixBalExtension.dll</HintPath>
-      <Name>WixBalExtension</Name>
-    </WixExtension>
+    <PackageReference Include="WixToolset.Bal.wixext" Version="4.0.0-rc.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/installer.wxs
+++ b/platforms/Windows/installer.wxs
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
   <Bundle Name="Swift Developer Package for Windows x86_64" Version="$(var.ProductVersion)" Manufacturer="swift.org" UpgradeCode="8c75f32a-7bdf-4c61-abf6-c7e1c4b8fbf6">
-    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
-      <bal:WixStandardBootstrapperApplication LicenseUrl="" LogoFile="Resources/swift.png" SuppressOptionsUI="yes" SuppressRepair="no" />
-    </BootstrapperApplicationRef>
+    <BootstrapperApplication>
+      <bal:WixStandardBootstrapperApplication LicenseUrl="" LogoFile="Resources/swift.png" SuppressOptionsUI="yes" SuppressRepair="no" Theme="hyperlinkLicense" />
+    </BootstrapperApplication>
 
     <Chain>
       <?if $(var.RequiredChain) != "" ?>

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Runtime for Windows x86_64" UpgradeCode="850349e4-5a24-44eb-bded-f49a2709d26f" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Runtime for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift Runtime for Windows x86_64"
+      UpgradeCode="850349e4-5a24-44eb-bded-f49a2709d26f"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Runtime for Windows x86_64" />
 
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -9,21 +14,17 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <!-- TODO(compnerd) use $(var.ProductVersion) -->
-        <Directory Id="_" Name="runtime-development">
-          <Directory Id="_usr" Name="usr">
-            <Directory Id="_usr_bin" Name="bin">
-            </Directory>
+    <Directory Id="INSTALLDIR">
+      <!-- TODO(compnerd) use $(var.ProductVersion) -->
+      <Directory Id="_" Name="runtime-development">
+        <Directory Id="_usr" Name="usr">
+          <Directory Id="_usr_bin" Name="bin">
           </Directory>
         </Directory>
       </Directory>
-    </Directory>
+    </Directory>    
 
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">
@@ -108,12 +109,6 @@
       <Component Id="FoundationXML.pdb" Guid="97bc6b02-8ac0-4a28-a032-7ebe1dd0d496">
         <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
       </Component>
-      <Component Id="swiftReflection.pdb" Guid="2151438b-4ae9-4ca1-823a-c18e3229f2e1">
-        <File Id="swiftReflection.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftReflection.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_Runtime.pdb" Guid="21e51dd8-234d-4a98-b920-436086758074">
-        <File Id="swift_Runtime.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Runtime.pdb" Checksum="yes" DiskId="2" />
-      </Component>
       <Component Id="swift_Concurrency.pdb" Guid="433dd15e-f72c-4294-9bf5-0be4771d1c10">
         <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
       </Component>
@@ -164,44 +159,42 @@
     </ComponentGroup>
     <?endif?>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="f249625e-aacd-4b17-a464-8f8df05ba5f3">
-        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
-      </Component>
-    </DirectoryRef>
-
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="f249625e-aacd-4b17-a464-8f8df05ba5f3">
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
+    </Component>
+    
     <!-- Feature -->
-    <Feature Id="WinX64SwiftRuntime" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows x86_64" Level="1" Title="Swift Runtime for Windows x86_64">
+    <Feature Id="WinX64SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows x86_64" Level="1" Title="Swift Runtime for Windows x86_64">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows x86_64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows x86_64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftRuntimeDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
-    <Feature Id="WinX64SwiftUtilities" Absent="allow" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows x86_64" Level="1" Title="Swift Utilities for Windows x86_64">
+    <Feature Id="WinX64SwiftUtilities" AllowAbsent="yes" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows x86_64" Level="1" Title="Swift Utilities for Windows x86_64">
       <ComponentGroupRef Id="SwiftUtilities" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows x86_64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows x86_64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftUtilitiesDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
 
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Runtime for Windows aarch64" UpgradeCode="bea8c6dc-f73e-445b-9486-2333d1cf2886" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Runtime for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift Runtime for Windows aarch64"
+      UpgradeCode="bea8c6dc-f73e-445b-9486-2333d1cf2886"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Runtime for Windows aarch64" />
 
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -9,21 +14,18 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <!-- TODO(compnerd) use $(var.ProductVersion) -->
-        <Directory Id="_" Name="runtime-development">
-          <Directory Id="_usr" Name="usr">
-            <Directory Id="_usr_bin" Name="bin">
-            </Directory>
+    <Directory Id="INSTALLDIR">
+      <!-- TODO(compnerd) use $(var.ProductVersion) -->
+      <Directory Id="_" Name="runtime-development">
+        <Directory Id="_usr" Name="usr">
+          <Directory Id="_usr_bin" Name="bin">
           </Directory>
         </Directory>
       </Directory>
     </Directory>
+    
 
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">
@@ -41,12 +43,6 @@
       </Component>
       <Component Id="FoundationXML.dll" Guid="959fd680-b5b7-4c1d-bdd2-6c019a611874">
         <File Id="FoundationXML.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
-      </Component>
-      <Component Id="swiftReflection.dll" Guid="a02ca3fb-0f04-416a-8702-982c3cce58b2">
-        <File Id="swiftReflection.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftReflection.dll" Checksum="yes" />
-      </Component>
-      <Component Id="swift_Runtime.dll" Guid="07de8108-867a-4992-8ca7-91e9a98c6b73">
-        <File Id="swift_Runtime.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Runtime.dll" Checksum="yes" />
       </Component>
       <Component Id="swift_Concurrency.dll" Guid="67373728-5a66-401f-b62d-dc7ced8b87e8">
         <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
@@ -164,44 +160,42 @@
     </ComponentGroup>
     <?endif?>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="8681d813-eb32-46f9-8b1c-f622b38b5eaf">
-        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="8681d813-eb32-46f9-8b1c-f622b38b5eaf">
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
+    </Component>
 
     <!-- Feature -->
-    <Feature Id="WinARM64SwiftRuntime" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows aarch64" Level="1" Title="Swift Runtime for Windows aarch64">
+    <Feature Id="WinARM64SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows aarch64" Level="1" Title="Swift Runtime for Windows aarch64">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows aarch64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows aarch64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftRuntimeDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
-    <Feature Id="WinARM64SwiftUtilities" Absent="allow" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows aarch64" Level="1" Title="Swift Utilities for Windows aarch64">
+    <Feature Id="WinARM64SwiftUtilities" AllowAbsent="yes" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows aarch64" Level="1" Title="Swift Utilities for Windows aarch64">
       <ComponentGroupRef Id="SwiftUtilities" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows aarch64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows aarch64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftUtilitiesDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
 
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -1,28 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Runtime for Windows i686" UpgradeCode="01a3fe60-8c3e-4249-8477-deba39b99dd9" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2022 Swift Open Source Project" Compressed="yes" Description="Swift Runtime for Windows i686" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift Runtime for Windows i686"
+      UpgradeCode="01a3fe60-8c3e-4249-8477-deba39b99dd9"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Runtime for Windows i686" />
+    
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
     <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <!-- TODO(compnerd) use $(var.ProductVersion) -->
-        <Directory Id="_" Name="runtime-development">
-          <Directory Id="_usr" Name="usr">
-            <Directory Id="_usr_bin" Name="bin">
-            </Directory>
+    <Directory Id="INSTALLDIR">
+      <!-- TODO(compnerd) use $(var.ProductVersion) -->
+      <Directory Id="_" Name="runtime-development">
+        <Directory Id="_usr" Name="usr">
+          <Directory Id="_usr_bin" Name="bin">
           </Directory>
         </Directory>
       </Directory>
     </Directory>
-
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFilesFolder]swift">
-      NOT INSTALLDIR
-    </SetDirectory>
+    
+    <SetDirectory Id="INSTALLDIR" Value="[ProgramFilesFolder]swift" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">
@@ -40,12 +42,6 @@
       </Component>
       <Component Id="FoundationXML.dll" Guid="154951da-1a4a-4034-b318-51aa3069a512">
         <File Id="FoundationXML.dll" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.dll" Checksum="yes" />
-      </Component>
-      <Component Id="swiftReflection.dll" Guid="2d718d10-4286-4343-a440-4757acf0f801">
-        <File Id="swiftReflection.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftReflection.dll" Checksum="yes" />
-      </Component>
-      <Component Id="swift_Runtime.dll" Guid="3b8a6626-28c4-4ddc-9085-07963027144b">
-        <File Id="swift_Runtime.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Runtime.dll" Checksum="yes" />
       </Component>
       <Component Id="swift_Concurrency.dll" Guid="08d4e353-00af-4db0-9c55-2ea50eeddeb7">
         <File Id="swift_Concurrency.dll" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.dll" Checksum="yes" />
@@ -163,44 +159,41 @@
     </ComponentGroup>
     <?endif?>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="3b4386ac-3341-407d-b946-6e670f4a83f6">
-        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="3b4386ac-3341-407d-b946-6e670f4a83f6">
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
+    </Component>
 
     <!-- Feature -->
-    <Feature Id="Win32SwiftRuntime" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows i686" Level="1" Title="Swift Runtime for Windows i686">
+    <Feature Id="Win32SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows i686" Level="1" Title="Swift Runtime for Windows i686">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows i686" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows i686" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftRuntimeDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
-    <Feature Id="Win32SwiftUtilities" Absent="allow" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows i686" Level="1" Title="Swift Utilities for Windows i686">
+    <Feature Id="Win32SwiftUtilities" AllowAbsent="yes" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows i686" Level="1" Title="Swift Utilities for Windows i686">
       <ComponentGroupRef Id="SwiftUtilities" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows x86_64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows x86_64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftUtilitiesDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
-
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/runtime.wixproj
+++ b/platforms/Windows/runtime.wixproj
@@ -1,10 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
   <PropertyGroup>
-    <OutputName>runtime</OutputName>
-    <OutputType>Package</OutputType>
-    <ProjectGuid></ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -18,14 +14,7 @@
   <PropertyGroup>
     <OutputPath>build\</OutputPath>
     <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
-    <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
-
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <Target Name="EnsureWiXToolsetInstalled" Condition="">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
-  </Target>
 
   <Import Project="WiXCodeSigning.targets" />
 
@@ -49,10 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <WixExtension Include="WixUIExtension">
-      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
-      <Name>WixUIExtension</Name>
-    </WixExtension>
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift SDK for Windows x86_64" UpgradeCode="83af0249-2b57-4ce1-8121-c29c6c555225" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift SDK for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift SDK for Windows x86_64"
+      UpgradeCode="83af0249-2b57-4ce1-8121-c29c6c555225"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift SDK for Windows x86_64" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -9,94 +14,92 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="DeveloperPlatforms" Name="Platforms">
-            <Directory Id="WindowsPlatform" Name="Windows.platform">
-              <Directory Id="WindowsPlatform_Developer" Name="Developer">
-                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="DeveloperPlatforms" Name="Platforms">
+          <Directory Id="WindowsPlatform" Name="Windows.platform">
+            <Directory Id="WindowsPlatform_Developer" Name="Developer">
+              <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                  <!-- XCTest -->
-                  <!--
-                    FIXME(compnerd) this should actually be the proper version
-                    of XCTest, and needs to be reflected in the plist as well.
-                  -->
-                  <Directory Id="XCTest" Name="XCTest-development">
-                    <Directory Id="XCTest_usr" Name="usr">
-                      <Directory Id="XCTest_usr_bin64" Name="bin64">
-                      </Directory>
-                      <Directory Id="XCTest_usr_lib" Name="lib">
-                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
-                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="XCTest_usr_lib_swift_windows_x86_64" Name="x86_64">
-                            </Directory>
-                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
-                            </Directory>
+                <!-- XCTest -->
+                <!--
+                  FIXME(compnerd) this should actually be the proper version
+                  of XCTest, and needs to be reflected in the plist as well.
+                -->
+                <Directory Id="XCTest" Name="XCTest-development">
+                  <Directory Id="XCTest_usr" Name="usr">
+                    <Directory Id="XCTest_usr_bin64" Name="bin64">
+                    </Directory>
+                    <Directory Id="XCTest_usr_lib" Name="lib">
+                      <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                        <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                          <Directory Id="XCTest_usr_lib_swift_windows_x86_64" Name="x86_64">
+                          </Directory>
+                          <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
                           </Directory>
                         </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
                 </Directory>
+              </Directory>
 
-                <Directory Id="SDKs" Name="SDKs">
+              <Directory Id="SDKs" Name="SDKs">
 
-                  <!-- Windows.sdk -->
-                  <Directory Id="WindowsSDK" Name="Windows.sdk">
-                    <Directory Id="WindowsSDK_usr" Name="usr">
-                      <Directory Id="WindowsSDK_usr_include" Name="include">
-                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
+                <!-- Windows.sdk -->
+                <Directory Id="WindowsSDK" Name="Windows.sdk">
+                  <Directory Id="WindowsSDK_usr" Name="usr">
+                    <Directory Id="WindowsSDK_usr_include" Name="include">
+                      <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                        <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
+                      </Directory>
+                    </Directory>
+                    <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                      <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                        <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                        <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                          <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                          </Directory>
+                          <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                          </Directory>
+                          <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                          </Directory>
+                          <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                          </Directory>
+                          <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                          </Directory>
+                          <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                          </Directory>
+                          <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                          </Directory>
+                          <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                          </Directory>
+                          <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                          </Directory>
+                          <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                          </Directory>
+                          <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                          </Directory>
+                          <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                          </Directory>
+                          <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                          </Directory>
+                          <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
                           </Directory>
                         </Directory>
                       </Directory>
-                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
-                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
-                          </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                            </Directory>
-                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                            </Directory>
-                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                            </Directory>
-                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                            </Directory>
-                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                            </Directory>
-                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                            </Directory>
-                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
-                            </Directory>
-                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                            </Directory>
-                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                            </Directory>
-                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                            </Directory>
-                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                            </Directory>
-                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                            </Directory>
-                            <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
-                            </Directory>
-                          </Directory>
-                        </Directory>
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_share" Name="share">
-                      </Directory>
+                    </Directory>
+                    <Directory Id="WindowsSDK_usr_share" Name="share">
                     </Directory>
                   </Directory>
                 </Directory>
@@ -106,10 +109,9 @@
         </Directory>
       </Directory>
     </Directory>
+    
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="XCTest">
@@ -484,15 +486,13 @@
       </Component>
     </ComponentGroup>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
-        <!-- <Condition> %PROCESSOR_ARCHITECTURE~="amd64" </Condition> -->
-        <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
+      <!-- <Condition> %PROCESSOR_ARCHITECTURE~="amd64" </Condition> -->
+      <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
+    </Component>
 
     <!-- Features -->
-    <Feature Id="WinX64SDK" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows x86_64" Level="1" Title="Swift SDK for Windows x86_64">
+    <Feature Id="WinX64SDK" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows x86_64" Level="1" Title="Swift SDK for Windows x86_64" AllowAbsent="no">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="CXX" />
@@ -521,20 +521,20 @@
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows x86_64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows x86_64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentRef Id="XCTestRuntimeDebugInfo" />
       </Feature>
-      <?endif ?>
+      <?endif?>
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift SDK for Windows aarch64" UpgradeCode="4c37a396-d9e2-490a-89b7-0a3d271d847f" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift SDK for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift SDK for Windows aarch64"
+      UpgradeCode="4c37a396-d9e2-490a-89b7-0a3d271d847f"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift SDK for Windows aarch64" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -9,94 +14,92 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="DeveloperPlatforms" Name="Platforms">
-            <Directory Id="WindowsPlatform" Name="Windows.platform">
-              <Directory Id="WindowsPlatform_Developer" Name="Developer">
-                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="DeveloperPlatforms" Name="Platforms">
+          <Directory Id="WindowsPlatform" Name="Windows.platform">
+            <Directory Id="WindowsPlatform_Developer" Name="Developer">
+              <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                  <!-- XCTest -->
-                  <!--
-                    FIXME(compnerd) this should actually be the proper version
-                    of XCTest, and needs to be reflected in the plist as well.
-                  -->
-                  <Directory Id="XCTest" Name="XCTest-development">
-                    <Directory Id="XCTest_usr" Name="usr">
-                      <Directory Id="XCTest_usr_bin64a" Name="bin64a">
-                      </Directory>
-                      <Directory Id="XCTest_usr_lib" Name="lib">
-                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
-                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="XCTest_usr_lib_swift_windows_aarch64" Name="aarch64">
-                            </Directory>
-                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
-                            </Directory>
+                <!-- XCTest -->
+                <!--
+                  FIXME(compnerd) this should actually be the proper version
+                  of XCTest, and needs to be reflected in the plist as well.
+                -->
+                <Directory Id="XCTest" Name="XCTest-development">
+                  <Directory Id="XCTest_usr" Name="usr">
+                    <Directory Id="XCTest_usr_bin64a" Name="bin64a">
+                    </Directory>
+                    <Directory Id="XCTest_usr_lib" Name="lib">
+                      <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                        <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                          <Directory Id="XCTest_usr_lib_swift_windows_aarch64" Name="aarch64">
+                          </Directory>
+                          <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
                           </Directory>
                         </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
                 </Directory>
+              </Directory>
 
-                <Directory Id="SDKs" Name="SDKs">
+              <Directory Id="SDKs" Name="SDKs">
 
-                  <!-- Windows.sdk -->
-                  <Directory Id="WindowsSDK" Name="Windows.sdk">
-                    <Directory Id="WindowsSDK_usr" Name="usr">
-                      <Directory Id="WindowsSDK_usr_include" Name="include">
-                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
+                <!-- Windows.sdk -->
+                <Directory Id="WindowsSDK" Name="Windows.sdk">
+                  <Directory Id="WindowsSDK_usr" Name="usr">
+                    <Directory Id="WindowsSDK_usr_include" Name="include">
+                      <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                        <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
+                      </Directory>
+                    </Directory>
+                    <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                      <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                        <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                        <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                          <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                          </Directory>
+                          <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                          </Directory>
+                          <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                          </Directory>
+                          <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                          </Directory>
+                          <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                          </Directory>
+                          <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                          </Directory>
+                          <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                          </Directory>
+                          <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                          </Directory>
+                          <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                          </Directory>
+                          <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                          </Directory>
+                          <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                          </Directory>
+                          <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                          </Directory>
+                          <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                          </Directory>
+                          <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_windows_aarch64" Name="aarch64">
                           </Directory>
                         </Directory>
                       </Directory>
-                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
-                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
-                          </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                            </Directory>
-                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                            </Directory>
-                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                            </Directory>
-                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                            </Directory>
-                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                            </Directory>
-                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                            </Directory>
-                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
-                            </Directory>
-                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                            </Directory>
-                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                            </Directory>
-                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                            </Directory>
-                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                            </Directory>
-                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                            </Directory>
-                            <Directory Id="WindowsSDK_usr_lib_swift_windows_aarch64" Name="aarch64">
-                            </Directory>
-                          </Directory>
-                        </Directory>
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_share" Name="share">
-                      </Directory>
+                    </Directory>
+                    <Directory Id="WindowsSDK_usr_share" Name="share">
                     </Directory>
                   </Directory>
                 </Directory>
@@ -107,9 +110,7 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="XCTest">
@@ -484,15 +485,13 @@
       </Component>
     </ComponentGroup>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
-        <!-- <Condition> %PROCESSOR_ARCHITECTURE~="arm64" </Condition> -->
-        <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
+      <!-- <Condition> %PROCESSOR_ARCHITECTURE~="arm64" </Condition> -->
+      <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
+    </Component>
 
     <!-- Features -->
-    <Feature Id="WinARM64SDK" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows aarch64" Level="1" Title="Swift SDK for Windows aarch64">
+    <Feature Id="WinARM64SDK" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows aarch64" Level="1" Title="Swift SDK for Windows aarch64">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="CXX" />
@@ -521,20 +520,20 @@
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows aarch64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows aarch64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentRef Id="XCTestRuntimeDebugInfo" />
       </Feature>
-      <?endif ?>
+      <?endif?>
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift SDK for Windows i686" UpgradeCode="7ab082f9-cd6d-480e-9a97-4186782c3db0" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2022 Swift Open Source Project" Compressed="yes" Description="Swift SDK for Windows i686" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift SDK for Windows i686"
+      UpgradeCode="7ab082f9-cd6d-480e-9a97-4186782c3db0"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift SDK for Windows i686" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
     <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -9,94 +14,92 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="DeveloperPlatforms" Name="Platforms">
-            <Directory Id="WindowsPlatform" Name="Windows.platform">
-              <Directory Id="WindowsPlatform_Developer" Name="Developer">
-                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="DeveloperPlatforms" Name="Platforms">
+          <Directory Id="WindowsPlatform" Name="Windows.platform">
+            <Directory Id="WindowsPlatform_Developer" Name="Developer">
+              <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                  <!-- XCTest -->
-                  <!--
-                    FIXME(compnerd) this should actually be the proper version
-                    of XCTest, and needs to be reflected in the plist as well.
-                  -->
-                  <Directory Id="XCTest" Name="XCTest-development">
-                    <Directory Id="XCTest_usr" Name="usr">
-                      <Directory Id="XCTest_usr_bin32" Name="bin32">
-                      </Directory>
-                      <Directory Id="XCTest_usr_lib" Name="lib">
-                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
-                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="XCTest_usr_lib_swift_windows_i686" Name="i686">
-                            </Directory>
-                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
-                            </Directory>
+                <!-- XCTest -->
+                <!--
+                  FIXME(compnerd) this should actually be the proper version
+                  of XCTest, and needs to be reflected in the plist as well.
+                -->
+                <Directory Id="XCTest" Name="XCTest-development">
+                  <Directory Id="XCTest_usr" Name="usr">
+                    <Directory Id="XCTest_usr_bin32" Name="bin32">
+                    </Directory>
+                    <Directory Id="XCTest_usr_lib" Name="lib">
+                      <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                        <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                          <Directory Id="XCTest_usr_lib_swift_windows_i686" Name="i686">
+                          </Directory>
+                          <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
                           </Directory>
                         </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
                 </Directory>
+              </Directory>
 
-                <Directory Id="SDKs" Name="SDKs">
+              <Directory Id="SDKs" Name="SDKs">
 
-                  <!-- Windows.sdk -->
-                  <Directory Id="WindowsSDK" Name="Windows.sdk">
-                    <Directory Id="WindowsSDK_usr" Name="usr">
-                      <Directory Id="WindowsSDK_usr_include" Name="include">
-                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
+                <!-- Windows.sdk -->
+                <Directory Id="WindowsSDK" Name="Windows.sdk">
+                  <Directory Id="WindowsSDK_usr" Name="usr">
+                    <Directory Id="WindowsSDK_usr_include" Name="include">
+                      <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                        <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
+                      </Directory>
+                    </Directory>
+                    <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                      <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                        <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                        <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                          <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                          </Directory>
+                          <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                          </Directory>
+                          <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                          </Directory>
+                          <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                          </Directory>
+                          <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                          </Directory>
+                          <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                          </Directory>
+                          <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                          </Directory>
+                          <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                          </Directory>
+                          <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                          </Directory>
+                          <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                          </Directory>
+                          <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                          </Directory>
+                          <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                          </Directory>
+                          <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                          </Directory>
+                          <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_windows_i686" Name="i686">
                           </Directory>
                         </Directory>
                       </Directory>
-                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
-                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
-                          </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                            </Directory>
-                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                            </Directory>
-                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                            </Directory>
-                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                            </Directory>
-                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                            </Directory>
-                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                            </Directory>
-                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
-                            </Directory>
-                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                            </Directory>
-                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                            </Directory>
-                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                            </Directory>
-                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                            </Directory>
-                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                            </Directory>
-                            <Directory Id="WindowsSDK_usr_lib_swift_windows_i686" Name="i686">
-                            </Directory>
-                          </Directory>
-                        </Directory>
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_share" Name="share">
-                      </Directory>
+                    </Directory>
+                    <Directory Id="WindowsSDK_usr_share" Name="share">
                     </Directory>
                   </Directory>
                 </Directory>
@@ -106,10 +109,8 @@
         </Directory>
       </Directory>
     </Directory>
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="XCTest">
@@ -486,7 +487,7 @@
 
 
     <!-- Features -->
-    <Feature Id="Win32SDK" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows i686" Level="1" Title="Swift SDK for Windows i686">
+    <Feature Id="Win32SDK" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows i686" Level="1" Title="Swift SDK for Windows i686">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="CXX" />
@@ -513,20 +514,20 @@
       <ComponentGroupRef Id="Configuration" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows i686" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows i686" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentRef Id="XCTestRuntimeDebugInfo" />
       </Feature>
-      <?endif ?>
+      <?endif?>
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/sdk.wixproj
+++ b/platforms/Windows/sdk.wixproj
@@ -1,10 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
   <PropertyGroup>
-    <OutputName>sdk</OutputName>
-    <OutputType>Package</OutputType>
-    <ProjectGuid>39170311-3634-4a14-9546-7e4825e7dcd8</ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -18,14 +14,7 @@
   <PropertyGroup>
     <OutputPath>build\</OutputPath>
     <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
-    <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
-
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <Target Name="EnsureWiXToolsetInstalled" Condition="">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
-  </Target>
 
   <Import Project="WiXCodeSigning.targets" />
 
@@ -40,24 +29,17 @@
     <HarvestDirectorySuppressRootDirectory>true</HarvestDirectorySuppressRootDirectory>
   </PropertyGroup>
 
-  <Target Name="BeforeBuild">
-    <ItemGroup>
-      <HarvestDirectory Include="$(SDK_ROOT)\usr\lib\swift\shims">
-        <ComponentGroupName>SwiftShims</ComponentGroupName>
-        <DirectoryRefId>WindowsSDK_usr_lib_swift_shims</DirectoryRefId>
-        <PreprocessorVariable>var.SwiftShimsPath</PreprocessorVariable>
-      </HarvestDirectory>
-    </ItemGroup>
-  </Target>
-
   <ItemGroup>
-    <WixExtension Include="WixUIExtension">
-      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
-      <Name>WixUIExtension</Name>
-    </WixExtension>
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
+    <PackageReference Include="WixToolset.Heat" Version="4.0.0-rc.4" />
   </ItemGroup>
 
   <ItemGroup>
+    <HarvestDirectory Include="$(SDK_ROOT)\usr\lib\swift\shims">
+      <ComponentGroupName>SwiftShims</ComponentGroupName>
+      <DirectoryRefId>WindowsSDK_usr_lib_swift_shims</DirectoryRefId>
+      <PreprocessorVariable>var.SwiftShimsPath</PreprocessorVariable>
+    </HarvestDirectory>
     <Compile Include="sdk-$(ProductArchitecture).wxs" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/swift-format-amd64.wxs
+++ b/platforms/Windows/swift-format-amd64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Code Formatter for Windows x86_64" UpgradeCode="2f8df238-f65c-4bf4-a78e-f2d26ee27225" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Code Formatter for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033" 
+      Manufacturer="swift.org" 
+      Name="Swift Code Formatter for Windows x86_64" 
+      UpgradeCode="2f8df238-f65c-4bf4-a78e-f2d26ee27225" 
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Code Formatter for Windows x86_64" />
 
     <!-- NOTE(compnerd) use pre-3.0 schema for better compatibility. -->
     <Media Id="1" Cabinet="SwiftFormat.cab" EmbedCab="yes" />
@@ -10,18 +15,14 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Tools" Name="Tools">
-          </Directory>
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="Tools" Name="Tools">
         </Directory>
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftFormat">
@@ -38,32 +39,30 @@
     </ComponentGroup>
     <?endif?>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="645cdd3d-9dde-4e6d-8071-c0349ae87bcf">
-        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Tools" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="645cdd3d-9dde-4e6d-8071-c0349ae87bcf">
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Tools" />
+    </Component>
 
-    <Feature Id="SwiftFormat" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Code Formatter for Windows x86_64" Level="1" Title="Swift Code Formatter (Windows x86_64)">
+    <Feature Id="SwiftFormat" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Code Formatter for Windows x86_64" Level="1" Title="Swift Code Formatter (Windows x86_64)">
       <ComponentGroupRef Id="SwiftFormat" />
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO?>
-      <Feature Id="DebugInfo" Absent="allow" Description="Debug Information for Swift Code Formatter for Windows x86_64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" Description="Debug Information for Swift Code Formatter for Windows x86_64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftFormatDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
 
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/swift-format-arm64.wxs
+++ b/platforms/Windows/swift-format-arm64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Code Formatter for Windows aarch64" UpgradeCode="45f1ae7a-4d90-414d-80b3-a5a45898b212" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Code Formatter for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift Code Formatter for Windows aarch64"
+      UpgradeCode="45f1ae7a-4d90-414d-80b3-a5a45898b212"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Code Formatter for Windows aarch64" />
 
     <!-- NOTE(compnerd) use pre-3.0 schema for better compatibility. -->
     <Media Id="1" Cabinet="SwiftFormat.cab" EmbedCab="yes" />
@@ -10,18 +15,14 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Tools" Name="Tools">
-          </Directory>
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="Tools" Name="Tools">
         </Directory>
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftFormat">
@@ -38,32 +39,30 @@
     </ComponentGroup>
     <?endif?>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="c1a01e55-3353-4eca-8b58-9960e57a3758">
-        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Tools" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="c1a01e55-3353-4eca-8b58-9960e57a3758">
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Tools" />
+    </Component>
 
-    <Feature Id="SwiftFormat" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Code Formatter for Windows aarch64" Level="1" Title="Swift Code Formatter (Windows aarch64)">
+    <Feature Id="SwiftFormat" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Code Formatter for Windows aarch64" Level="1" Title="Swift Code Formatter (Windows aarch64)">
       <ComponentGroupRef Id="SwiftFormat" />
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO?>
-      <Feature Id="DebugInfo" Absent="allow" Description="Debug Information for Swift Code Formatter for Windows aarch64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" Description="Debug Information for Swift Code Formatter for Windows aarch64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="SwiftFormatDebugInfo" />
       </Feature>
       <?endif?>
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
 
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/swift-format.wixproj
+++ b/platforms/Windows/swift-format.wixproj
@@ -1,10 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTarget="build">
+<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
   <PropertyGroup>
-    <OutputName>swift-format</OutputName>
-    <OutputType>Package</OutputType>
-    <ProjectGuid>19d8e67a-655f-4ac2-a868-2ce653506192</ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -18,17 +14,6 @@
   <PropertyGroup>
     <OutputPath>build\</OutputPath>
     <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
-    <DefineSolutionProperties>false</DefineSolutionProperties>
-  </PropertyGroup>
-
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <Target Name="EnsureWiXToolsetInstalled" Condition="">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
-  </Target>
-
-  <PropertyGroup>
-    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
   </PropertyGroup>
 
   <Import Project="WiXCodeSigning.targets" />
@@ -38,10 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <WixExtension Include="WixUIExtension">
-      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
-      <Name>WixUIExtension</Name>
-    </WixExtension>
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/toolchain-amd64.wxs
+++ b/platforms/Windows/toolchain-amd64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Toolchain for Windows x86_64" UpgradeCode="9871289b-f9cb-4b39-8122-2c7ec1ab24d5" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Toolchain for Windows x86_64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift Toolchain for Windows x86_64"
+      UpgradeCode="9871289b-f9cb-4b39-8122-2c7ec1ab24d5"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Toolchain for Windows x86_64" />
 
     <!--
       NOTE(compnerd) Use high compression as this is an extrodinarily large
@@ -29,67 +34,65 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Toolchains" Name="Toolchains">
-            <!-- TODO(compnerd):
-              This really should be
-              unknown-Asserts-$(var.ProductVersion).xctoolchain,
-              though before changing, we should setup a
-              `unknown-Asserts-current.xctoolchain`
-              symlink. Additionally, beware that the environment chagnes
-              below will need to be updated to reflect this change. Ideally,
-              we would have as part of this a tool to select the different
-              toolchain versions.
-            -->
-            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-              <Directory Id="_usr" Name="usr">
-                <Directory Id="_usr_bin" Name="bin">
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="Toolchains" Name="Toolchains">
+          <!-- TODO(compnerd):
+            This really should be
+            unknown-Asserts-$(var.ProductVersion).xctoolchain,
+            though before changing, we should setup a
+            `unknown-Asserts-current.xctoolchain`
+            symlink. Additionally, beware that the environment chagnes
+            below will need to be updated to reflect this change. Ideally,
+            we would have as part of this a tool to select the different
+            toolchain versions.
+          -->
+          <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+            <Directory Id="_usr" Name="usr">
+              <Directory Id="_usr_bin" Name="bin">
+              </Directory>
+              <Directory Id="_usr_include" Name="include">
+                <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
                 </Directory>
-                <Directory Id="_usr_include" Name="include">
-                  <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
-                  </Directory>
-                  <Directory Id="_usr_include_clang_c" Name="clang-c">
-                  </Directory>
-                  <Directory Id="_usr_include_dispatch" Name="dispatch">
-                  </Directory>
-                  <Directory Id="_usr_include_indexstore" Name="indexstore">
-                  </Directory>
-                  <Directory Id="_usr_include_lldb" Name="lldb">
-                  </Directory>
-                  <Directory Id="_usr_include_llvm_c" Name="llvm-c">
-                  </Directory>
-                  <Directory Id="_usr_include_os" Name="os">
-                  </Directory>
-                  <Directory Id="_usr_include_SourceKit" Name="SourceKit">
-                  </Directory>
+                <Directory Id="_usr_include_clang_c" Name="clang-c">
                 </Directory>
-                <Directory Id="_usr_lib" Name="lib">
-                  <Directory Id="_usr_lib_clang" Name="clang">
-                  </Directory>
-                  <Directory Id="_usr_lib_site_packages" Name="site-packages">
-                    <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
-                      <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
-                        <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
-                        </Directory>
-                      </Directory>
-                      <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
+                <Directory Id="_usr_include_dispatch" Name="dispatch">
+                </Directory>
+                <Directory Id="_usr_include_indexstore" Name="indexstore">
+                </Directory>
+                <Directory Id="_usr_include_lldb" Name="lldb">
+                </Directory>
+                <Directory Id="_usr_include_llvm_c" Name="llvm-c">
+                </Directory>
+                <Directory Id="_usr_include_os" Name="os">
+                </Directory>
+                <Directory Id="_usr_include_SourceKit" Name="SourceKit">
+                </Directory>
+              </Directory>
+              <Directory Id="_usr_lib" Name="lib">
+                <Directory Id="_usr_lib_clang" Name="clang">
+                </Directory>
+                <Directory Id="_usr_lib_site_packages" Name="site-packages">
+                  <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
+                    <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
+                      <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
                       </Directory>
                     </Directory>
-                  </Directory>
-                  <Directory Id="_usr_lib_swift" Name="swift">
-                    <Directory Id="_usr_lib_swift_migrator" Name="migrator">
-                    </Directory>
-                    <Directory Id="_usr_lib_swift_shims" Name="shims">
+                    <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
                     </Directory>
                   </Directory>
                 </Directory>
-                <Directory Id="_usr_libexec" Name="libexec">
-                </Directory>
-                <Directory Id="_usr_share" Name="share">
-                  <Directory Id="_usr_share_swift" Name="swift">
+                <Directory Id="_usr_lib_swift" Name="swift">
+                  <Directory Id="_usr_lib_swift_migrator" Name="migrator">
                   </Directory>
+                  <Directory Id="_usr_lib_swift_shims" Name="shims">
+                  </Directory>
+                </Directory>
+              </Directory>
+              <Directory Id="_usr_libexec" Name="libexec">
+              </Directory>
+              <Directory Id="_usr_share" Name="share">
+                <Directory Id="_usr_share_swift" Name="swift">
                 </Directory>
               </Directory>
             </Directory>
@@ -97,10 +100,9 @@
         </Directory>
       </Directory>
     </Directory>
+    
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="binutils">
@@ -756,14 +758,12 @@
     </ComponentGroup>
     <?endif?>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
-        <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer" />
-        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
+      <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer" />
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
+    </Component>
 
-    <Feature Id="Toolchain" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows x86_64" Level="1" Title="Swift Toolchain for Windows x86_64">
+    <Feature Id="Toolchain" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows x86_64" Level="1" Title="Swift Toolchain for Windows x86_64">
       <ComponentGroupRef Id="binutils" />
       <ComponentGroupRef Id="clang" />
       <ComponentGroupRef Id="lld" />
@@ -785,8 +785,8 @@
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows x86_64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows x86_64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="binutilsDebugInfo" />
         <ComponentGroupRef Id="clangDebugInfo" />
         <ComponentGroupRef Id="lldDebugInfo" />
@@ -804,13 +804,13 @@
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
 
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/toolchain-arm64.wxs
+++ b/platforms/Windows/toolchain-arm64.wxs
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="swift.org" Name="Swift Toolchain for Windows aarch64" UpgradeCode="7e95dc06-7f84-4e8e-a038-8304af0468fb" Version="$(var.ProductVersion)">
-    <Package Comments="Copyright (c) 2021-2022 Swift Open Source Project" Compressed="yes" Description="Swift Toolchain for Windows aarch64" InstallScope="perMachine" Manufacturer="swift.org" />
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="swift.org"
+      Name="Swift Toolchain for Windows aarch64"
+      UpgradeCode="7e95dc06-7f84-4e8e-a038-8304af0468fb"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="Swift Toolchain for Windows aarch64" />
 
     <!--
       NOTE(compnerd) Use high compression as this is an extrodinarily large
@@ -29,67 +34,65 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="INSTALLDIR">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Toolchains" Name="Toolchains">
-            <!-- TODO(compnerd):
-              This really should be
-              unknown-Asserts-$(var.ProductVersion).xctoolchain,
-              though before changing, we should setup a
-              `unknown-Asserts-current.xctoolchain`
-              symlink. Additionally, beware that the environment chagnes
-              below will need to be updated to reflect this change. Ideally,
-              we would have as part of this a tool to select the different
-              toolchain versions.
-            -->
-            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-              <Directory Id="_usr" Name="usr">
-                <Directory Id="_usr_bin" Name="bin">
+    <Directory Id="INSTALLDIR">
+      <Directory Id="Developer" Name="Developer">
+        <Directory Id="Toolchains" Name="Toolchains">
+          <!-- TODO(compnerd):
+            This really should be
+            unknown-Asserts-$(var.ProductVersion).xctoolchain,
+            though before changing, we should setup a
+            `unknown-Asserts-current.xctoolchain`
+            symlink. Additionally, beware that the environment chagnes
+            below will need to be updated to reflect this change. Ideally,
+            we would have as part of this a tool to select the different
+            toolchain versions.
+          -->
+          <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+            <Directory Id="_usr" Name="usr">
+              <Directory Id="_usr_bin" Name="bin">
+              </Directory>
+              <Directory Id="_usr_include" Name="include">
+                <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
                 </Directory>
-                <Directory Id="_usr_include" Name="include">
-                  <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
-                  </Directory>
-                  <Directory Id="_usr_include_clang_c" Name="clang-c">
-                  </Directory>
-                  <Directory Id="_usr_include_dispatch" Name="dispatch">
-                  </Directory>
-                  <Directory Id="_usr_include_indexstore" Name="indexstore">
-                  </Directory>
-                  <Directory Id="_usr_include_lldb" Name="lldb">
-                  </Directory>
-                  <Directory Id="_usr_include_llvm_c" Name="llvm-c">
-                  </Directory>
-                  <Directory Id="_usr_include_os" Name="os">
-                  </Directory>
-                  <Directory Id="_usr_include_SourceKit" Name="SourceKit">
-                  </Directory>
+                <Directory Id="_usr_include_clang_c" Name="clang-c">
                 </Directory>
-                <Directory Id="_usr_lib" Name="lib">
-                  <Directory Id="_usr_lib_clang" Name="clang">
-                  </Directory>
-                  <Directory Id="_usr_lib_site_packages" Name="site-packages">
-                    <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
-                      <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
-                        <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
-                        </Directory>
-                      </Directory>
-                      <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
+                <Directory Id="_usr_include_dispatch" Name="dispatch">
+                </Directory>
+                <Directory Id="_usr_include_indexstore" Name="indexstore">
+                </Directory>
+                <Directory Id="_usr_include_lldb" Name="lldb">
+                </Directory>
+                <Directory Id="_usr_include_llvm_c" Name="llvm-c">
+                </Directory>
+                <Directory Id="_usr_include_os" Name="os">
+                </Directory>
+                <Directory Id="_usr_include_SourceKit" Name="SourceKit">
+                </Directory>
+              </Directory>
+              <Directory Id="_usr_lib" Name="lib">
+                <Directory Id="_usr_lib_clang" Name="clang">
+                </Directory>
+                <Directory Id="_usr_lib_site_packages" Name="site-packages">
+                  <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
+                    <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
+                      <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
                       </Directory>
                     </Directory>
-                  </Directory>
-                  <Directory Id="_usr_lib_swift" Name="swift">
-                    <Directory Id="_usr_lib_swift_migrator" Name="migrator">
-                    </Directory>
-                    <Directory Id="_usr_lib_swift_shims" Name="shims">
+                    <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
                     </Directory>
                   </Directory>
                 </Directory>
-                <Directory Id="_usr_libexec" Name="libexec">
-                </Directory>
-                <Directory Id="_usr_share" Name="share">
-                  <Directory Id="_usr_share_swift" Name="swift">
+                <Directory Id="_usr_lib_swift" Name="swift">
+                  <Directory Id="_usr_lib_swift_migrator" Name="migrator">
                   </Directory>
+                  <Directory Id="_usr_lib_swift_shims" Name="shims">
+                  </Directory>
+                </Directory>
+              </Directory>
+              <Directory Id="_usr_libexec" Name="libexec">
+              </Directory>
+              <Directory Id="_usr_share" Name="share">
+                <Directory Id="_usr_share_swift" Name="swift">
                 </Directory>
               </Directory>
             </Directory>
@@ -98,9 +101,7 @@
       </Directory>
     </Directory>
 
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library">
-      NOT INSTALLDIR
-    </SetDirectory>
+    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="binutils">
@@ -756,14 +757,12 @@
     </ComponentGroup>
     <?endif?>
 
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="EnvironmentVariables" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
-        <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer" />
-        <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
+      <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer" />
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
+    </Component>
 
-    <Feature Id="Toolchain" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows aarch64" Level="1" Title="Swift Toolchain for Windows aarch64">
+    <Feature Id="Toolchain" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows aarch64" Level="1" Title="Swift Toolchain for Windows aarch64">
       <ComponentGroupRef Id="binutils" />
       <ComponentGroupRef Id="clang" />
       <ComponentGroupRef Id="lld" />
@@ -785,8 +784,8 @@
       <ComponentRef Id="EnvironmentVariables" />
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows aarch64" Level="0" Title="Debug Information">
-        <Condition Level="1">INSTALL_DEBUGINFO</Condition>
+      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows aarch64" Level="0" Title="Debug Information">
+        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
         <ComponentGroupRef Id="binutilsDebugInfo" />
         <ComponentGroupRef Id="clangDebugInfo" />
         <ComponentGroupRef Id="lldDebugInfo" />
@@ -804,13 +803,13 @@
     </Feature>
 
     <UI>
-      <UIRef Id="WixUI_InstallDir" />
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" ></Property>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
     <WixVariable Id="WixUIDialogBmp" Value="Resources\swift_dialog.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\swift_banner.png" />
 
-  </Product>
+  </Package>
 </Wix>

--- a/platforms/Windows/toolchain.wixproj
+++ b/platforms/Windows/toolchain.wixproj
@@ -1,10 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
   <PropertyGroup>
-    <OutputName>toolchain</OutputName>
-    <OutputType>Package</OutputType>
-    <ProjectGuid>6ebfb883-fc92-4b73-81ae-ddeb2cec4df9</ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -18,14 +14,7 @@
   <PropertyGroup>
     <OutputPath>build\</OutputPath>
     <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
-    <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
-
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <Target Name="EnsureWiXToolsetInstalled" Condition="">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/." />
-  </Target>
 
   <Import Project="WiXCodeSigning.targets" />
 
@@ -40,30 +29,17 @@
     <HarvestDirectorySuppressRootDirectory>true</HarvestDirectorySuppressRootDirectory>
   </PropertyGroup>
 
-  <Target Name="BeforeBuild">
-    <ItemGroup>
-      <!-- FIXME(compnerd): include the shims in the toolchain instead of the SDK?
-      <HarvestDirectory Include="$(TOOLCHAIN_ROOT)\usr\lib\swift\shims">
-        <ComponentGroupName>SwiftShims</ComponentGroupName>
-        <DirectoryRefId>_usr_lib_swift_shims</DirectoryRefId>
-      </HarvestDirectory>
-      -->
-      <HarvestDirectory Include="$(TOOLCHAIN_ROOT)\usr\lib\clang">
-        <ComponentGroupName>ClangResources</ComponentGroupName>
-        <DirectoryRefId>_usr_lib_clang</DirectoryRefId>
-        <PreprocessorVariable>var.TOOLCHAIN_ROOT_USR_LIB_CLANG</PreprocessorVariable>
-      </HarvestDirectory>
-    </ItemGroup>
-  </Target>
-
   <ItemGroup>
-    <WixExtension Include="WixUIExtension">
-      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
-      <Name>WixUIExtension</Name>
-    </WixExtension>
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
+    <PackageReference Include="WixToolset.Heat" Version="4.0.0-rc.4" />
   </ItemGroup>
 
   <ItemGroup>
+    <HarvestDirectory Include="$(TOOLCHAIN_ROOT)\usr\lib\clang">
+      <ComponentGroupName>ClangResources</ComponentGroupName>
+      <DirectoryRefId>_usr_lib_clang</DirectoryRefId>
+      <PreprocessorVariable>var.TOOLCHAIN_ROOT_USR_LIB_CLANG</PreprocessorVariable>
+    </HarvestDirectory>
     <Compile Include="toolchain-$(ProductArchitecture).wxs" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/toolchain.wixproj
+++ b/platforms/Windows/toolchain.wixproj
@@ -35,6 +35,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- FIXME(compnerd): include the shims in the toolchain instead of the SDK?
+      <HarvestDirectory Include="$(TOOLCHAIN_ROOT)\usr\lib\swift\shims">
+        <ComponentGroupName>SwiftShims</ComponentGroupName>
+        <DirectoryRefId>_usr_lib_swift_shims</DirectoryRefId>
+      </HarvestDirectory>
+      -->
     <HarvestDirectory Include="$(TOOLCHAIN_ROOT)\usr\lib\clang">
       <ComponentGroupName>ClangResources</ComponentGroupName>
       <DirectoryRefId>_usr_lib_clang</DirectoryRefId>


### PR DESCRIPTION
Migrates the Windows installer to WiX v4, SDK-style project and consuming WiX from Nuget, meaning that it doesn't need to be installed on the machine anymore. This also unblocks the arm64 installer.

I ran the WiX v4 converter extension in VS, then tweaked the output to minimize the diff. Many elements are slightly different in v4:
- wixprojs are sdk-style, with `<Project>`. They require `msbuild -restore`.
- wix extensions are served through nuget via `<PackageReference>`
- `Compressed="yes"` is now default.
- `TARGETDIR` should not be defined anymore
- Condition syntax is slightly different
- `Absent="disallow"` became `allowAbsent="no"`

How tested:
- Built locally

Pending related changes to consuming repos. (adding `-restore` to the msbuild invocation)