### PR TITLE
WiX: add upgrade code for ARM64 devtools

### DIFF
--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -3,7 +3,7 @@
       Language="1033"
       Manufacturer="swift.org"
       Name="Swift Developer Tools for Windows aarch64"
-      UpgradeCode=""
+      UpgradeCode="87019842-3f3e-4227-b5c5-23a8ef72ad89"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
     <SummaryInformation Description="Swift Developer Tools for Windows aarch64" />


### PR DESCRIPTION
This field was incorrectly empty preventing the MSI from being built. Fill in the value.