### PR TITLE
WiX: remove unnecessary MSI Property

### DIFF
--- a/platforms/Windows/installer-amd64.wxs
+++ b/platforms/Windows/installer-amd64.wxs
@@ -7,17 +7,13 @@
     <Chain>
       <?if $(var.RequiredChain) != "" ?>
       <?foreach MSI in $(var.RequiredChain) ?>
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes">
-        <MsiProperty Name="INSTALL_DEBUGINFO" Value="[INSTALL_DEBUGINFO]" />
-      </MsiPackage>
+      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes" />
       <?endforeach?>
       <?endif?>
 
       <?if $(var.OptionalChain) != "" ?>
       <?foreach MSI in $(var.OptionalChain) ?>
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes" Visible="yes">
-        <MsiProperty Name="INSTALL_DEBUGINFO" Value="[INSTALL_DEBUGINFO]" />
-      </MsiPackage>
+      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes" Visible="yes" />
       <?endforeach?>
       <?endif?>
     </Chain>

--- a/platforms/Windows/installer-arm64.wxs
+++ b/platforms/Windows/installer-arm64.wxs
@@ -7,17 +7,13 @@
     <Chain>
       <?if $(var.RequiredChain) != "" ?>
       <?foreach MSI in $(var.RequiredChain) ?>
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes">
-        <MsiProperty Name="INSTALL_DEBUGINFO" Value="[INSTALL_DEBUGINFO]" />
-      </MsiPackage>
+      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes" />
       <?endforeach?>
       <?endif?>
 
       <?if $(var.OptionalChain) != "" ?>
       <?foreach MSI in $(var.OptionalChain) ?>
-      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes" Visible="yes">
-        <MsiProperty Name="INSTALL_DEBUGINFO" Value="[INSTALL_DEBUGINFO]" />
-      </MsiPackage>
+      <MsiPackage SourceFile="$(var.MSI_LOCATION)\$(var.MSI)" Compressed="yes" Visible="yes" />
       <?endforeach?>
       <?endif?>
     </Chain>


### PR DESCRIPTION
The ability to distribute the debug information with the installer has been removed as the total size of the debug information vastly outsizes the packaging of the toolchain (~7x).  The traditional way to distribute debug information on Windows is via a symbol server with indexing via SaaS such as Azure Packages.  Remove the now defunct property setting.