### PR TITLE
Migrate Windows installer to Wix v4.0.0 release

### DIFF
--- a/platforms/Windows/devtools.wixproj
+++ b/platforms/Windows/devtools.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
+<Project Sdk="WixToolset.Sdk/4.0.0">
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/platforms/Windows/installer.wixproj
+++ b/platforms/Windows/installer.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
+<Project Sdk="WixToolset.Sdk/4.0.0">
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <OutputType>Bundle</OutputType>
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.Bal.wixext" Version="4.0.0-rc.4" />
+    <PackageReference Include="WixToolset.Bal.wixext" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/runtime.wixproj
+++ b/platforms/Windows/runtime.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
+<Project Sdk="WixToolset.Sdk/4.0.0">
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/sdk.wixproj
+++ b/platforms/Windows/sdk.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
+<Project Sdk="WixToolset.Sdk/4.0.0">
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -30,8 +30,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
-    <PackageReference Include="WixToolset.Heat" Version="4.0.0-rc.4" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0" />
+    <PackageReference Include="WixToolset.Heat" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/swift-format.wixproj
+++ b/platforms/Windows/swift-format.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
+<Project Sdk="WixToolset.Sdk/4.0.0">
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/toolchain.wixproj
+++ b/platforms/Windows/toolchain.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.0-rc.4">
+<Project Sdk="WixToolset.Sdk/4.0.0">
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -30,8 +30,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.4" />
-    <PackageReference Include="WixToolset.Heat" Version="4.0.0-rc.4" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0" />
+    <PackageReference Include="WixToolset.Heat" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Wix v4.0.0 has now been published on [nuget](https://www.nuget.org/packages/WixToolset.Sdk). Time to migrate from the release candidate.