### PR TITLE
Fix default Windows install directory regression from WiX v4 port

### DIFF
--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -17,20 +17,22 @@
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="07cd7a30-e084-447d-af16-ca3a013c5147" Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLDIR" Name="Library">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Toolchains" Name="Toolchains">
-            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-              <Directory Id="_usr" Name="usr">
-                <Directory Id="_usr_bin" Name="bin">
-                </Directory>
-                <Directory Id="_usr_lib" Name="lib">
-                  <!-- FIXME(compnerd) should we include the SPM import libraries? -->
-                  <Directory Id="_usr_lib_swift" Name="swift">
-                    <Directory Id="_usr_lib_swift_pm" Name="pm">
-                      <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
-                      </Directory>
-                      <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Library" Name="Library">
+          <Directory Id="Developer" Name="Developer">
+            <Directory Id="Toolchains" Name="Toolchains">
+              <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+                <Directory Id="_usr" Name="usr">
+                  <Directory Id="_usr_bin" Name="bin">
+                  </Directory>
+                  <Directory Id="_usr_lib" Name="lib">
+                    <!-- FIXME(compnerd) should we include the SPM import libraries? -->
+                    <Directory Id="_usr_lib_swift" Name="swift">
+                      <Directory Id="_usr_lib_swift_pm" Name="pm">
+                        <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
+                        </Directory>
+                        <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+                        </Directory>
                       </Directory>
                     </Directory>
                   </Directory>

--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -14,7 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="Toolchains" Name="Toolchains">
           <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
@@ -37,8 +37,6 @@
         </Directory>
       </Directory>
     </Directory>
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftCollections">

--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -14,20 +14,24 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="Toolchains" Name="Toolchains">
-          <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-            <Directory Id="_usr" Name="usr">
-              <Directory Id="_usr_bin" Name="bin">
-              </Directory>
-              <Directory Id="_usr_lib" Name="lib">
-                <!-- FIXME(compnerd) should we include the SPM import libraries? -->
-                <Directory Id="_usr_lib_swift" Name="swift">
-                  <Directory Id="_usr_lib_swift_pm" Name="pm">
-                    <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
-                    </Directory>
-                    <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="07cd7a30-e084-447d-af16-ca3a013c5147" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Toolchains" Name="Toolchains">
+            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+              <Directory Id="_usr" Name="usr">
+                <Directory Id="_usr_bin" Name="bin">
+                </Directory>
+                <Directory Id="_usr_lib" Name="lib">
+                  <!-- FIXME(compnerd) should we include the SPM import libraries? -->
+                  <Directory Id="_usr_lib_swift" Name="swift">
+                    <Directory Id="_usr_lib_swift_pm" Name="pm">
+                      <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
+                      </Directory>
+                      <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+                      </Directory>
                     </Directory>
                   </Directory>
                 </Directory>

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -14,7 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="Toolchains" Name="Toolchains">
           <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
@@ -37,8 +37,6 @@
         </Directory>
       </Directory>
     </Directory>
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftCollections">

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -17,20 +17,22 @@
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="61297eca-77a2-4749-b2f7-3b7ae6304140" Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLDIR" Name="Library">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Toolchains" Name="Toolchains">
-            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-              <Directory Id="_usr" Name="usr">
-                <Directory Id="_usr_bin" Name="bin">
-                </Directory>
-                <Directory Id="_usr_lib" Name="lib">
-                  <!-- FIXME(compnerd) should we include the SPM import libraries? -->
-                  <Directory Id="_usr_lib_swift" Name="swift">
-                    <Directory Id="_usr_lib_swift_pm" Name="pm">
-                      <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
-                      </Directory>
-                      <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Library" Name="Library">
+          <Directory Id="Developer" Name="Developer">
+            <Directory Id="Toolchains" Name="Toolchains">
+              <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+                <Directory Id="_usr" Name="usr">
+                  <Directory Id="_usr_bin" Name="bin">
+                  </Directory>
+                  <Directory Id="_usr_lib" Name="lib">
+                    <!-- FIXME(compnerd) should we include the SPM import libraries? -->
+                    <Directory Id="_usr_lib_swift" Name="swift">
+                      <Directory Id="_usr_lib_swift_pm" Name="pm">
+                        <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
+                        </Directory>
+                        <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+                        </Directory>
                       </Directory>
                     </Directory>
                   </Directory>

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -14,20 +14,24 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="Toolchains" Name="Toolchains">
-          <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-            <Directory Id="_usr" Name="usr">
-              <Directory Id="_usr_bin" Name="bin">
-              </Directory>
-              <Directory Id="_usr_lib" Name="lib">
-                <!-- FIXME(compnerd) should we include the SPM import libraries? -->
-                <Directory Id="_usr_lib_swift" Name="swift">
-                  <Directory Id="_usr_lib_swift_pm" Name="pm">
-                    <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
-                    </Directory>
-                    <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="61297eca-77a2-4749-b2f7-3b7ae6304140" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Toolchains" Name="Toolchains">
+            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+              <Directory Id="_usr" Name="usr">
+                <Directory Id="_usr_bin" Name="bin">
+                </Directory>
+                <Directory Id="_usr_lib" Name="lib">
+                  <!-- FIXME(compnerd) should we include the SPM import libraries? -->
+                  <Directory Id="_usr_lib_swift" Name="swift">
+                    <Directory Id="_usr_lib_swift_pm" Name="pm">
+                      <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI">
+                      </Directory>
+                      <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI">
+                      </Directory>
                     </Directory>
                   </Directory>
                 </Directory>

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -15,7 +15,7 @@
 
     <!-- Directory Structure -->
     <StandardDirectory Id="ProgramFiles64Folder">
-      <Directory Id="INSTALLDIR" Name="swift">
+      <Directory Id="INSTALLDIR" Name="Swift">
         <!-- TODO(compnerd) use $(var.ProductVersion) -->
         <Directory Id="_" Name="runtime-development">
           <Directory Id="_usr" Name="usr">

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -14,15 +14,17 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[ProgramFiles64Folder]swift">
-      <!-- TODO(compnerd) use $(var.ProductVersion) -->
-      <Directory Id="_" Name="runtime-development">
-        <Directory Id="_usr" Name="usr">
-          <Directory Id="_usr_bin" Name="bin">
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLDIR" Name="swift">
+        <!-- TODO(compnerd) use $(var.ProductVersion) -->
+        <Directory Id="_" Name="runtime-development">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin">
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
-    </Directory>
+    </StandardDirectory>
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -14,7 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[ProgramFiles64Folder]swift">
       <!-- TODO(compnerd) use $(var.ProductVersion) -->
       <Directory Id="_" Name="runtime-development">
         <Directory Id="_usr" Name="usr">
@@ -22,9 +22,7 @@
           </Directory>
         </Directory>
       </Directory>
-    </Directory>    
-
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift" Condition="NOT INSTALLDIR" />
+    </Directory>
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -15,7 +15,7 @@
 
     <!-- Directory Structure -->
     <StandardDirectory Id="ProgramFiles64Folder">
-      <Directory Id="INSTALLDIR" Name="swift">
+      <Directory Id="INSTALLDIR" Name="Swift">
         <!-- TODO(compnerd) use $(var.ProductVersion) -->
         <Directory Id="_" Name="runtime-development">
           <Directory Id="_usr" Name="usr">

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -14,15 +14,17 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[ProgramFiles64Folder]swift">
-      <!-- TODO(compnerd) use $(var.ProductVersion) -->
-      <Directory Id="_" Name="runtime-development">
-        <Directory Id="_usr" Name="usr">
-          <Directory Id="_usr_bin" Name="bin">
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLDIR" Name="swift">
+        <!-- TODO(compnerd) use $(var.ProductVersion) -->
+        <Directory Id="_" Name="runtime-development">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin">
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
-    </Directory>
+    </StandardDirectory>
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -14,7 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[ProgramFiles64Folder]swift">
       <!-- TODO(compnerd) use $(var.ProductVersion) -->
       <Directory Id="_" Name="runtime-development">
         <Directory Id="_usr" Name="usr">
@@ -23,9 +23,6 @@
         </Directory>
       </Directory>
     </Directory>
-    
-
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFiles64Folder]swift" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -14,7 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[ProgramFilesFolder]swift">
       <!-- TODO(compnerd) use $(var.ProductVersion) -->
       <Directory Id="_" Name="runtime-development">
         <Directory Id="_usr" Name="usr">
@@ -23,8 +23,6 @@
         </Directory>
       </Directory>
     </Directory>
-    
-    <SetDirectory Id="INSTALLDIR" Value="[ProgramFilesFolder]swift" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -15,7 +15,7 @@
 
     <!-- Directory Structure -->
     <StandardDirectory Id="ProgramFilesFolder">
-      <Directory Id="INSTALLDIR" Name="swift">
+      <Directory Id="INSTALLDIR" Name="Swift">
         <!-- TODO(compnerd) use $(var.ProductVersion) -->
         <Directory Id="_" Name="runtime-development">
           <Directory Id="_usr" Name="usr">

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -14,15 +14,17 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[ProgramFilesFolder]swift">
-      <!-- TODO(compnerd) use $(var.ProductVersion) -->
-      <Directory Id="_" Name="runtime-development">
-        <Directory Id="_usr" Name="usr">
-          <Directory Id="_usr_bin" Name="bin">
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLDIR" Name="swift">
+        <!-- TODO(compnerd) use $(var.ProductVersion) -->
+        <Directory Id="_" Name="runtime-development">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin">
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
-    </Directory>
+    </StandardDirectory>
 
     <!-- Components -->
     <ComponentGroup Id="SwiftRuntime" Directory="_usr_bin">

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -14,92 +14,95 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="DeveloperPlatforms" Name="Platforms">
-          <Directory Id="WindowsPlatform" Name="Windows.platform">
-            <Directory Id="WindowsPlatform_Developer" Name="Developer">
-              <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="bedc1fea-99ee-40be-ab38-3101698f2c0b" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="DeveloperPlatforms" Name="Platforms">
+            <Directory Id="WindowsPlatform" Name="Windows.platform">
+              <Directory Id="WindowsPlatform_Developer" Name="Developer">
+                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                <!-- XCTest -->
-                <!--
-                  FIXME(compnerd) this should actually be the proper version
-                  of XCTest, and needs to be reflected in the plist as well.
-                -->
-                <Directory Id="XCTest" Name="XCTest-development">
-                  <Directory Id="XCTest_usr" Name="usr">
-                    <Directory Id="XCTest_usr_bin64" Name="bin64">
-                    </Directory>
-                    <Directory Id="XCTest_usr_lib" Name="lib">
-                      <Directory Id="XCTest_usr_lib_swift" Name="swift">
-                        <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
-                          <Directory Id="XCTest_usr_lib_swift_windows_x86_64" Name="x86_64">
-                          </Directory>
-                          <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                  <!-- XCTest -->
+                  <!--
+                    FIXME(compnerd) this should actually be the proper version
+                    of XCTest, and needs to be reflected in the plist as well.
+                  -->
+                  <Directory Id="XCTest" Name="XCTest-development">
+                    <Directory Id="XCTest_usr" Name="usr">
+                      <Directory Id="XCTest_usr_bin64" Name="bin64">
+                      </Directory>
+                      <Directory Id="XCTest_usr_lib" Name="lib">
+                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="XCTest_usr_lib_swift_windows_x86_64" Name="x86_64">
+                            </Directory>
+                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                            </Directory>
                           </Directory>
                         </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
                 </Directory>
-              </Directory>
 
-              <Directory Id="SDKs" Name="SDKs">
+                <Directory Id="SDKs" Name="SDKs">
 
-                <!-- Windows.sdk -->
-                <Directory Id="WindowsSDK" Name="Windows.sdk">
-                  <Directory Id="WindowsSDK_usr" Name="usr">
-                    <Directory Id="WindowsSDK_usr_include" Name="include">
-                      <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_os" Name="os">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
-                        <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                  <!-- Windows.sdk -->
+                  <Directory Id="WindowsSDK" Name="Windows.sdk">
+                    <Directory Id="WindowsSDK_usr" Name="usr">
+                      <Directory Id="WindowsSDK_usr_include" Name="include">
+                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
                         </Directory>
-                      </Directory>
-                    </Directory>
-                    <Directory Id="WindowsSDK_usr_lib" Name="lib">
-                      <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
-                        <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                          <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                          </Directory>
-                          <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                          </Directory>
-                          <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                          </Directory>
-                          <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                          </Directory>
-                          <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                          </Directory>
-                          <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                          </Directory>
-                          <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
-                          </Directory>
-                          <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                          </Directory>
-                          <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                          </Directory>
-                          <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                          </Directory>
-                          <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                          </Directory>
-                          <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                          </Directory>
-                          <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                          </Directory>
-                          <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                          </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
+                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                           </Directory>
                         </Directory>
                       </Directory>
-                    </Directory>
-                    <Directory Id="WindowsSDK_usr_share" Name="share">
+                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                            </Directory>
+                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                            </Directory>
+                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                            </Directory>
+                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                            </Directory>
+                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                            </Directory>
+                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                            </Directory>
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                            </Directory>
+                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                            </Directory>
+                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                            </Directory>
+                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                            </Directory>
+                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                            </Directory>
+                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                            </Directory>
+                            <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
+                            </Directory>
+                          </Directory>
+                        </Directory>
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_share" Name="share">
+                      </Directory>
                     </Directory>
                   </Directory>
                 </Directory>

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -14,7 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="DeveloperPlatforms" Name="Platforms">
           <Directory Id="WindowsPlatform" Name="Windows.platform">
@@ -109,9 +109,6 @@
         </Directory>
       </Directory>
     </Directory>
-    
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="XCTest">

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -14,6 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="bedc1fea-99ee-40be-ab38-3101698f2c0b" Id="WINDOWSVOLUME">
       <Directory Id="INSTALLDIR">

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -16,92 +16,94 @@
     <!-- Directory Structure -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="bedc1fea-99ee-40be-ab38-3101698f2c0b" Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLDIR" Name="Library">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="DeveloperPlatforms" Name="Platforms">
-            <Directory Id="WindowsPlatform" Name="Windows.platform">
-              <Directory Id="WindowsPlatform_Developer" Name="Developer">
-                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Library" Name="Library">
+          <Directory Id="Developer" Name="Developer">
+            <Directory Id="DeveloperPlatforms" Name="Platforms">
+              <Directory Id="WindowsPlatform" Name="Windows.platform">
+                <Directory Id="WindowsPlatform_Developer" Name="Developer">
+                  <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                  <!-- XCTest -->
-                  <!--
-                    FIXME(compnerd) this should actually be the proper version
-                    of XCTest, and needs to be reflected in the plist as well.
-                  -->
-                  <Directory Id="XCTest" Name="XCTest-development">
-                    <Directory Id="XCTest_usr" Name="usr">
-                      <Directory Id="XCTest_usr_bin64" Name="bin64">
-                      </Directory>
-                      <Directory Id="XCTest_usr_lib" Name="lib">
-                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
-                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="XCTest_usr_lib_swift_windows_x86_64" Name="x86_64">
-                            </Directory>
-                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                    <!-- XCTest -->
+                    <!--
+                      FIXME(compnerd) this should actually be the proper version
+                      of XCTest, and needs to be reflected in the plist as well.
+                    -->
+                    <Directory Id="XCTest" Name="XCTest-development">
+                      <Directory Id="XCTest_usr" Name="usr">
+                        <Directory Id="XCTest_usr_bin64" Name="bin64">
+                        </Directory>
+                        <Directory Id="XCTest_usr_lib" Name="lib">
+                          <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                            <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                              <Directory Id="XCTest_usr_lib_swift_windows_x86_64" Name="x86_64">
+                              </Directory>
+                              <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                              </Directory>
                             </Directory>
                           </Directory>
                         </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
-                </Directory>
 
-                <Directory Id="SDKs" Name="SDKs">
+                  <Directory Id="SDKs" Name="SDKs">
 
-                  <!-- Windows.sdk -->
-                  <Directory Id="WindowsSDK" Name="Windows.sdk">
-                    <Directory Id="WindowsSDK_usr" Name="usr">
-                      <Directory Id="WindowsSDK_usr_include" Name="include">
-                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                    <!-- Windows.sdk -->
+                    <Directory Id="WindowsSDK" Name="Windows.sdk">
+                      <Directory Id="WindowsSDK_usr" Name="usr">
+                        <Directory Id="WindowsSDK_usr_include" Name="include">
+                          <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
                           </Directory>
-                        </Directory>
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
-                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                          <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
                           </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                            </Directory>
-                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                            </Directory>
-                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                            </Directory>
-                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                            </Directory>
-                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                            </Directory>
-                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                            </Directory>
-                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
-                            </Directory>
-                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                            </Directory>
-                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                            </Directory>
-                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                            </Directory>
-                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                            </Directory>
-                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                            </Directory>
-                            <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
+                          <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                            <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                             </Directory>
                           </Directory>
                         </Directory>
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_share" Name="share">
+                        <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                          <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                            <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                            </Directory>
+                            <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                              <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                              </Directory>
+                              <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                              </Directory>
+                              <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                              </Directory>
+                              <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                              </Directory>
+                              <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                              </Directory>
+                              <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                              </Directory>
+                              <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                              </Directory>
+                              <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                              </Directory>
+                              <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                              </Directory>
+                              <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                              </Directory>
+                              <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                              </Directory>
+                              <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                              </Directory>
+                              <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                              </Directory>
+                              <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                              </Directory>
+                              <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
+                              </Directory>
+                            </Directory>
+                          </Directory>
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_share" Name="share">
+                        </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
@@ -488,7 +490,7 @@
 
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
       <!-- <Condition> %PROCESSOR_ARCHITECTURE~="amd64" </Condition> -->
-      <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
+      <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
     </Component>
 
     <!-- Features -->

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -17,92 +17,94 @@
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="f0594364-d461-4652-96e0-2a7d58642f03" Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLDIR" Name="Library">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="DeveloperPlatforms" Name="Platforms">
-            <Directory Id="WindowsPlatform" Name="Windows.platform">
-              <Directory Id="WindowsPlatform_Developer" Name="Developer">
-                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Library" Name="Library">
+          <Directory Id="Developer" Name="Developer">
+            <Directory Id="DeveloperPlatforms" Name="Platforms">
+              <Directory Id="WindowsPlatform" Name="Windows.platform">
+                <Directory Id="WindowsPlatform_Developer" Name="Developer">
+                  <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                  <!-- XCTest -->
-                  <!--
-                    FIXME(compnerd) this should actually be the proper version
-                    of XCTest, and needs to be reflected in the plist as well.
-                  -->
-                  <Directory Id="XCTest" Name="XCTest-development">
-                    <Directory Id="XCTest_usr" Name="usr">
-                      <Directory Id="XCTest_usr_bin64a" Name="bin64a">
-                      </Directory>
-                      <Directory Id="XCTest_usr_lib" Name="lib">
-                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
-                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="XCTest_usr_lib_swift_windows_aarch64" Name="aarch64">
-                            </Directory>
-                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                    <!-- XCTest -->
+                    <!--
+                      FIXME(compnerd) this should actually be the proper version
+                      of XCTest, and needs to be reflected in the plist as well.
+                    -->
+                    <Directory Id="XCTest" Name="XCTest-development">
+                      <Directory Id="XCTest_usr" Name="usr">
+                        <Directory Id="XCTest_usr_bin64a" Name="bin64a">
+                        </Directory>
+                        <Directory Id="XCTest_usr_lib" Name="lib">
+                          <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                            <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                              <Directory Id="XCTest_usr_lib_swift_windows_aarch64" Name="aarch64">
+                              </Directory>
+                              <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                              </Directory>
                             </Directory>
                           </Directory>
                         </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
-                </Directory>
 
-                <Directory Id="SDKs" Name="SDKs">
+                  <Directory Id="SDKs" Name="SDKs">
 
-                  <!-- Windows.sdk -->
-                  <Directory Id="WindowsSDK" Name="Windows.sdk">
-                    <Directory Id="WindowsSDK_usr" Name="usr">
-                      <Directory Id="WindowsSDK_usr_include" Name="include">
-                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
-                        </Directory>
-                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                    <!-- Windows.sdk -->
+                    <Directory Id="WindowsSDK" Name="Windows.sdk">
+                      <Directory Id="WindowsSDK_usr" Name="usr">
+                        <Directory Id="WindowsSDK_usr_include" Name="include">
+                          <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
                           </Directory>
-                        </Directory>
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
-                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
-                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                          <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
                           </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                            </Directory>
-                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                            </Directory>
-                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                            </Directory>
-                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                            </Directory>
-                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                            </Directory>
-                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                            </Directory>
-                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
-                            </Directory>
-                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                            </Directory>
-                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                            </Directory>
-                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                            </Directory>
-                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                            </Directory>
-                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                            </Directory>
-                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                            </Directory>
-                            <Directory Id="WindowsSDK_usr_lib_swift_windows_aarch64" Name="aarch64">
+                          <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                            <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                             </Directory>
                           </Directory>
                         </Directory>
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_share" Name="share">
+                        <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                          <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                            <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                            </Directory>
+                            <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                              <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                              </Directory>
+                              <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                              </Directory>
+                              <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                              </Directory>
+                              <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                              </Directory>
+                              <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                              </Directory>
+                              <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                              </Directory>
+                              <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                              </Directory>
+                              <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                              </Directory>
+                              <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                              </Directory>
+                              <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                              </Directory>
+                              <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                              </Directory>
+                              <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                              </Directory>
+                              <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                              </Directory>
+                              <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                              </Directory>
+                              <Directory Id="WindowsSDK_usr_lib_swift_windows_aarch64" Name="aarch64">
+                              </Directory>
+                            </Directory>
+                          </Directory>
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_share" Name="share">
+                        </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
@@ -489,7 +491,7 @@
 
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="bd3ddc62-4c5c-4f6b-806e-02d2c6a65b65">
       <!-- <Condition> %PROCESSOR_ARCHITECTURE~="arm64" </Condition> -->
-      <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
+      <Environment Id="SDKRoot" Action="set" Name="SDKROOT" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" />
     </Component>
 
     <!-- Features -->

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -14,92 +14,96 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="DeveloperPlatforms" Name="Platforms">
-          <Directory Id="WindowsPlatform" Name="Windows.platform">
-            <Directory Id="WindowsPlatform_Developer" Name="Developer">
-              <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="f0594364-d461-4652-96e0-2a7d58642f03" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="DeveloperPlatforms" Name="Platforms">
+            <Directory Id="WindowsPlatform" Name="Windows.platform">
+              <Directory Id="WindowsPlatform_Developer" Name="Developer">
+                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                <!-- XCTest -->
-                <!--
-                  FIXME(compnerd) this should actually be the proper version
-                  of XCTest, and needs to be reflected in the plist as well.
-                -->
-                <Directory Id="XCTest" Name="XCTest-development">
-                  <Directory Id="XCTest_usr" Name="usr">
-                    <Directory Id="XCTest_usr_bin64a" Name="bin64a">
-                    </Directory>
-                    <Directory Id="XCTest_usr_lib" Name="lib">
-                      <Directory Id="XCTest_usr_lib_swift" Name="swift">
-                        <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
-                          <Directory Id="XCTest_usr_lib_swift_windows_aarch64" Name="aarch64">
-                          </Directory>
-                          <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                  <!-- XCTest -->
+                  <!--
+                    FIXME(compnerd) this should actually be the proper version
+                    of XCTest, and needs to be reflected in the plist as well.
+                  -->
+                  <Directory Id="XCTest" Name="XCTest-development">
+                    <Directory Id="XCTest_usr" Name="usr">
+                      <Directory Id="XCTest_usr_bin64a" Name="bin64a">
+                      </Directory>
+                      <Directory Id="XCTest_usr_lib" Name="lib">
+                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="XCTest_usr_lib_swift_windows_aarch64" Name="aarch64">
+                            </Directory>
+                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                            </Directory>
                           </Directory>
                         </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
                 </Directory>
-              </Directory>
 
-              <Directory Id="SDKs" Name="SDKs">
+                <Directory Id="SDKs" Name="SDKs">
 
-                <!-- Windows.sdk -->
-                <Directory Id="WindowsSDK" Name="Windows.sdk">
-                  <Directory Id="WindowsSDK_usr" Name="usr">
-                    <Directory Id="WindowsSDK_usr_include" Name="include">
-                      <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_os" Name="os">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
-                        <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                  <!-- Windows.sdk -->
+                  <Directory Id="WindowsSDK" Name="Windows.sdk">
+                    <Directory Id="WindowsSDK_usr" Name="usr">
+                      <Directory Id="WindowsSDK_usr_include" Name="include">
+                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
                         </Directory>
-                      </Directory>
-                    </Directory>
-                    <Directory Id="WindowsSDK_usr_lib" Name="lib">
-                      <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
-                        <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                          <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                          </Directory>
-                          <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                          </Directory>
-                          <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                          </Directory>
-                          <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                          </Directory>
-                          <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                          </Directory>
-                          <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                          </Directory>
-                          <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
-                          </Directory>
-                          <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                          </Directory>
-                          <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                          </Directory>
-                          <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                          </Directory>
-                          <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                          </Directory>
-                          <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                          </Directory>
-                          <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                          </Directory>
-                          <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                          </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_windows_aarch64" Name="aarch64">
+                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                           </Directory>
                         </Directory>
                       </Directory>
-                    </Directory>
-                    <Directory Id="WindowsSDK_usr_share" Name="share">
+                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                            </Directory>
+                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                            </Directory>
+                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                            </Directory>
+                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                            </Directory>
+                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                            </Directory>
+                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                            </Directory>
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                            </Directory>
+                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                            </Directory>
+                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                            </Directory>
+                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                            </Directory>
+                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                            </Directory>
+                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                            </Directory>
+                            <Directory Id="WindowsSDK_usr_lib_swift_windows_aarch64" Name="aarch64">
+                            </Directory>
+                          </Directory>
+                        </Directory>
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_share" Name="share">
+                      </Directory>
                     </Directory>
                   </Directory>
                 </Directory>

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -14,7 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="DeveloperPlatforms" Name="Platforms">
           <Directory Id="WindowsPlatform" Name="Windows.platform">
@@ -109,8 +109,6 @@
         </Directory>
       </Directory>
     </Directory>
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="XCTest">

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -14,92 +14,96 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="DeveloperPlatforms" Name="Platforms">
-          <Directory Id="WindowsPlatform" Name="Windows.platform">
-            <Directory Id="WindowsPlatform_Developer" Name="Developer">
-              <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="a69e744d-4da2-468c-8438-71c3c66a482c" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="DeveloperPlatforms" Name="Platforms">
+            <Directory Id="WindowsPlatform" Name="Windows.platform">
+              <Directory Id="WindowsPlatform_Developer" Name="Developer">
+                <Directory Id="WindowsPlatform_Developer_Library" Name="Library">
 
-                <!-- XCTest -->
-                <!--
-                  FIXME(compnerd) this should actually be the proper version
-                  of XCTest, and needs to be reflected in the plist as well.
-                -->
-                <Directory Id="XCTest" Name="XCTest-development">
-                  <Directory Id="XCTest_usr" Name="usr">
-                    <Directory Id="XCTest_usr_bin32" Name="bin32">
-                    </Directory>
-                    <Directory Id="XCTest_usr_lib" Name="lib">
-                      <Directory Id="XCTest_usr_lib_swift" Name="swift">
-                        <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
-                          <Directory Id="XCTest_usr_lib_swift_windows_i686" Name="i686">
-                          </Directory>
-                          <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                  <!-- XCTest -->
+                  <!--
+                    FIXME(compnerd) this should actually be the proper version
+                    of XCTest, and needs to be reflected in the plist as well.
+                  -->
+                  <Directory Id="XCTest" Name="XCTest-development">
+                    <Directory Id="XCTest_usr" Name="usr">
+                      <Directory Id="XCTest_usr_bin32" Name="bin32">
+                      </Directory>
+                      <Directory Id="XCTest_usr_lib" Name="lib">
+                        <Directory Id="XCTest_usr_lib_swift" Name="swift">
+                          <Directory Id="XCTest_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="XCTest_usr_lib_swift_windows_i686" Name="i686">
+                            </Directory>
+                            <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule">
+                            </Directory>
                           </Directory>
                         </Directory>
                       </Directory>
                     </Directory>
                   </Directory>
                 </Directory>
-              </Directory>
 
-              <Directory Id="SDKs" Name="SDKs">
+                <Directory Id="SDKs" Name="SDKs">
 
-                <!-- Windows.sdk -->
-                <Directory Id="WindowsSDK" Name="Windows.sdk">
-                  <Directory Id="WindowsSDK_usr" Name="usr">
-                    <Directory Id="WindowsSDK_usr_include" Name="include">
-                      <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_os" Name="os">
-                      </Directory>
-                      <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
-                        <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
+                  <!-- Windows.sdk -->
+                  <Directory Id="WindowsSDK" Name="Windows.sdk">
+                    <Directory Id="WindowsSDK_usr" Name="usr">
+                      <Directory Id="WindowsSDK_usr_include" Name="include">
+                        <Directory Id="WindowsSDK_usr_include_Block" Name="Block">
                         </Directory>
-                      </Directory>
-                    </Directory>
-                    <Directory Id="WindowsSDK_usr_lib" Name="lib">
-                      <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
-                        <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                        <Directory Id="WindowsSDK_usr_include_dispatch" Name="dispatch">
                         </Directory>
-                        <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
-                          <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
-                          </Directory>
-                          <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
-                          </Directory>
-                          <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
-                          </Directory>
-                          <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
-                          </Directory>
-                          <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
-                          </Directory>
-                          <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
-                          </Directory>
-                          <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
-                          </Directory>
-                          <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
-                          </Directory>
-                          <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
-                          </Directory>
-                          <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
-                          </Directory>
-                          <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
-                          </Directory>
-                          <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
-                          </Directory>
-                          <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
-                          </Directory>
-                          <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
-                          </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_windows_i686" Name="i686">
+                        <Directory Id="WindowsSDK_usr_include_os" Name="os">
+                        </Directory>
+                        <Directory Id="WindowsSDK_usr_include_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror">
                           </Directory>
                         </Directory>
                       </Directory>
-                    </Directory>
-                    <Directory Id="WindowsSDK_usr_share" Name="share">
+                      <Directory Id="WindowsSDK_usr_lib" Name="lib">
+                        <Directory Id="WindowsSDK_usr_lib_swift" Name="swift">
+                          <Directory Id="WindowsSDK_usr_lib_swift_shims" Name="shims">
+                          </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_windows" Name="windows">
+                            <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule">
+                            </Directory>
+                            <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule">
+                            </Directory>
+                            <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule">
+                            </Directory>
+                            <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule">
+                            </Directory>
+                            <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule">
+                            </Directory>
+                            <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule">
+                            </Directory>
+                            <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
+                            </Directory>
+                            <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
+                            </Directory>
+                            <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule">
+                            </Directory>
+                            <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule">
+                            </Directory>
+                            <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule">
+                            </Directory>
+                            <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule">
+                            </Directory>
+                            <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule">
+                            </Directory>
+                            <Directory Id="WindowsSDK_usr_lib_swift_windows_i686" Name="i686">
+                            </Directory>
+                          </Directory>
+                        </Directory>
+                      </Directory>
+                      <Directory Id="WindowsSDK_usr_share" Name="share">
+                      </Directory>
                     </Directory>
                   </Directory>
                 </Directory>

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -14,7 +14,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="DeveloperPlatforms" Name="Platforms">
           <Directory Id="WindowsPlatform" Name="Windows.platform">
@@ -109,8 +109,6 @@
         </Directory>
       </Directory>
     </Directory>
-    
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="XCTest">

--- a/platforms/Windows/swift-format-amd64.wxs
+++ b/platforms/Windows/swift-format-amd64.wxs
@@ -15,9 +15,14 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="Tools" Name="Tools">
+    
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="b153bc1a-71af-454c-8c5d-85f0eed7f94b" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Tools" Name="Tools">
+          </Directory>
         </Directory>
       </Directory>
     </Directory>

--- a/platforms/Windows/swift-format-amd64.wxs
+++ b/platforms/Windows/swift-format-amd64.wxs
@@ -15,14 +15,12 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="Tools" Name="Tools">
         </Directory>
       </Directory>
     </Directory>
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftFormat">

--- a/platforms/Windows/swift-format-amd64.wxs
+++ b/platforms/Windows/swift-format-amd64.wxs
@@ -19,9 +19,11 @@
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="b153bc1a-71af-454c-8c5d-85f0eed7f94b" Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLDIR" Name="Library">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Tools" Name="Tools">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Library" Name="Library">
+          <Directory Id="Developer" Name="Developer">
+            <Directory Id="Tools" Name="Tools">
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
@@ -43,7 +45,7 @@
     <?endif?>
 
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="645cdd3d-9dde-4e6d-8071-c0349ae87bcf">
-      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Tools" />
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Tools" />
     </Component>
 
     <Feature Id="SwiftFormat" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Code Formatter for Windows x86_64" Level="1" Title="Swift Code Formatter (Windows x86_64)">

--- a/platforms/Windows/swift-format-amd64.wxs
+++ b/platforms/Windows/swift-format-amd64.wxs
@@ -15,7 +15,6 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="b153bc1a-71af-454c-8c5d-85f0eed7f94b" Id="WINDOWSVOLUME">

--- a/platforms/Windows/swift-format-arm64.wxs
+++ b/platforms/Windows/swift-format-arm64.wxs
@@ -15,14 +15,12 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="Tools" Name="Tools">
         </Directory>
       </Directory>
     </Directory>
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="SwiftFormat">

--- a/platforms/Windows/swift-format-arm64.wxs
+++ b/platforms/Windows/swift-format-arm64.wxs
@@ -18,9 +18,11 @@
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="ab1b7ca9-b240-44c7-be8b-3cf1e34ad747" Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLDIR" Name="Library">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Tools" Name="Tools">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Library" Name="Library">
+          <Directory Id="Developer" Name="Developer">
+            <Directory Id="Tools" Name="Tools">
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
@@ -42,7 +44,7 @@
     <?endif?>
 
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="c1a01e55-3353-4eca-8b58-9960e57a3758">
-      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Tools" />
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Tools" />
     </Component>
 
     <Feature Id="SwiftFormat" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Code Formatter for Windows aarch64" Level="1" Title="Swift Code Formatter (Windows aarch64)">

--- a/platforms/Windows/swift-format-arm64.wxs
+++ b/platforms/Windows/swift-format-arm64.wxs
@@ -15,9 +15,13 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="Tools" Name="Tools">
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="ab1b7ca9-b240-44c7-be8b-3cf1e34ad747" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Tools" Name="Tools">
+          </Directory>
         </Directory>
       </Directory>
     </Directory>

--- a/platforms/Windows/toolchain-amd64.wxs
+++ b/platforms/Windows/toolchain-amd64.wxs
@@ -34,7 +34,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="Toolchains" Name="Toolchains">
           <!-- TODO(compnerd):
@@ -100,9 +100,6 @@
         </Directory>
       </Directory>
     </Directory>
-    
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="binutils">

--- a/platforms/Windows/toolchain-amd64.wxs
+++ b/platforms/Windows/toolchain-amd64.wxs
@@ -34,65 +34,69 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="Toolchains" Name="Toolchains">
-          <!-- TODO(compnerd):
-            This really should be
-            unknown-Asserts-$(var.ProductVersion).xctoolchain,
-            though before changing, we should setup a
-            `unknown-Asserts-current.xctoolchain`
-            symlink. Additionally, beware that the environment chagnes
-            below will need to be updated to reflect this change. Ideally,
-            we would have as part of this a tool to select the different
-            toolchain versions.
-          -->
-          <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-            <Directory Id="_usr" Name="usr">
-              <Directory Id="_usr_bin" Name="bin">
-              </Directory>
-              <Directory Id="_usr_include" Name="include">
-                <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="ad85d64e-469f-4984-b16e-edb243d8d117" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Toolchains" Name="Toolchains">
+            <!-- TODO(compnerd):
+              This really should be
+              unknown-Asserts-$(var.ProductVersion).xctoolchain,
+              though before changing, we should setup a
+              `unknown-Asserts-current.xctoolchain`
+              symlink. Additionally, beware that the environment chagnes
+              below will need to be updated to reflect this change. Ideally,
+              we would have as part of this a tool to select the different
+              toolchain versions.
+            -->
+            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+              <Directory Id="_usr" Name="usr">
+                <Directory Id="_usr_bin" Name="bin">
                 </Directory>
-                <Directory Id="_usr_include_clang_c" Name="clang-c">
+                <Directory Id="_usr_include" Name="include">
+                  <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+                  </Directory>
+                  <Directory Id="_usr_include_clang_c" Name="clang-c">
+                  </Directory>
+                  <Directory Id="_usr_include_dispatch" Name="dispatch">
+                  </Directory>
+                  <Directory Id="_usr_include_indexstore" Name="indexstore">
+                  </Directory>
+                  <Directory Id="_usr_include_lldb" Name="lldb">
+                  </Directory>
+                  <Directory Id="_usr_include_llvm_c" Name="llvm-c">
+                  </Directory>
+                  <Directory Id="_usr_include_os" Name="os">
+                  </Directory>
+                  <Directory Id="_usr_include_SourceKit" Name="SourceKit">
+                  </Directory>
                 </Directory>
-                <Directory Id="_usr_include_dispatch" Name="dispatch">
-                </Directory>
-                <Directory Id="_usr_include_indexstore" Name="indexstore">
-                </Directory>
-                <Directory Id="_usr_include_lldb" Name="lldb">
-                </Directory>
-                <Directory Id="_usr_include_llvm_c" Name="llvm-c">
-                </Directory>
-                <Directory Id="_usr_include_os" Name="os">
-                </Directory>
-                <Directory Id="_usr_include_SourceKit" Name="SourceKit">
-                </Directory>
-              </Directory>
-              <Directory Id="_usr_lib" Name="lib">
-                <Directory Id="_usr_lib_clang" Name="clang">
-                </Directory>
-                <Directory Id="_usr_lib_site_packages" Name="site-packages">
-                  <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
-                    <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
-                      <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                <Directory Id="_usr_lib" Name="lib">
+                  <Directory Id="_usr_lib_clang" Name="clang">
+                  </Directory>
+                  <Directory Id="_usr_lib_site_packages" Name="site-packages">
+                    <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
+                      <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
+                        <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                        </Directory>
+                      </Directory>
+                      <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
                       </Directory>
                     </Directory>
-                    <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
+                  </Directory>
+                  <Directory Id="_usr_lib_swift" Name="swift">
+                    <Directory Id="_usr_lib_swift_migrator" Name="migrator">
+                    </Directory>
+                    <Directory Id="_usr_lib_swift_shims" Name="shims">
                     </Directory>
                   </Directory>
                 </Directory>
-                <Directory Id="_usr_lib_swift" Name="swift">
-                  <Directory Id="_usr_lib_swift_migrator" Name="migrator">
-                  </Directory>
-                  <Directory Id="_usr_lib_swift_shims" Name="shims">
-                  </Directory>
+                <Directory Id="_usr_libexec" Name="libexec">
                 </Directory>
-              </Directory>
-              <Directory Id="_usr_libexec" Name="libexec">
-              </Directory>
-              <Directory Id="_usr_share" Name="share">
-                <Directory Id="_usr_share_swift" Name="swift">
+                <Directory Id="_usr_share" Name="share">
+                  <Directory Id="_usr_share_swift" Name="swift">
+                  </Directory>
                 </Directory>
               </Directory>
             </Directory>

--- a/platforms/Windows/toolchain-amd64.wxs
+++ b/platforms/Windows/toolchain-amd64.wxs
@@ -37,65 +37,67 @@
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="ad85d64e-469f-4984-b16e-edb243d8d117" Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLDIR" Name="Library">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Toolchains" Name="Toolchains">
-            <!-- TODO(compnerd):
-              This really should be
-              unknown-Asserts-$(var.ProductVersion).xctoolchain,
-              though before changing, we should setup a
-              `unknown-Asserts-current.xctoolchain`
-              symlink. Additionally, beware that the environment chagnes
-              below will need to be updated to reflect this change. Ideally,
-              we would have as part of this a tool to select the different
-              toolchain versions.
-            -->
-            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-              <Directory Id="_usr" Name="usr">
-                <Directory Id="_usr_bin" Name="bin">
-                </Directory>
-                <Directory Id="_usr_include" Name="include">
-                  <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Library" Name="Library">
+          <Directory Id="Developer" Name="Developer">
+            <Directory Id="Toolchains" Name="Toolchains">
+              <!-- TODO(compnerd):
+                This really should be
+                unknown-Asserts-$(var.ProductVersion).xctoolchain,
+                though before changing, we should setup a
+                `unknown-Asserts-current.xctoolchain`
+                symlink. Additionally, beware that the environment chagnes
+                below will need to be updated to reflect this change. Ideally,
+                we would have as part of this a tool to select the different
+                toolchain versions.
+              -->
+              <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+                <Directory Id="_usr" Name="usr">
+                  <Directory Id="_usr_bin" Name="bin">
                   </Directory>
-                  <Directory Id="_usr_include_clang_c" Name="clang-c">
+                  <Directory Id="_usr_include" Name="include">
+                    <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+                    </Directory>
+                    <Directory Id="_usr_include_clang_c" Name="clang-c">
+                    </Directory>
+                    <Directory Id="_usr_include_dispatch" Name="dispatch">
+                    </Directory>
+                    <Directory Id="_usr_include_indexstore" Name="indexstore">
+                    </Directory>
+                    <Directory Id="_usr_include_lldb" Name="lldb">
+                    </Directory>
+                    <Directory Id="_usr_include_llvm_c" Name="llvm-c">
+                    </Directory>
+                    <Directory Id="_usr_include_os" Name="os">
+                    </Directory>
+                    <Directory Id="_usr_include_SourceKit" Name="SourceKit">
+                    </Directory>
                   </Directory>
-                  <Directory Id="_usr_include_dispatch" Name="dispatch">
-                  </Directory>
-                  <Directory Id="_usr_include_indexstore" Name="indexstore">
-                  </Directory>
-                  <Directory Id="_usr_include_lldb" Name="lldb">
-                  </Directory>
-                  <Directory Id="_usr_include_llvm_c" Name="llvm-c">
-                  </Directory>
-                  <Directory Id="_usr_include_os" Name="os">
-                  </Directory>
-                  <Directory Id="_usr_include_SourceKit" Name="SourceKit">
-                  </Directory>
-                </Directory>
-                <Directory Id="_usr_lib" Name="lib">
-                  <Directory Id="_usr_lib_clang" Name="clang">
-                  </Directory>
-                  <Directory Id="_usr_lib_site_packages" Name="site-packages">
-                    <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
-                      <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
-                        <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                  <Directory Id="_usr_lib" Name="lib">
+                    <Directory Id="_usr_lib_clang" Name="clang">
+                    </Directory>
+                    <Directory Id="_usr_lib_site_packages" Name="site-packages">
+                      <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
+                        <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
+                          <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                          </Directory>
+                        </Directory>
+                        <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
                         </Directory>
                       </Directory>
-                      <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
+                    </Directory>
+                    <Directory Id="_usr_lib_swift" Name="swift">
+                      <Directory Id="_usr_lib_swift_migrator" Name="migrator">
+                      </Directory>
+                      <Directory Id="_usr_lib_swift_shims" Name="shims">
                       </Directory>
                     </Directory>
                   </Directory>
-                  <Directory Id="_usr_lib_swift" Name="swift">
-                    <Directory Id="_usr_lib_swift_migrator" Name="migrator">
-                    </Directory>
-                    <Directory Id="_usr_lib_swift_shims" Name="shims">
-                    </Directory>
+                  <Directory Id="_usr_libexec" Name="libexec">
                   </Directory>
-                </Directory>
-                <Directory Id="_usr_libexec" Name="libexec">
-                </Directory>
-                <Directory Id="_usr_share" Name="share">
-                  <Directory Id="_usr_share_swift" Name="swift">
+                  <Directory Id="_usr_share" Name="share">
+                    <Directory Id="_usr_share_swift" Name="swift">
+                    </Directory>
                   </Directory>
                 </Directory>
               </Directory>
@@ -760,8 +762,8 @@
     <?endif?>
 
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
-      <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer" />
-      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
+      <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer" />
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
     </Component>
 
     <Feature Id="Toolchain" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows x86_64" Level="1" Title="Swift Toolchain for Windows x86_64">

--- a/platforms/Windows/toolchain-arm64.wxs
+++ b/platforms/Windows/toolchain-arm64.wxs
@@ -34,7 +34,7 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR">
+    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
       <Directory Id="Developer" Name="Developer">
         <Directory Id="Toolchains" Name="Toolchains">
           <!-- TODO(compnerd):
@@ -100,8 +100,6 @@
         </Directory>
       </Directory>
     </Directory>
-
-    <SetDirectory Id="INSTALLDIR" Value="[WindowsVolume]Library" Condition="NOT INSTALLDIR" />
 
     <!-- Components -->
     <ComponentGroup Id="binutils">

--- a/platforms/Windows/toolchain-arm64.wxs
+++ b/platforms/Windows/toolchain-arm64.wxs
@@ -37,65 +37,67 @@
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
     <Directory ComponentGuidGenerationSeed="289f73df-ade6-4eab-95f1-7d9e76a5db8e" Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLDIR" Name="Library">
-        <Directory Id="Developer" Name="Developer">
-          <Directory Id="Toolchains" Name="Toolchains">
-            <!-- TODO(compnerd):
-              This really should be
-              unknown-Asserts-$(var.ProductVersion).xctoolchain,
-              though before changing, we should setup a
-              `unknown-Asserts-current.xctoolchain`
-              symlink. Additionally, beware that the environment chagnes
-              below will need to be updated to reflect this change. Ideally,
-              we would have as part of this a tool to select the different
-              toolchain versions.
-            -->
-            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-              <Directory Id="_usr" Name="usr">
-                <Directory Id="_usr_bin" Name="bin">
-                </Directory>
-                <Directory Id="_usr_include" Name="include">
-                  <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+      <Directory Id="INSTALLDIR">
+        <Directory Id="Library" Name="Library">
+          <Directory Id="Developer" Name="Developer">
+            <Directory Id="Toolchains" Name="Toolchains">
+              <!-- TODO(compnerd):
+                This really should be
+                unknown-Asserts-$(var.ProductVersion).xctoolchain,
+                though before changing, we should setup a
+                `unknown-Asserts-current.xctoolchain`
+                symlink. Additionally, beware that the environment chagnes
+                below will need to be updated to reflect this change. Ideally,
+                we would have as part of this a tool to select the different
+                toolchain versions.
+              -->
+              <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+                <Directory Id="_usr" Name="usr">
+                  <Directory Id="_usr_bin" Name="bin">
                   </Directory>
-                  <Directory Id="_usr_include_clang_c" Name="clang-c">
+                  <Directory Id="_usr_include" Name="include">
+                    <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+                    </Directory>
+                    <Directory Id="_usr_include_clang_c" Name="clang-c">
+                    </Directory>
+                    <Directory Id="_usr_include_dispatch" Name="dispatch">
+                    </Directory>
+                    <Directory Id="_usr_include_indexstore" Name="indexstore">
+                    </Directory>
+                    <Directory Id="_usr_include_lldb" Name="lldb">
+                    </Directory>
+                    <Directory Id="_usr_include_llvm_c" Name="llvm-c">
+                    </Directory>
+                    <Directory Id="_usr_include_os" Name="os">
+                    </Directory>
+                    <Directory Id="_usr_include_SourceKit" Name="SourceKit">
+                    </Directory>
                   </Directory>
-                  <Directory Id="_usr_include_dispatch" Name="dispatch">
-                  </Directory>
-                  <Directory Id="_usr_include_indexstore" Name="indexstore">
-                  </Directory>
-                  <Directory Id="_usr_include_lldb" Name="lldb">
-                  </Directory>
-                  <Directory Id="_usr_include_llvm_c" Name="llvm-c">
-                  </Directory>
-                  <Directory Id="_usr_include_os" Name="os">
-                  </Directory>
-                  <Directory Id="_usr_include_SourceKit" Name="SourceKit">
-                  </Directory>
-                </Directory>
-                <Directory Id="_usr_lib" Name="lib">
-                  <Directory Id="_usr_lib_clang" Name="clang">
-                  </Directory>
-                  <Directory Id="_usr_lib_site_packages" Name="site-packages">
-                    <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
-                      <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
-                        <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                  <Directory Id="_usr_lib" Name="lib">
+                    <Directory Id="_usr_lib_clang" Name="clang">
+                    </Directory>
+                    <Directory Id="_usr_lib_site_packages" Name="site-packages">
+                      <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
+                        <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
+                          <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                          </Directory>
+                        </Directory>
+                        <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
                         </Directory>
                       </Directory>
-                      <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
+                    </Directory>
+                    <Directory Id="_usr_lib_swift" Name="swift">
+                      <Directory Id="_usr_lib_swift_migrator" Name="migrator">
+                      </Directory>
+                      <Directory Id="_usr_lib_swift_shims" Name="shims">
                       </Directory>
                     </Directory>
                   </Directory>
-                  <Directory Id="_usr_lib_swift" Name="swift">
-                    <Directory Id="_usr_lib_swift_migrator" Name="migrator">
-                    </Directory>
-                    <Directory Id="_usr_lib_swift_shims" Name="shims">
-                    </Directory>
+                  <Directory Id="_usr_libexec" Name="libexec">
                   </Directory>
-                </Directory>
-                <Directory Id="_usr_libexec" Name="libexec">
-                </Directory>
-                <Directory Id="_usr_share" Name="share">
-                  <Directory Id="_usr_share_swift" Name="swift">
+                  <Directory Id="_usr_share" Name="share">
+                    <Directory Id="_usr_share_swift" Name="swift">
+                    </Directory>
                   </Directory>
                 </Directory>
               </Directory>
@@ -103,7 +105,7 @@
           </Directory>
         </Directory>
       </Directory>
-    </StandardDirectory>
+    </Directory>
 
     <!-- Components -->
     <ComponentGroup Id="binutils">
@@ -760,8 +762,8 @@
     <?endif?>
 
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
-      <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Developer" />
-      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
+      <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer" />
+      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
     </Component>
 
     <Feature Id="Toolchain" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows aarch64" Level="1" Title="Swift Toolchain for Windows aarch64">

--- a/platforms/Windows/toolchain-arm64.wxs
+++ b/platforms/Windows/toolchain-arm64.wxs
@@ -34,72 +34,76 @@
     <?endif?>
 
     <!-- Directory Structure -->
-    <Directory Id="INSTALLDIR" Name="[WindowsVolume]Library">
-      <Directory Id="Developer" Name="Developer">
-        <Directory Id="Toolchains" Name="Toolchains">
-          <!-- TODO(compnerd):
-            This really should be
-            unknown-Asserts-$(var.ProductVersion).xctoolchain,
-            though before changing, we should setup a
-            `unknown-Asserts-current.xctoolchain`
-            symlink. Additionally, beware that the environment chagnes
-            below will need to be updated to reflect this change. Ideally,
-            we would have as part of this a tool to select the different
-            toolchain versions.
-          -->
-          <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
-            <Directory Id="_usr" Name="usr">
-              <Directory Id="_usr_bin" Name="bin">
-              </Directory>
-              <Directory Id="_usr_include" Name="include">
-                <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+    <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
+    <Directory ComponentGuidGenerationSeed="289f73df-ade6-4eab-95f1-7d9e76a5db8e" Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLDIR" Name="Library">
+        <Directory Id="Developer" Name="Developer">
+          <Directory Id="Toolchains" Name="Toolchains">
+            <!-- TODO(compnerd):
+              This really should be
+              unknown-Asserts-$(var.ProductVersion).xctoolchain,
+              though before changing, we should setup a
+              `unknown-Asserts-current.xctoolchain`
+              symlink. Additionally, beware that the environment chagnes
+              below will need to be updated to reflect this change. Ideally,
+              we would have as part of this a tool to select the different
+              toolchain versions.
+            -->
+            <Directory Id="xctoolchain" Name="unknown-Asserts-development.xctoolchain">
+              <Directory Id="_usr" Name="usr">
+                <Directory Id="_usr_bin" Name="bin">
                 </Directory>
-                <Directory Id="_usr_include_clang_c" Name="clang-c">
+                <Directory Id="_usr_include" Name="include">
+                  <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan">
+                  </Directory>
+                  <Directory Id="_usr_include_clang_c" Name="clang-c">
+                  </Directory>
+                  <Directory Id="_usr_include_dispatch" Name="dispatch">
+                  </Directory>
+                  <Directory Id="_usr_include_indexstore" Name="indexstore">
+                  </Directory>
+                  <Directory Id="_usr_include_lldb" Name="lldb">
+                  </Directory>
+                  <Directory Id="_usr_include_llvm_c" Name="llvm-c">
+                  </Directory>
+                  <Directory Id="_usr_include_os" Name="os">
+                  </Directory>
+                  <Directory Id="_usr_include_SourceKit" Name="SourceKit">
+                  </Directory>
                 </Directory>
-                <Directory Id="_usr_include_dispatch" Name="dispatch">
-                </Directory>
-                <Directory Id="_usr_include_indexstore" Name="indexstore">
-                </Directory>
-                <Directory Id="_usr_include_lldb" Name="lldb">
-                </Directory>
-                <Directory Id="_usr_include_llvm_c" Name="llvm-c">
-                </Directory>
-                <Directory Id="_usr_include_os" Name="os">
-                </Directory>
-                <Directory Id="_usr_include_SourceKit" Name="SourceKit">
-                </Directory>
-              </Directory>
-              <Directory Id="_usr_lib" Name="lib">
-                <Directory Id="_usr_lib_clang" Name="clang">
-                </Directory>
-                <Directory Id="_usr_lib_site_packages" Name="site-packages">
-                  <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
-                    <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
-                      <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                <Directory Id="_usr_lib" Name="lib">
+                  <Directory Id="_usr_lib_clang" Name="clang">
+                  </Directory>
+                  <Directory Id="_usr_lib_site_packages" Name="site-packages">
+                    <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
+                      <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
+                        <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp">
+                        </Directory>
+                      </Directory>
+                      <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
                       </Directory>
                     </Directory>
-                    <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils">
+                  </Directory>
+                  <Directory Id="_usr_lib_swift" Name="swift">
+                    <Directory Id="_usr_lib_swift_migrator" Name="migrator">
+                    </Directory>
+                    <Directory Id="_usr_lib_swift_shims" Name="shims">
                     </Directory>
                   </Directory>
                 </Directory>
-                <Directory Id="_usr_lib_swift" Name="swift">
-                  <Directory Id="_usr_lib_swift_migrator" Name="migrator">
-                  </Directory>
-                  <Directory Id="_usr_lib_swift_shims" Name="shims">
-                  </Directory>
+                <Directory Id="_usr_libexec" Name="libexec">
                 </Directory>
-              </Directory>
-              <Directory Id="_usr_libexec" Name="libexec">
-              </Directory>
-              <Directory Id="_usr_share" Name="share">
-                <Directory Id="_usr_share_swift" Name="swift">
+                <Directory Id="_usr_share" Name="share">
+                  <Directory Id="_usr_share_swift" Name="swift">
+                  </Directory>
                 </Directory>
               </Directory>
             </Directory>
           </Directory>
         </Directory>
       </Directory>
-    </Directory>
+    </StandardDirectory>
 
     <!-- Components -->
     <ComponentGroup Id="binutils">


### PR DESCRIPTION
The rules around `<SetDirectory>` changed between WiX v3 and v4, so our port resulted in the INSTALLDIR defaulting to `C:\` instead of either `C:\Program Files\swift` or `C:\Library`.

Changes:
- For the runtime, use `<StandardDirectory>` to root in `ProgramFiles`, and capitalize `Swift` for consistency with all other programs
- For stuff installed under `C:\Library`, use `<SetDirectory>` + `<Directory>` as a means of rooting at `WindowsVolume`, also change the customizable installation path to the `C:\` underneath `Library` (so the installer will write the `Library` directory under the users' path rather than start at the `Developer` directory)

How tested:
- Rebuilt and installed runtime + sdk msi's to their default locations and to overriden locations, then installed the full installer. Verified that paths and environment variables are as expected in all cases.