### PR TITLE
WiX: remove the support for packaging for Debug Info

### DIFF
--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -9,9 +9,6 @@
     <SummaryInformation Description="Swift Developer Tools for Windows x86_64" />
 
     <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
@@ -57,33 +54,11 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftCollectionsDebugInfo">
-      <Component Id="Collections.pdb" Directory="_usr_bin" Guid="be44261f-8aa1-484b-87a1-d2b1a697a2ca">
-        <File Id="Collections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="DequeModule.pdb" Directory="_usr_bin" Guid="702354af-089c-4180-86a4-6b427305c1bb">
-        <File Id="DequeModule.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="OrderedCollections.pdb" Directory="_usr_bin" Guid="e88ac571-94a9-43e0-b8ea-72c555a67023">
-        <File Id="OrderedCollections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SwiftSystem">
       <Component Id="SystemPackage.dll" Directory="_usr_bin" Guid="16215499-75a2-49b2-bb9c-18b72cc059ef">
         <File Id="SystemPackage.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.dll" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftSystemDebugInfo">
-      <Component Id="SystemPackage.pdb" Directory="_usr_bin" Guid="95301361-03eb-458b-a5d7-6f48ec148a28">
-        <File Id="SystemPackage.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftPackageManager">
       <Component Id="Basics.dll" Directory="_usr_bin" Guid="b8032e5d-802d-4ce0-963a-c799873db876">
@@ -157,91 +132,17 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftPackageManagerDebugInfo">
-      <Component Id="Basics.pdb" Directory="_usr_bin" Guid="7237e918-9b5b-4c2c-9330-bb8670624463">
-        <File Id="Basics.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="Build.pdb" Directory="_usr_bin" Guid="5da27caf-801f-430a-9b9a-e5efbf13708e">
-        <File Id="Build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="Commands.pdb" Directory="_usr_bin" Guid="949a08c5-ec4e-4d69-a18a-d8547a66c50a">
-        <File Id="Commands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="CoreCommands.pdb" Directory="_usr_bin" Guid="39e660e2-e428-4828-848a-c11bccb727e2">
-        <File Id="CoreCommands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CoreCommands.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="DriverSupport.pdb" Directory="_usr_bin" Guid="e228fd9f-13df-4ec5-b989-cca47925f272">
-        <File Id="DriverSupport.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="PackageGraph.pdb" Directory="_usr_bin" Guid="07b49917-5bdd-4491-a151-cb180a04aa90">
-        <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="PackageLoading.pdb" Directory="_usr_bin" Guid="94294eda-8c10-446c-a26f-c652bf6da155">
-        <File Id="PackageLoading.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="PackageModel.pdb" Directory="_usr_bin" Guid="3f849e3c-649f-426d-b088-d840600dbca2">
-        <File Id="PackageModel.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="SPMBuildCore.pdb" Directory="_usr_bin" Guid="aff3a3f5-2bc4-4fa1-b07d-f4e85bb54734">
-        <File Id="SPMBuildCore.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="Workspace.pdb" Directory="_usr_bin" Guid="a690ccb6-cc82-47f1-91c3-bed6994dc44b">
-        <File Id="Workspace.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
-      </Component>
-
-      <Component Id="swift_build.pdb" Directory="_usr_bin" Guid="bfea3c79-9656-4dee-8259-d041db3be1ba">
-        <File Id="swift_build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="swift_package.pdb" Directory="_usr_bin" Guid="0b9cf255-e141-43d3-af4b-e93984b57b4f">
-        <File Id="swift_package.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="swift_run.pdb" Directory="_usr_bin" Guid="aedc7604-351a-4134-baaf-6364db8d53b3">
-        <File Id="swift_run.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="swift_test.pdb" Directory="_usr_bin" Guid="afec8751-e99d-4e2b-b7e9-32e6c3e4507f">
-        <File Id="swift_test.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.pdb" Checksum="yes" />
-      </Component>
-
-      <Component Id="PackageDescription.pdb" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="01d006f5-431e-4f75-820d-98249c580893">
-        <File Id="PackageDescription.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
-      </Component>
-
-      <Component Id="PackagePlugin.pdb" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="7739a6e7-b8f7-4b99-bd7e-0fd13b717b94">
-        <File Id="PackagePlugin.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\pluginAPI\PackagePlugin.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SourceKitLSP">
       <Component Id="sourcekit_lsp.exe" Directory="_usr_bin" Guid="61d82a9e-2f72-415c-b6bb-9f43ec3f6bcd">
         <File Id="sourcekit_lsp.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SourceKitLSPDebugInfo">
-      <Component Id="sourcekit_lsp.pdb" Directory="_usr_bin" Guid="e8a2c9bd-2988-43a4-9382-6d85b3d6e7b4">
-        <File Id="soucekit_lsp.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Feature Id="DeveloperTools" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows x86_64" Level="1" Title="Swift Developer Tools (Windows x86_64)">
       <ComponentGroupRef Id="SwiftCollections" />
       <ComponentGroupRef Id="SwiftSystem" />
       <ComponentGroupRef Id="SwiftPackageManager" />
       <ComponentGroupRef Id="SourceKitLSP" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows x86_64" Level="0" Title="Debug Info">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftCollectionsDebugInfo" />
-        <ComponentGroupRef Id="SwiftSystemDebugInfo" />
-        <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />
-        <ComponentGroupRef Id="SourceKitLSPDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -9,9 +9,6 @@
     <SummaryInformation Description="Swift Developer Tools for Windows aarch64" />
 
     <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
@@ -57,33 +54,11 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftCollectionsDebugInfo">
-      <Component Id="Collections.pdb" Directory="_usr_bin" Guid="d33e610e-171b-445b-bfbe-8f4dadaa8741">
-        <File Id="Collections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="DequeModule.pdb" Directory="_usr_bin" Guid="779c0307-95fe-4cf8-9631-fe2de10e6031">
-        <File Id="DequeModule.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="OrderedCollections.pdb" Directory="_usr_bin" Guid="0546f5b7-10c3-4766-968b-0add6b08c3e1">
-        <File Id="OrderedCollections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SwiftSystem">
       <Component Id="SystemPackage.dll" Directory="_usr_bin" Guid="3a77763d-f9fb-4f1e-a056-f785bb1912e9">
         <File Id="SystemPackage.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.dll" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftSystemDebugInfo">
-      <Component Id="SystemPackage.pdb" Directory="_usr_bin" Guid="157a0be9-c296-4244-8975-7125fb8306d4">
-        <File Id="SystemPackage.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SystemPackage.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftPackageManager">
       <Component Id="Basics.dll" Directory="_usr_bin" Guid="03e5871a-9ded-4010-9708-6217f294edc4">
@@ -157,91 +132,17 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftPackageManagerDebugInfo">
-      <Component Id="Basics.pdb" Directory="_usr_bin" Guid="2fdea2ca-5498-4cb1-bf74-b771321a0b2b">
-        <File Id="Basics.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Basics.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="Build.pdb" Directory="_usr_bin" Guid="cbc19845-fd86-4d2a-977e-5ae49de856d4">
-        <File Id="Build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Build.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="Commands.pdb" Directory="_usr_bin" Guid="345f96d2-f9ac-4c83-8722-855686401a9d">
-        <File Id="Commands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Commands.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="CoreCommands.pdb" Directory="_usr_bin" Guid="8925173e-f45d-44ea-bc8f-a936b1a883ad">
-        <File Id="CoreCommands.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CoreCommands.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="DriverSupport.pdb" Directory="_usr_bin" Guid="f8f8cb75-8f42-4522-bdd7-89499943ef32">
-        <File Id="DriverSupport.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="PackageGraph.pdb" Directory="_usr_bin" Guid="71a32056-bb8d-4d9b-ab76-e25ee6fd04bc">
-        <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="PackageLoading.pdb" Directory="_usr_bin" Guid="991958ab-0f7b-4547-8286-732671282ec1">
-        <File Id="PackageLoading.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="PackageModel.pdb" Directory="_usr_bin" Guid="511fd24a-f9b9-4c7b-97c1-5845dfc308d0">
-        <File Id="PackageModel.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="SPMBuildCore.pdb" Directory="_usr_bin" Guid="3f66ca4f-d560-496f-9f8f-bc350a559ce5">
-        <File Id="SPMBuildCore.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="Workspace.pdb" Directory="_usr_bin" Guid="cf7d3735-03f9-4d17-89b3-c051d1cc3c5a">
-        <File Id="Workspace.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Workspace.pdb" Checksum="yes" />
-      </Component>
-
-      <Component Id="swift_build.pdb" Directory="_usr_bin" Guid="84d4c04b-158f-446b-aa5e-9ffe3318dd02">
-        <File Id="swift_build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="swift_package.pdb" Directory="_usr_bin" Guid="7038d860-c614-4c74-b2ce-d6dc84f8f638">
-        <File Id="swift_package.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="swift_run.pdb" Directory="_usr_bin" Guid="d5eb453e-1e43-4492-b9d6-e3c08b8f7b80">
-        <File Id="swift_run.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />
-      </Component>
-      <Component Id="swift_test.pdb" Directory="_usr_bin" Guid="a9240a6b-9934-4356-80e9-5311d6c35fa5">
-        <File Id="swift_test.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.pdb" Checksum="yes" />
-      </Component>
-
-      <Component Id="PackageDescription.pdb" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="aabedd70-4b90-46ef-8db6-9724c2340f81">
-        <File Id="PackageDescription.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
-      </Component>
-
-      <Component Id="PackagePlugin.pdb" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="bbf77ff9-fa10-4fe3-ab4b-3cbf95fa6be9">
-        <File Id="PackagePlugin.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\pluginAPI\PackagePlugin.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SourceKitLSP">
       <Component Id="sourcekit_lsp.exe" Directory="_usr_bin" Guid="1e4d7fbd-a435-4d11-bd17-2dec0b235c28">
         <File Id="sourcekit_lsp.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SourceKitLSPDebugInfo">
-      <Component Id="sourcekit_lsp.pdb" Directory="_usr_bin" Guid="3a72124e-6b23-42ac-be52-c1ac2d7972f6">
-        <File Id="soucekit_lsp.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Feature Id="DeveloperTools" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows aarch64" Level="1" Title="Swift Developer Tools (Windows aarch64)">
       <ComponentGroupRef Id="SwiftCollections" />
       <ComponentGroupRef Id="SwiftSystem" />
       <ComponentGroupRef Id="SwiftPackageManager" />
       <ComponentGroupRef Id="SourceKitLSP" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows aarch64" Level="0" Title="Debug Info">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftCollectionsDebugInfo" />
-        <ComponentGroupRef Id="SwiftSystemDebugInfo" />
-        <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />
-        <ComponentGroupRef Id="SourceKitLSPDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -9,9 +9,6 @@
     <SummaryInformation Description="Swift Runtime for Windows x86_64" />
 
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <StandardDirectory Id="ProgramFiles64Folder">
@@ -92,73 +89,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftRuntimeDebugInfo">
-      <Component Id="BlocksRuntime.pdb" Guid="230f07ae-6378-410e-8c21-6f6af65ab10c">
-        <File Id="BlocksRuntime.pdb" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="dispatch.pdb" Guid="9540ccae-ca75-449d-bab0-1ba691a22615">
-        <File Id="dispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="Foundation.pdb" Guid="4acf2787-e5df-45fa-a13f-d17eace5477e">
-        <File Id="Foundation.pdb" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="FoundationNetworking.pdb" Guid="a099090f-2db2-4f06-aa87-afbc89926e2f">
-        <File Id="FoundationNetworking.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="FoundationXML.pdb" Guid="97bc6b02-8ac0-4a28-a032-7ebe1dd0d496">
-        <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_Concurrency.pdb" Guid="433dd15e-f72c-4294-9bf5-0be4771d1c10">
-        <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_Differentiation.pdb" Guid="0f761b2c-f01c-4c46-b29a-9e319912089b">
-        <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftDistributed.pdb" Guid="cac90c19-4f03-40e4-be41-f3f7d9484230">
-        <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_RegexParser.pdb" Guid="1272f4c6-36a2-4323-abce-daab5a8e02d9">
-        <File Id="swift_RegexParser.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_StringProcessing.pdb" Guid="d123c083-9dca-4814-875e-27458ae378d9">
-        <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftCore.pdb" Guid="57d56adc-dc40-4d6f-b0d7-11d472f11dbe">
-        <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftCxx.pdb" Guid="d2fdd831-3da3-4f74-8a19-94cdb80eaf4b">
-        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftDispatch.pdb" Guid="155ba810-d2a9-420e-890b-08dfb966daa6">
-        <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <!--
-      <Component Id="swiftDemangle.pdb" Guid="37b6f780-2d6b-45b9-8c54-dc253af0a644">
-        <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      -->
-      <Component Id="swiftCRT.pdb" Guid="42ce883f-3187-46d3-b5db-3efed0b34858">
-        <File Id="swiftCRT.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftRemoteMirror.pdb" Guid="b7c53b19-31f8-4f7e-bb72-226cdf46012a">
-        <File Id="swiftRemoteMirror.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftSwiftOnoneSupport.pdb" Guid="65fcbe1b-f4a6-437e-8e58-6d4504ee789e">
-        <File Id="swiftSwiftOnoneSupport.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftWinSDK.pdb" Guid="793e856f-5f54-48c8-af91-47262bf86b87">
-        <File Id="swiftWinSDK.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="SwiftUtilitiesDebugInfo">
-      <Component Id="plutil.pdb" Guid="20169950-ef36-465e-a52c-cf071e1c0b44">
-        <File Id="plutil.pdb" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="f249625e-aacd-4b17-a464-8f8df05ba5f3">
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
     </Component>
@@ -167,24 +97,10 @@
     <Feature Id="WinX64SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows x86_64" Level="1" Title="Swift Runtime for Windows x86_64">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows x86_64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftRuntimeDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <Feature Id="WinX64SwiftUtilities" AllowAbsent="yes" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows x86_64" Level="1" Title="Swift Utilities for Windows x86_64">
       <ComponentGroupRef Id="SwiftUtilities" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows x86_64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftUtilitiesDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -9,9 +9,6 @@
     <SummaryInformation Description="Swift Runtime for Windows aarch64" />
 
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <StandardDirectory Id="ProgramFiles64Folder">
@@ -92,73 +89,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftRuntimeDebugInfo">
-      <Component Id="BlocksRuntime.pdb" Guid="78e0a44c-7d34-4e87-962c-4bcc23f07a38">
-        <File Id="BlocksRuntime.pdb" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="dispatch.pdb" Guid="bc475b8b-81e4-48d4-a73d-ddb2ca47662e">
-        <File Id="dispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="Foundation.pdb" Guid="16f10b41-575a-4d75-a77d-4d7dbc9c6504">
-        <File Id="Foundation.pdb" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="FoundationNetworking.pdb" Guid="e2f4bc80-b6e8-4589-9fd4-cc1d58011f43">
-        <File Id="FoundationNetworking.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="FoundationXML.pdb" Guid="3c442778-665e-4060-88db-31af4b4255ba">
-        <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_Concurrency.pdb" Guid="6a14736b-be12-4618-bded-aa56a79003c3">
-        <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_Differentiation.pdb" Guid="8c274a2a-2d55-4007-8141-3952b85a4de0">
-        <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftDistributed.pdb" Guid="47bd82d8-3949-4b3e-830a-fa3ec8f61672">
-        <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_RegexParser.pdb" Guid="0575b1c6-fa5e-4db8-ac05-2a048054d9c6">
-        <File Id="swift_RegexParser.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_StringProcessing.pdb" Guid="6fd2d711-4452-4aca-91c0-34e240bcc2d0">
-        <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftCore.pdb" Guid="ba858ada-58f6-499d-a9f3-fdad7e858e15">
-        <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftCxx.pdb" Guid="3e1ebd5a-e9e0-4a8d-bd02-519d93b3e9c8">
-        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftDispatch.pdb" Guid="3a9c9745-99bb-42c8-9a6d-1da25c0365e0">
-        <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <!--
-      <Component Id="swiftDemangle.pdb" Guid="01d707b8-4ce3-4fb7-a694-a71d56b0d779">
-        <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      -->
-      <Component Id="swiftCRT.pdb" Guid="3295a0ed-3e2b-4c5e-9cc6-8e99d3acc50c">
-        <File Id="swiftCRT.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftRemoteMirror.pdb" Guid="9993ed62-00d1-4f44-bda1-c9b9a9df60d2">
-        <File Id="swiftRemoteMirror.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftSwiftOnoneSupport.pdb" Guid="cb55867e-8bff-4961-b064-199b91a9e134">
-        <File Id="swiftSwiftOnoneSupport.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftWinSDK.pdb" Guid="15661f62-a003-41eb-ba01-4999ce9540cb">
-        <File Id="swiftWinSDK.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="SwiftUtilitiesDebugInfo">
-      <Component Id="plutil.pdb" Guid="e882f817-4ede-4720-85d6-ff54d5ca1f75">
-        <File Id="plutil.pdb" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="8681d813-eb32-46f9-8b1c-f622b38b5eaf">
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
     </Component>
@@ -167,24 +97,10 @@
     <Feature Id="WinARM64SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows aarch64" Level="1" Title="Swift Runtime for Windows aarch64">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows aarch64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftRuntimeDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <Feature Id="WinARM64SwiftUtilities" AllowAbsent="yes" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows aarch64" Level="1" Title="Swift Utilities for Windows aarch64">
       <ComponentGroupRef Id="SwiftUtilities" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows aarch64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftUtilitiesDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -9,9 +9,6 @@
     <SummaryInformation Description="Swift Runtime for Windows i686" />
     
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <StandardDirectory Id="ProgramFilesFolder">
@@ -92,73 +89,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftRuntimeDebugInfo">
-      <Component Id="BlocksRuntime.pdb" Guid="ae1e5c85-3672-4114-9e82-f8152ed8e919">
-        <File Id="BlocksRuntime.pdb" Source="$(var.SDK_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="dispatch.pdb" Guid="1f2385b7-e4d4-464c-b987-5139949499c2">
-        <File Id="dispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="Foundation.pdb" Guid="2fa5fdb1-e875-46e3-aa18-5aac03ee6f63">
-        <File Id="Foundation.pdb" Source="$(var.SDK_ROOT)\usr\bin\Foundation.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="FoundationNetworking.pdb" Guid="0636b89e-a623-4ef5-adf7-56ab5250987b">
-        <File Id="FoundationNetworking.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationNetworking.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="FoundationXML.pdb" Guid="e9e6eb2e-9423-4e6d-8b91-751e174624a4">
-        <File Id="FoundationXML.pdb" Source="$(var.SDK_ROOT)\usr\bin\FoundationXML.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_Concurrency.pdb" Guid="4c11a732-031a-4c07-81ba-49407a0870f5">
-        <File Id="swift_Concurrency.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Concurrency.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_Differentiation.pdb" Guid="e4eb5456-7142-4be4-a1ca-1328f76ed875">
-        <File Id="swift_Differentiation.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_Differentiation.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftDistributed.pdb" Guid="e6f9a9a6-1ba2-4807-b35a-7726ac30b91e">
-        <File Id="swiftDistributed.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDistributed.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_RegexParser.pdb" Guid="c69fd450-0fbf-4b30-baf0-f5107c65cf28">
-        <File Id="swift_RegexParser.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_RegexParser.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swift_StringProcessing.pdb" Guid="e1d856db-107e-452b-95ba-d8b0c4bc4cbf">
-        <File Id="swift_StringProcessing.pdb" Source="$(var.SDK_ROOT)\usr\bin\swift_StringProcessing.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftCore.pdb" Guid="abd0c880-8dcc-4c23-88d4-afb224d3433b">
-        <File Id="swiftCore.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftCxx.pdb" Guid="e41ad064-6cb2-4fbc-9b7e-44ba17bf8264">
-        <File Id="swiftCxx.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftDispatch.pdb" Guid="cff0a63a-a76a-4785-92b0-4894ffa19a7d">
-        <File Id="swiftDispatch.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <!--
-      <Component Id="swiftDemangle.pdb" Guid="0dd0b3b5-3d85-48aa-a7c7-ca804c685a99">
-        <File Id="swiftDemangle.pdb" Source="$(var.SDK_ROOT)\bin\swiftDemangle.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      -->
-      <Component Id="swiftCRT.pdb" Guid="0f4fbbfa-e85e-4c18-93a0-37ab09b80bf7">
-        <File Id="swiftCRT.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftCRT.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftRemoteMirror.pdb" Guid="2bcc963d-e2d7-44f1-a7aa-0524bec668c6">
-        <File Id="swiftRemoteMirror.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftRemoteMirror.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftSwiftOnoneSupport.pdb" Guid="a013f1d6-3e2a-4e0a-b315-e40b87967d1b">
-        <File Id="swiftSwiftOnoneSupport.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftSwiftOnoneSupport.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="swiftWinSDK.pdb" Guid="c8924901-6ed0-4629-a940-0eeaeeb5039e">
-        <File Id="swiftWinSDK.pdb" Source="$(var.SDK_ROOT)\usr\bin\swiftWinSDK.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="SwiftUtilitiesDebugInfo">
-      <Component Id="plutil.pdb" Guid="76275d27-3e4f-40f5-9810-a4fbe1d16e5e">
-        <File Id="plutil.pdb" Source="$(var.SDK_ROOT)\usr\bin\plutil.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="3b4386ac-3341-407d-b946-6e670f4a83f6">
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]runtime-development\usr\bin" />
     </Component>
@@ -167,24 +97,10 @@
     <Feature Id="Win32SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows i686" Level="1" Title="Swift Runtime for Windows i686">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Runtime for Windows i686" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftRuntimeDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <Feature Id="Win32SwiftUtilities" AllowAbsent="yes" AllowAdvertise="yes" Description="Extra Swift Utilities for Windows i686" Level="1" Title="Swift Utilities for Windows i686">
       <ComponentGroupRef Id="SwiftUtilities" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift Utilties for Windows x86_64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftUtilitiesDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/runtime.wixproj
+++ b/platforms/Windows/runtime.wixproj
@@ -19,7 +19,7 @@
   <Import Project="WiXCodeSigning.targets" />
 
   <PropertyGroup>
-    <DefineConstants>ProductVersion=$(ProductVersion);SDK_ROOT=$(SDK_ROOT);$(INCLUDE_DEBUG_INFO)</DefineConstants>
+    <DefineConstants>ProductVersion=$(ProductVersion);SDK_ROOT=$(SDK_ROOT)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -9,9 +9,6 @@
     <SummaryInformation Description="Swift SDK for Windows x86_64" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
@@ -131,14 +128,6 @@
         <File Id="XCTest.swiftmodule" Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64\XCTest.swiftmodule" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="XCTestDebugInfo">
-      <Component Id="XCTest.pdb" Directory="XCTest_usr_bin64" Guid="6ad780c3-7245-4b63-b0b0-ba04e65f1638">
-        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftRemoteMirror">
       <Component Id="MemoryReaderInterface.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="4493ba7f-b3b3-4cb3-b645-6457e81ad752">
@@ -522,13 +511,6 @@
       <ComponentGroupRef Id="Configuration" />
 
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows x86_64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentRef Id="XCTestRuntimeDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -9,9 +9,6 @@
     <SummaryInformation Description="Swift SDK for Windows aarch64" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
@@ -131,14 +128,6 @@
         <File Id="XCTest.swiftmodule" Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\aarch64\XCTest.swiftmodule" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="XCTestDebugInfo">
-      <Component Id="XCTest.pdb" Directory="XCTest_usr_bin64a" Guid="92e52a04-6193-4a0f-bd4d-8ae3c30a2901">
-        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftRemoteMirror">
       <Component Id="MemoryReaderInterface.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="4493ba7f-b3b3-4cb3-b645-6457e81ad752">
@@ -522,13 +511,6 @@
       <ComponentGroupRef Id="Configuration" />
 
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows aarch64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentRef Id="XCTestRuntimeDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -9,9 +9,6 @@
     <SummaryInformation Description="Swift SDK for Windows i686" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
@@ -129,14 +126,6 @@
         <File Id="XCTest.swiftmodule" Name="i686-unknown-windows-msvc.swiftmodule" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\windows\i686\XCTest.swiftmodule" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="XCTestDebugInfo">
-      <Component Id="XCTest.pdb" Directory="XCTest_usr_bin32" Guid="f9f54891-8fe4-444b-b7a1-dc4787e069ee">
-        <File Id="XCTest.pdb" Source="$(var.PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\bin\XCTest.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftRemoteMirror">
       <Component Id="MemoryReaderInterface.h" Directory="WindowsSDK_usr_include_swift_SwiftRemoteMirror" Guid="4493ba7f-b3b3-4cb3-b645-6457e81ad752">
@@ -514,13 +503,6 @@
       <ComponentGroupRef Id="Registrar" />
       <ComponentGroupRef Id="AuxiliaryFiles" />
       <ComponentGroupRef Id="Configuration" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Information for Swift SDK for Windows i686" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentRef Id="XCTestRuntimeDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/swift-format-amd64.wxs
+++ b/platforms/Windows/swift-format-amd64.wxs
@@ -10,9 +10,6 @@
 
     <!-- NOTE(compnerd) use pre-3.0 schema for better compatibility. -->
     <Media Id="1" Cabinet="SwiftFormat.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
@@ -35,14 +32,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftFormatDebugInfo">
-      <Component Id="swift_format.pdb" Directory="Tools" Guid="c0cd09c3-09be-48af-8321-63fee64cc2c3">
-        <File Id="swift_format.pdb" Source="$(var.SWIFT_FORMAT_BUILD)\swift-format.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="645cdd3d-9dde-4e6d-8071-c0349ae87bcf">
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Tools" />
     </Component>
@@ -50,13 +39,6 @@
     <Feature Id="SwiftFormat" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Code Formatter for Windows x86_64" Level="1" Title="Swift Code Formatter (Windows x86_64)">
       <ComponentGroupRef Id="SwiftFormat" />
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" Description="Debug Information for Swift Code Formatter for Windows x86_64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftFormatDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/swift-format-arm64.wxs
+++ b/platforms/Windows/swift-format-arm64.wxs
@@ -10,9 +10,6 @@
 
     <!-- NOTE(compnerd) use pre-3.0 schema for better compatibility. -->
     <Media Id="1" Cabinet="SwiftFormat.cab" EmbedCab="yes" />
-    <?ifdef INCLUDE_DEBUG_INFO?>
-    <Media Id="2" Cabinet="PDBs.cab" EmbedCab="yes" />
-    <?endif?>
 
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
@@ -35,14 +32,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftFormatDebugInfo">
-      <Component Id="swift_format.pdb" Directory="Tools" Guid="24079895-af2f-4a67-95f3-a262d4e88390">
-        <File Id="swift_format.pdb" Source="$(var.SWIFT_FORMAT_BUILD)\swift-format.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="c1a01e55-3353-4eca-8b58-9960e57a3758">
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Tools" />
     </Component>
@@ -50,13 +39,6 @@
     <Feature Id="SwiftFormat" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Code Formatter for Windows aarch64" Level="1" Title="Swift Code Formatter (Windows aarch64)">
       <ComponentGroupRef Id="SwiftFormat" />
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" Description="Debug Information for Swift Code Formatter for Windows aarch64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="SwiftFormatDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/toolchain-amd64.wxs
+++ b/platforms/Windows/toolchain-amd64.wxs
@@ -18,21 +18,6 @@
     -->
     <Media Id="1" Cabinet="toolchain.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.llvm.cab" />
-    <Media Id="3" Cabinet="PDBs.clang.cab" />
-    <Media Id="4" Cabinet="PDBs.lld.cab" />
-    <Media Id="5" Cabinet="PDBs.lldb.cab" />
-    <Media Id="6" Cabinet="PDBs.BlocksRuntime.cab" />
-    <Media Id="7" Cabinet="PDBs.dispatch.cab" />
-    <Media Id="8" Cabinet="PDBs.SourceKit.cab" />
-    <Media Id="9" Cabinet="PDBs.swift.cab" />
-    <Media Id="10" Cabinet="PDBs.llbuild.cab" />
-    <Media Id="11" Cabinet="PDBs.ArgumentParser.cab" />
-    <Media Id="12" Cabinet="PDBs.ToolsSupportCore.cab" />
-    <Media Id="13" Cabinet="PDBs.swift-driver.cab" />
-    <?endif?>
-
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
@@ -203,75 +188,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="binutilsDebugInfo">
-      <Component Id="dsymutil.pdb" Directory="_usr_bin" Guid="678d56e2-6121-4c97-9bdc-7539baa4857b">
-        <File Id="dsymutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_ar.pdb" Directory="_usr_bin" Guid="68cf625a-8147-45d4-bfdf-26e07406d991">
-        <File Id="llvm_ar.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_cov.pdb" Directory="_usr_bin" Guid="f9788dbf-989b-4e91-86a8-00a38010eb79">
-        <File Id="llvm_cov.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_cvtres.pdb" Directory="_usr_bin" Guid="ecb48149-fb22-44c4-8da3-bff3b9c4f8ba">
-        <File Id="llvm_cvtres.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_cxxfilt.pdb" Directory="_usr_bin" Guid="4e7fb27f-3f91-4ae5-9c1f-c9da06e2e547">
-        <File Id="llvm_cxxfilt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_dwarfdump.pdb" Directory="_usr_bin" Guid="80aec81b-98ff-4768-82be-18916708e1fb">
-        <File Id="llvm_dwarfdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_dwp.pdb" Directory="_usr_bin" Guid="b61c1a91-b812-47ad-94a3-0adb8d417124">
-        <File Id="llvm_dwp.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_lipo.pdb" Directory="_usr_bin" Guid="915083a3-6c96-4f6b-ae93-2f8ef32d0f31">
-        <File Id="llvm_lipo.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_mt.pdb" Directory="_usr_bin" Guid="b1ff8ac6-231d-497b-8c66-502ddf9d7d4a">
-        <File Id="llvm_mt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_nm.pdb" Directory="_usr_bin" Guid="37b43872-0261-4eda-b104-e3093f8ccd8a">
-        <File Id="llvm_nm.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_objcopy.pdb" Directory="_usr_bin" Guid="17fb9703-06f9-43fe-a719-b05a319962ea">
-        <File Id="llvm_objcopy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_objdump.pdb" Directory="_usr_bin" Guid="6b951a96-ec63-4b43-8a13-7a24d438c1ab">
-        <File Id="llvm_objdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_pdbutil.pdb" Directory="_usr_bin" Guid="5a490f07-d4df-461d-b6ca-aed6c51757f0">
-        <File Id="llvm_pdbutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_profdata.pdb" Directory="_usr_bin" Guid="728aca25-78ca-428b-b393-d6dda0d73340">
-        <File Id="llvm_profdata.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_rc.pdb" Directory="_usr_bin" Guid="fe91ef90-4ed4-4c12-aa94-e8507d345ec1">
-        <File Id="llvm_rc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_readobj.pdb" Directory="_usr_bin" Guid="0dcda88c-339c-4d38-8784-72ba0acb9fc4">
-        <File Id="llvm_readobj.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_size.pdb" Directory="_usr_bin" Guid="8d55885c-17d4-4d67-86f5-3e4fe2f8133f">
-        <File Id="llvm_size.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_strings.pdb" Directory="_usr_bin" Guid="06c5757b-53fc-4ed3-ab85-a7063dfbfe81">
-        <File Id="llvm_strings.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_symbolizer.pdb" Directory="_usr_bin" Guid="15254998-b680-4eee-92fb-9abe0cce6199">
-        <File Id="llvm_symbolizer.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_undname.pdb" Directory="_usr_bin" Guid="0a8b17c5-c24e-4a0f-8654-72c88deb28a1">
-        <File Id="llvm_undname.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-
-      <Component Id="LTO.pdb" Directory="_usr_bin" Guid="dd03c59f-7f18-4d35-94cf-9887c4d39243">
-        <File Id="LTO.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="clang">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
       <Component Id="clang_cl.exe" Directory="_usr_bin" Guid="f7c9cc75-059b-426e-af7f-abd54474a71d">
@@ -350,30 +266,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="clangDebugInfo">
-      <Component Id="clang_format.pdb" Directory="_usr_bin" Guid="6b56108f-8c47-4cd8-926f-007b46390438">
-        <File Id="clang_format.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-      <Component Id="clang_format.pdb" Directory="_usr_bin" Guid="6b98925e-e6e2-4c90-9ef2-e3dc3d0b2d8a">
-        <File Id="clang_tidy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-      <Component Id="clang.pdb" Directory="_usr_bin" Guid="1259c5a6-7418-4cd7-aab1-e6912c37b1e3">
-        <File Id="clang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-      <Component Id="clangd.pdb" Source="_usr_bin" Guid="9afe1bc9-a814-45e2-ba6a-505f4f18592a">
-        <File Id="clangd.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clangd.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-
-      <Component Id="libclang.pdb" Directory="_usr_bin" Guid="d2d21dac-e7cb-494f-96be-c271af6cd02b">
-        <File Id="libclang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-      <Component Id="libIndexStore.pdb" Directory="_usr_bin" Guid="2f709fd4-d6d6-4878-acdc-a2f7218d8888">
-        <File Id="libIndexStore.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="lld">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
       <Component Id="ld.lld.exe" Directory="_usr_bin" Guid="95cf3aaa-c2dd-4550-be0d-263e53c9f9f7">
@@ -393,14 +285,6 @@
         <File Id="lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.exe" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="lldDebugInfo">
-      <Component Id="lld.pdb" Directory="_usr_bin" Guid="595a700f-b994-418d-8d14-b164e75abbdd">
-        <File Id="lld.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.pdb" Checksum="yes" DiskId="4" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="lldb">
       <Component Id="lldb_server.exe" Directory="_usr_bin" Guid="ba62d5bb-5091-4d92-aa94-fed5357ec01e">
@@ -477,24 +361,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="lldbDebugInfo">
-      <Component Id="lldb_server.pdb" Directory="_usr_bin" Guid="e814828d-0b71-4e51-bf57-6227642787a2">
-        <File Id="lldb_server.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.pdb" Checksum="yes" DiskId="5" />
-      </Component>
-      <Component Id="lldb_vscode.pdb" Directory="_usr_bin" Guid="e960363f-5f04-4584-b69b-8c42d35f9b34">
-        <File Id="lldb_vscode.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.pdb" Checksum="yes" DiskId="5" />
-      </Component>
-      <Component Id="lldb.pdb" Directory="_usr_bin" Guid="b64e3b50-55b7-472c-bf87-961b46757f94">
-        <File Id="lldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.pdb" Checksum="yes" DiskId="5" />
-      </Component>
-
-      <Component Id="liblldb.pdb" Directory="_usr_bin" Guid="b096068d-1b6d-4a53-a544-d718ac4b289a">
-        <File Id="liblldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.pdb" Checksum="yes" DiskId="5" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="BlocksRuntime">
       <Component Id="BlocksRuntime.dll" Directory="_usr_bin" Guid="e170a9fa-d4e3-4b1a-9308-1bb9383fe771">
         <File Id="BlocksRuntime.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
@@ -507,14 +373,6 @@
       <!-- TODO(compnerd) should we install the block headers? -->
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="BlocksRuntimeDebugInfo">
-      <Component Id="BlocksRuntime.pdb" Directory="_usr_bin" Guid="6cb091fb-0aae-40d8-9e83-fb79bce9e592">
-        <File Id="BlocksRuntime.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="dispatch">
       <Component Id="dispatch.dll" Directory="_usr_bin" Guid="27c600e2-40be-44a5-9089-76d9e6021b51">
         <File Id="dispatch.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
@@ -526,14 +384,6 @@
 
       <!-- TODO(compnerd) should we install the dispatch headers? -->
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="dispatchDebugInfo">
-      <Component Id="dispatch.pdb" Directory="_usr_bin" Guid="64524656-4b87-42f9-9e5b-50ed8c4e0315">
-        <File Id="dispatch.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="7" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SourceKit">
       <Component Id="sourcekitdInProc.dll" Directory="_usr_bin" Guid="6d8cfa8d-a4eb-40b3-af29-afb80997494a">
@@ -548,14 +398,6 @@
         <File Id="sourcekitd.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\SourceKit\sourcekitd.h" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SourceKitDebugInfo">
-      <Component Id="sourcekitdInProc.pdb" Directory="_usr_bin" Guid="36e02ecc-48ce-4401-9e6d-4d8a54da8cdb">
-        <File Id="sourcekitdInProc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.pdb" Checksum="yes" DiskId="8" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="swift">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
@@ -636,24 +478,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="swiftDebugInfo">
-      <Component Id="swift_demangle.pdb" Directory="_usr_bin" Guid="30250a78-68ca-414b-8717-135b4c87ee83">
-        <File Id="swift_demangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.pdb" Checksum="yes" DiskId="9" />
-      </Component>
-      <Component Id="swift_frontend.pdb" Directory="_usr_bin" Guid="b01ae108-aa02-45a4-b751-497934842385">
-        <File Id="swift_frontend.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.pdb" Checksum="yes" DiskId="9" />
-      </Component>
-
-      <Component Id="swiftDemangle.pdb" Directory="_usr_bin" Guid="ab2ef973-8ae1-4b2b-87db-62a81f2da8d7">
-        <File Id="swiftDemangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="9" />
-      </Component>
-      <Component Id="_InternalSwiftScan.pdb" Directory="_usr_bin" Guid="2321b5d4-fa60-495e-b275-3f0713c35278">
-        <File Id="_InternalSwiftScan.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.pdb" Checksum="yes" DiskId="9" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="llbuild">
       <Component Id="swift_build_tool.exe" Directory="_usr_bin" Guid="f7f3b232-a07f-4bc2-9cf5-323060b9fd91">
         <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
@@ -664,31 +488,11 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="llbuildDebugInfo">
-      <Component Id="swift_build_tool.pdb" Directory="_usr_bin" Guid="731d2652-2a1f-45ad-904d-b51c9ae8d46a">
-        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" DiskId="10" />
-      </Component>
-
-      <Component Id="llbuildSwift.pdb" Directory="_usr_bin" Guid="7a0a4f52-344f-41cc-bd9a-266af3afbc84">
-        <File Id="llbuildSwift.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" DiskId="10" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SwiftArgumentParser">
       <Component Id="ArgumentParser.dll" Directory="_usr_bin" Guid="f8dc1ec7-d2bc-418c-8d70-310722b1a09c">
         <File Id="ArgumentParser.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftArgumentParserDebugInfo">
-      <Component Id="ArgumentParser.pdb" Directory="_usr_bin" Guid="6901fb07-e566-43b8-b5f4-3438debc623e">
-        <File Id="ArgumentParser.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" DiskId="11" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftToolsSupportCore">
       <Component Id="TSCBasic.dll" Directory="_usr_bin" Guid="62c1421e-781b-4ffb-b11d-9d4f2a5bafa5">
@@ -698,17 +502,6 @@
         <File Id="TSCUtility.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftToolsSupportCoreDebugInfo">
-      <Component Id="TSCBasic.pdb" Directory="_usr_bin" Guid="002d49f9-4322-4513-9a2f-36842423b676">
-        <File Id="TSCBasic.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" DiskId="12" />
-      </Component>
-      <Component Id="TSCUtility.pdb" Directory="_usr_bin" Guid="62e56d7b-d2fa-4950-a876-2f7f23a6726a">
-        <File Id="TSCUtility.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" DiskId="12" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftDriver">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
@@ -737,30 +530,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftDriverDebugInfo">
-      <Component Id="swift.pdb" Directory="_usr_bin" Guid="b14f75f3-cd32-469b-b442-b2f62090cec3">
-        <File Id="swift.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-      <Component Id="swift_help.pdb" Directory="_usr_bin" Guid="02a7aa71-d30b-4fe7-9518-aa7ab9533652">
-        <File Id="swift_help.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-help.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-      <Component Id="swift_build_sdk_interfaces.pdb" Directory="_usr_bin" Guid="e9cdfc86-ae01-4967-a17d-c55ee1486f15">
-        <File Id="swift_build_sdk_interfaces.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-build-sdk-interfaces.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-
-      <Component Id="SwiftOptions.pdb" Directory="_usr_bin" Guid="86ba07e2-3271-4c17-9465-e4515ff7669b">
-        <File Id="SwiftOptions.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-      <Component Id="SwiftDriver.pdb" Directory="_usr_bin" Guid="61588fa0-87c2-4d16-8995-12090e9e8924">
-        <File Id="SwiftDriver.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-      <Component Id="SwiftDriverExecution.pdb" Directory="_usr_bin" Guid="1d28c854-ebc9-49ac-a62b-b44f37d1a617">
-        <File Id="SwiftDriverExecution.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
       <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer" />
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
@@ -786,24 +555,6 @@
       -->
 
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows x86_64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="binutilsDebugInfo" />
-        <ComponentGroupRef Id="clangDebugInfo" />
-        <ComponentGroupRef Id="lldDebugInfo" />
-        <ComponentGroupRef Id="lldbDebugInfo" />
-        <ComponentGroupRef Id="BlocksRuntimeDebugInfo" />
-        <ComponentGroupRef Id="dispatchDebugInfo" />
-        <ComponentGroupRef Id="SourceKitDebugInfo" />
-        <ComponentGroupRef Id="swiftDebugInfo" />
-        <ComponentGroupRef Id="llbuildDebugInfo" />
-        <ComponentGroupRef Id="SwiftArgumentParserDebugInfo" />
-        <ComponentGroupRef Id="SwiftToolsSupportCoreDebugInfo" />
-        <ComponentGroupRef Id="SwiftDriverDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/toolchain-arm64.wxs
+++ b/platforms/Windows/toolchain-arm64.wxs
@@ -18,21 +18,6 @@
     -->
     <Media Id="1" Cabinet="toolchain.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <Media Id="2" Cabinet="PDBs.llvm.cab" />
-    <Media Id="3" Cabinet="PDBs.clang.cab" />
-    <Media Id="4" Cabinet="PDBs.lld.cab" />
-    <Media Id="5" Cabinet="PDBs.lldb.cab" />
-    <Media Id="6" Cabinet="PDBs.BlocksRuntime.cab" />
-    <Media Id="7" Cabinet="PDBs.dispatch.cab" />
-    <Media Id="8" Cabinet="PDBs.SourceKit.cab" />
-    <Media Id="9" Cabinet="PDBs.swift.cab" />
-    <Media Id="10" Cabinet="PDBs.llbuild.cab" />
-    <Media Id="11" Cabinet="PDBs.ArgumentParser.cab" />
-    <Media Id="12" Cabinet="PDBs.ToolsSupportCore.cab" />
-    <Media Id="13" Cabinet="PDBs.swift-driver.cab" />
-    <?endif?>
-
     <!-- Directory Structure -->
     <!-- WindowsVolume is not a StandardDirectory value, but rather a standard property. See https://github.com/wixtoolset/issues/issues/7314 -->
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
@@ -203,75 +188,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="binutilsDebugInfo">
-      <Component Id="dsymutil.pdb" Directory="_usr_bin" Guid="73c8822d-5711-4ac9-8c24-1d6d299a56b6">
-        <File Id="dsymutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dsymutil.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_ar.pdb" Directory="_usr_bin" Guid="84e78011-23e8-4c9f-89ef-5257a3407966">
-        <File Id="llvm_ar.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-ar.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_cov.pdb" Directory="_usr_bin" Guid="04bf4eec-d707-49ad-90ce-1d7c2e057cb6">
-        <File Id="llvm_cov.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cov.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_cvtres.pdb" Directory="_usr_bin" Guid="b40f1683-fd0d-4e91-8f09-41719acc1694">
-        <File Id="llvm_cvtres.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cvtres.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_cxxfilt.pdb" Directory="_usr_bin" Guid="e2f84ed3-25fd-4337-99c6-4dec94d18fa0">
-        <File Id="llvm_cxxfilt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-cxxfilt.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_dwarfdump.pdb" Directory="_usr_bin" Guid="3d33ee41-0766-4644-a7b2-23eb37ec69db">
-        <File Id="llvm_dwarfdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwarfdump.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_dwp.pdb" Directory="_usr_bin" Guid="141a8180-b655-4fcc-a9f5-b6df56007de9">
-        <File Id="llvm_dwp.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-dwp.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_lipo.pdb" Directory="_usr_bin" Guid="2bbe87ef-2598-4099-a64b-22b3fab16e45">
-        <File Id="llvm_lipo.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_mt.pdb" Directory="_usr_bin" Guid="d8df5263-37e0-45dd-be1b-1d58f6b26e1b">
-        <File Id="llvm_mt.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-mt.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_nm.pdb" Directory="_usr_bin" Guid="2a5ee43c-1c54-4a06-90c1-a408b04af75c">
-        <File Id="llvm_nm.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-nm.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_objcopy.pdb" Directory="_usr_bin" Guid="cc50faea-b1ef-4169-a767-c2b58657df72">
-        <File Id="llvm_objcopy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objcopy.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_objdump.pdb" Directory="_usr_bin" Guid="ad547b72-b03d-4341-8ab9-c521913ab492">
-        <File Id="llvm_objdump.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-objdump.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_pdbutil.pdb" Directory="_usr_bin" Guid="5ec1cd38-13cb-4f0d-a87a-e4df5178e404">
-        <File Id="llvm_pdbutil.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-pdbutil.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_profdata.pdb" Directory="_usr_bin" Guid="e1506848-6ba7-49d3-9aff-698b89d99e3f">
-        <File Id="llvm_profdata.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-profdata.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_rc.pdb" Directory="_usr_bin" Guid="a3d95f6f-e763-4f38-a244-2a214f1d84f4">
-        <File Id="llvm_rc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-rc.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_readobj.pdb" Directory="_usr_bin" Guid="a9ab57da-f803-46c3-a07e-014cc6916ba6">
-        <File Id="llvm_readobj.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-readobj.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_size.pdb" Directory="_usr_bin" Guid="96494ade-83cf-49b9-abc0-f7b9d4ceddb4">
-        <File Id="llvm_size.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-size.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_strings.pdb" Directory="_usr_bin" Guid="853cf1ae-186f-49df-a7a9-0bd95be5d03f">
-        <File Id="llvm_strings.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-strings.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_symbolizer.pdb" Directory="_usr_bin" Guid="74cdda53-a1be-4a7d-8730-0afbe598bfa9">
-        <File Id="llvm_symbolizer.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-symbolizer.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-      <Component Id="llvm_undname.pdb" Directory="_usr_bin" Guid="75d9ec7c-9f49-46cb-b593-5e9e0dc16485">
-        <File Id="llvm_undname.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\llvm-undname.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-
-      <Component Id="LTO.pdb" Directory="_usr_bin" Guid="1f0e8bee-2049-4b77-a43b-8255f7371f0d">
-        <File Id="LTO.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\LTO.pdb" Checksum="yes" DiskId="2" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="clang">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
       <Component Id="clang_cl.exe" Directory="_usr_bin" Guid="6ad2751d-f1e6-47c2-82c7-4bd3c7c51e7b">
@@ -350,30 +266,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="clangDebugInfo">
-      <Component Id="clang_format.pdb" Directory="_usr_bin" Guid="432d6998-0f0b-44ce-97a2-221e1e82e19f">
-        <File Id="clang_format.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-format.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-      <Component Id="clang_format.pdb" Directory="_usr_bin" Guid="b2dc1258-d664-4850-9c97-6eff66813c84">
-        <File Id="clang_tidy.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang-tidy.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-      <Component Id="clang.pdb" Directory="_usr_bin" Guid="737d7fd3-c932-494b-bfa6-0e3ac9b2820c">
-        <File Id="clang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clang.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-      <Component Id="clangd.pdb" Source="_usr_bin" Guid="9afe1bc9-a814-45e2-ba6a-505f4f18592a">
-        <File Id="clangd.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\clangd.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-
-      <Component Id="libclang.pdb" Directory="_usr_bin" Guid="db1b1f54-5646-4e5a-98d2-ef524703bab3">
-        <File Id="libclang.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libclang.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-      <Component Id="libIndexStore.pdb" Directory="_usr_bin" Guid="0129ab89-71b6-4c52-afdd-c58fbe8792b2">
-        <File Id="libIndexStore.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\libIndexStore.pdb" Checksum="yes" DiskId="3" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="lld">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
       <Component Id="ld.lld.exe" Directory="_usr_bin" Guid="82fcce13-68e0-4048-a935-846111d9bbb2">
@@ -393,14 +285,6 @@
         <File Id="lld.exe" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.exe" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="lldDebugInfo">
-      <Component Id="lld.pdb" Directory="_usr_bin" Guid="e4709585-751e-4708-945c-7c1e4e415d16">
-        <File Id="lld.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lld.pdb" Checksum="yes" DiskId="4" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="lldb">
       <Component Id="lldb_server.exe" Directory="_usr_bin" Guid="d9dbdd0f-9f0b-4aa6-84d0-75d96f4a71e7">
@@ -477,24 +361,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="lldbDebugInfo">
-      <Component Id="lldb_server.pdb" Directory="_usr_bin" Guid="6c5964a1-978c-4c07-b36b-95ace75fba56">
-        <File Id="lldb_server.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-server.pdb" Checksum="yes" DiskId="5" />
-      </Component>
-      <Component Id="lldb_vscode.pdb" Directory="_usr_bin" Guid="4cf41f68-7dfc-4b69-97c5-2c1591b80b40">
-        <File Id="lldb_vscode.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb-vscode.pdb" Checksum="yes" DiskId="5" />
-      </Component>
-      <Component Id="lldb.pdb" Directory="_usr_bin" Guid="346dd53d-96b3-40c9-b1c9-d3bcbfb1fe9c">
-        <File Id="lldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\lldb.pdb" Checksum="yes" DiskId="5" />
-      </Component>
-
-      <Component Id="liblldb.pdb" Directory="_usr_bin" Guid="07a46aa1-620c-43d2-b762-c16b5e0219f3">
-        <File Id="liblldb.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\liblldb.pdb" Checksum="yes" DiskId="5" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="BlocksRuntime">
       <Component Id="BlocksRuntime.dll" Directory="_usr_bin" Guid="a5f1af33-9980-4b5d-a503-7b9aa6b28fae">
         <File Id="BlocksRuntime.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
@@ -507,14 +373,6 @@
       <!-- TODO(compnerd) should we install the block headers? -->
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="BlocksRuntimeDebugInfo">
-      <Component Id="BlocksRuntime.pdb" Directory="_usr_bin" Guid="431178b6-2f8a-4484-a012-9f8108613aa7">
-        <File Id="BlocksRuntime.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="dispatch">
       <Component Id="dispatch.dll" Directory="_usr_bin" Guid="3ff2a2ed-6e2d-4065-8de5-aff556f9081c">
         <File Id="dispatch.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
@@ -526,14 +384,6 @@
 
       <!-- TODO(compnerd) should we install the dispatch headers? -->
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="dispatchDebugInfo">
-      <Component Id="dispatch.pdb" Directory="_usr_bin" Guid="1030bebe-2b44-4c47-98f4-0a9bdd9b5963">
-        <File Id="dispatch.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.pdb" Checksum="yes" DiskId="7" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SourceKit">
       <Component Id="sourcekitdInProc.dll" Directory="_usr_bin" Guid="56274f9b-be12-4140-a20b-2e2ae2ce0109">
@@ -548,14 +398,6 @@
         <File Id="sourcekitd.h" Source="$(var.TOOLCHAIN_ROOT)\usr\include\SourceKit\sourcekitd.h" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SourceKitDebugInfo">
-      <Component Id="sourcekitdInProc.pdb" Directory="_usr_bin" Guid="d21c977f-c567-4d5b-a53d-15bc841fd1d0">
-        <File Id="sourcekitdInProc.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\sourcekitdInProc.pdb" Checksum="yes" DiskId="8" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="swift">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
@@ -636,24 +478,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="swiftDebugInfo">
-      <Component Id="swift_demangle.pdb" Directory="_usr_bin" Guid="5ab65ead-31b4-4f87-b80a-c77f01375a0a">
-        <File Id="swift_demangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-demangle.pdb" Checksum="yes" DiskId="9" />
-      </Component>
-      <Component Id="swift_frontend.pdb" Directory="_usr_bin" Guid="103fc70f-d6fa-4325-b13d-8b5678202431">
-        <File Id="swift_frontend.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-frontend.pdb" Checksum="yes" DiskId="9" />
-      </Component>
-
-      <Component Id="swiftDemangle.pdb" Directory="_usr_bin" Guid="9234f831-2587-42f9-b257-7af1f9251816">
-        <File Id="swiftDemangle.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="9" />
-      </Component>
-      <Component Id="_InternalSwiftScan.pdb" Directory="_usr_bin" Guid="79269c96-4952-4028-b764-8cfbac6c2062">
-        <File Id="_InternalSwiftScan.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftScan.pdb" Checksum="yes" DiskId="9" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="llbuild">
       <Component Id="swift_build_tool.exe" Directory="_usr_bin" Guid="b5a61b2e-f18e-444c-8eac-e0401dac965f">
         <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.exe" Checksum="yes" />
@@ -664,31 +488,11 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="llbuildDebugInfo">
-      <Component Id="swift_build_tool.pdb" Directory="_usr_bin" Guid="93a981d1-a4c4-4949-aee4-762a052212eb">
-        <File Id="swift_build_tool.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build-tool.pdb" Checksum="yes" DiskId="10" />
-      </Component>
-
-      <Component Id="llbuildSwift.pdb" Directory="_usr_bin" Guid="07c8df77-4dd8-4081-90ba-28ebd2b4e560">
-        <File Id="llbuildSwift.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\llbuildSwift.pdb" Checksum="yes" DiskId="10" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SwiftArgumentParser">
       <Component Id="ArgumentParser.dll" Directory="_usr_bin" Guid="1c179884-b2b1-46c8-b359-ef4271001f44">
         <File Id="ArgumentParser.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftArgumentParserDebugInfo">
-      <Component Id="ArgumentParser.pdb" Directory="_usr_bin" Guid="4bd6bcaf-85be-4d3e-b952-4efee6a95f27">
-        <File Id="ArgumentParser.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\ArgumentParser.pdb" Checksum="yes" DiskId="11" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftToolsSupportCore">
       <Component Id="TSCBasic.dll" Directory="_usr_bin" Guid="62671622-472e-421d-80ea-39fcb8bf42d4">
@@ -698,17 +502,6 @@
         <File Id="TSCUtility.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" Checksum="yes" />
       </Component>
     </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftToolsSupportCoreDebugInfo">
-      <Component Id="TSCBasic.pdb" Directory="_usr_bin" Guid="c4cfe6d9-232c-47be-88f3-a84045d20b82">
-        <File Id="TSCBasic.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCBasic.pdb" Checksum="yes" DiskId="12" />
-      </Component>
-      <Component Id="TSCUtility.pdb" Directory="_usr_bin" Guid="c316113b-5459-4d27-b006-122e82687cf7">
-        <File Id="TSCUtility.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" DiskId="12" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
 
     <ComponentGroup Id="SwiftDriver">
       <!-- TODO(compnerd) can we use symbolic links instead? -->
@@ -737,30 +530,6 @@
       </Component>
     </ComponentGroup>
 
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftDriverDebugInfo">
-      <Component Id="swift.pdb" Directory="_usr_bin" Guid="1a279dbb-24d1-4025-82c9-b386e5434ae2">
-        <File Id="swift.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-      <Component Id="swift_help.pdb" Directory="_usr_bin" Guid="7e7ea69a-101f-47e3-a74d-b38d00639ad6">
-        <File Id="swift_help.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-help.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-      <Component Id="swift_build_sdk_interfaces.pdb" Directory="_usr_bin" Guid="ea1bcfbf-77a1-4b11-ab94-0981d2bbd2da">
-        <File Id="swift_build_sdk_interfaces.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-build-sdk-interfaces.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-
-      <Component Id="SwiftOptions.pdb" Directory="_usr_bin" Guid="57fbbc35-f028-483b-b976-de0f9c3fe1ad">
-        <File Id="SwiftOptions.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-      <Component Id="SwiftDriver.pdb" Directory="_usr_bin" Guid="f64ba7f7-dd9d-4009-b9ea-54cb4302f058">
-        <File Id="SwiftDriver.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-      <Component Id="SwiftDriverExecution.pdb" Directory="_usr_bin" Guid="477c115e-84cb-4452-8d6c-514ff7851952">
-        <File Id="SwiftDriverExecution.pdb" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.pdb" Checksum="yes" DiskId="14" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <Component Id="EnvironmentVariables" Directory="INSTALLDIR" Guid="d01ea5b8-0f8a-4388-9b61-1186efddfc39">
       <Environment Id="DeveloperDir" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer" />
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
@@ -786,24 +555,6 @@
       -->
 
       <ComponentRef Id="EnvironmentVariables" />
-
-      <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Feature Id="DebugInfo" AllowAbsent="yes" AllowAdvertise="yes" Description="Debug Infomation for Swift Toolchain for Windows aarch64" Level="0" Title="Debug Information">
-        <Level Value="1" Condition="INSTALL_DEBUGINFO" />
-        <ComponentGroupRef Id="binutilsDebugInfo" />
-        <ComponentGroupRef Id="clangDebugInfo" />
-        <ComponentGroupRef Id="lldDebugInfo" />
-        <ComponentGroupRef Id="lldbDebugInfo" />
-        <ComponentGroupRef Id="BlocksRuntimeDebugInfo" />
-        <ComponentGroupRef Id="dispatchDebugInfo" />
-        <ComponentGroupRef Id="SourceKitDebugInfo" />
-        <ComponentGroupRef Id="swiftDebugInfo" />
-        <ComponentGroupRef Id="llbuildDebugInfo" />
-        <ComponentGroupRef Id="SwiftArgumentParserDebugInfo" />
-        <ComponentGroupRef Id="SwiftToolsSupportCoreDebugInfo" />
-        <ComponentGroupRef Id="SwiftDriverDebugInfo" />
-      </Feature>
-      <?endif?>
     </Feature>
 
     <UI>

--- a/platforms/Windows/toolchain.wixproj
+++ b/platforms/Windows/toolchain.wixproj
@@ -19,7 +19,7 @@
   <Import Project="WiXCodeSigning.targets" />
 
   <PropertyGroup>
-    <DefineConstants>ProductVersion=$(ProductVersion);DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;$(INCLUDE_DEBUG_INFO)</DefineConstants>
+    <DefineConstants>ProductVersion=$(ProductVersion);DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
     <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>


### PR DESCRIPTION
The preference for distribution of the debug information should be a symbol server which would permit the matching of the binary to the proper symbols for the particular build.  This is important as the total debug information is ~10x larger than the distribution itself and would add a very large overhead to the download sizes.