### PR TITLE
WiX: rewrite the package identities

### DIFF
--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -3,11 +3,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift Developer Tools for Windows x86_64"
+      Name="Swift Developer Tools"
       UpgradeCode="5778fa7a-f1a6-4133-b4e0-fc0d9caf4544"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift Developer Tools for Windows x86_64" />
+    <SummaryInformation Description="Swift Developer Tools" />
 
     <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
 
@@ -152,7 +152,7 @@
       </Component>
     </ComponentGroup>
 
-    <Feature Id="DeveloperTools" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows x86_64" Level="1" Title="Swift Developer Tools (Windows x86_64)">
+    <Feature Id="DeveloperTools" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools" Level="1" Title="Swift Developer Tools">
       <ComponentGroupRef Id="SwiftCollections" />
       <ComponentGroupRef Id="SwiftSystem" />
       <ComponentGroupRef Id="SwiftPackageManager" />

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -3,11 +3,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift Developer Tools for Windows aarch64"
+      Name="Swift Developer Tools"
       UpgradeCode="87019842-3f3e-4227-b5c5-23a8ef72ad89"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift Developer Tools for Windows aarch64" />
+    <SummaryInformation Description="Swift Developer Tools" />
 
     <Media Id="1" Cabinet="devtools.cab" EmbedCab="yes" />
 
@@ -152,7 +152,7 @@
       </Component>
     </ComponentGroup>
 
-    <Feature Id="DeveloperTools" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows aarch64" Level="1" Title="Swift Developer Tools (Windows aarch64)">
+    <Feature Id="DeveloperTools" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools" Level="1" Title="Swift Developer Tools">
       <ComponentGroupRef Id="SwiftCollections" />
       <ComponentGroupRef Id="SwiftSystem" />
       <ComponentGroupRef Id="SwiftPackageManager" />

--- a/platforms/Windows/installer-amd64.wxs
+++ b/platforms/Windows/installer-amd64.wxs
@@ -1,5 +1,5 @@
 ﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
-  <Bundle Name="Swift Developer Package for Windows x86_64" Version="$(var.ProductVersion)" Manufacturer="swift.org" UpgradeCode="8c75f32a-7bdf-4c61-abf6-c7e1c4b8fbf6">
+  <Bundle Name="Swift Software Development Kit" Version="$(var.ProductVersion)" Manufacturer="swift.org" UpgradeCode="8c75f32a-7bdf-4c61-abf6-c7e1c4b8fbf6">
     <BootstrapperApplication>
       <bal:WixStandardBootstrapperApplication LicenseUrl="" LogoFile="Resources/swift.png" SuppressOptionsUI="yes" SuppressRepair="no" Theme="hyperlinkLicense" />
     </BootstrapperApplication>

--- a/platforms/Windows/installer-arm64.wxs
+++ b/platforms/Windows/installer-arm64.wxs
@@ -1,5 +1,5 @@
 ﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
-  <Bundle Name="Swift Developer Package for Windows aarch64" Version="$(var.ProductVersion)" Manufacturer="swift.org" UpgradeCode="151d42d9-8877-4b72-ac62-4695243a35c1">
+  <Bundle Name="Swift Software Development Kit" Version="$(var.ProductVersion)" Manufacturer="swift.org" UpgradeCode="151d42d9-8877-4b72-ac62-4695243a35c1">
     <BootstrapperApplication>
       <bal:WixStandardBootstrapperApplication LicenseUrl="" LogoFile="Resources/swift.png" SuppressOptionsUI="yes" SuppressRepair="no" Theme="hyperlinkLicense" />
     </BootstrapperApplication>

--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -3,11 +3,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift Runtime for Windows x86_64"
+      Name="Swift Windows Runtime (AMD64)"
       UpgradeCode="850349e4-5a24-44eb-bded-f49a2709d26f"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift Runtime for Windows x86_64" />
+    <SummaryInformation Description="Swift Windows Runtime (AMD64)" />
 
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
 
@@ -94,7 +94,7 @@
     </Component>
 
     <!-- Feature -->
-    <Feature Id="WinX64SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows x86_64" Level="1" Title="Swift Runtime for Windows x86_64">
+    <Feature Id="WinX64SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Windows Runtime (AMD64)" Level="1" Title="Swift Windows Runtime (AMD64)">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
     </Feature>

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -3,11 +3,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift Runtime for Windows aarch64"
+      Name="Swift Windows Runtime (ARM64)"
       UpgradeCode="bea8c6dc-f73e-445b-9486-2333d1cf2886"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift Runtime for Windows aarch64" />
+    <SummaryInformation Description="Swift Windows Runtime (ARM64)" />
 
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
 
@@ -94,7 +94,7 @@
     </Component>
 
     <!-- Feature -->
-    <Feature Id="WinARM64SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows aarch64" Level="1" Title="Swift Runtime for Windows aarch64">
+    <Feature Id="WinARM64SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Windows Runtime (ARM64)" Level="1" Title="Swift Windows Runtime (ARM64)">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
     </Feature>

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -3,11 +3,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift Runtime for Windows i686"
+      Name="Swift Windows Runtime (x86)"
       UpgradeCode="01a3fe60-8c3e-4249-8477-deba39b99dd9"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift Runtime for Windows i686" />
+    <SummaryInformation Description="Swift Windows Runtime (x86)" />
 
     <Media Id="1" Cabinet="runtime.cab" EmbedCab="yes" />
 
@@ -94,7 +94,7 @@
     </Component>
 
     <!-- Feature -->
-    <Feature Id="Win32SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Runtime for Windows i686" Level="1" Title="Swift Runtime for Windows i686">
+    <Feature Id="Win32SwiftRuntime" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Windows Runtime (x86)" Level="1" Title="Swift Windows Runtime (x86)">
       <ComponentGroupRef Id="SwiftRuntime" />
       <ComponentRef Id="EnvironmentVariables" />
     </Feature>

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -2,11 +2,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift SDK for Windows x86_64"
+      Name="Swift Windows SDK (AMD64)"
       UpgradeCode="83af0249-2b57-4ce1-8121-c29c6c555225"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift SDK for Windows x86_64" />
+    <SummaryInformation Description="Swift Windows SDK (AMD64)" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
 
@@ -484,7 +484,7 @@
     </Component>
 
     <!-- Features -->
-    <Feature Id="WinX64SDK" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows x86_64" Level="1" Title="Swift SDK for Windows x86_64" AllowAbsent="no">
+    <Feature Id="WinX64SDK" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Windows SDK (AMD64)" Level="1" Title="Swift Windows SDK (AMD64)" AllowAbsent="no">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="CXX" />

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -2,11 +2,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift SDK for Windows aarch64"
+      Name="Swift Windows SDK (ARM64)"
       UpgradeCode="4c37a396-d9e2-490a-89b7-0a3d271d847f"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift SDK for Windows aarch64" />
+    <SummaryInformation Description="Swift Windows SDK (ARM64)" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
 
@@ -484,7 +484,7 @@
     </Component>
 
     <!-- Features -->
-    <Feature Id="WinARM64SDK" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows aarch64" Level="1" Title="Swift SDK for Windows aarch64">
+    <Feature Id="WinARM64SDK" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Windows SDK (ARM64)" Level="1" Title="Swift Windows SDK (ARM64)">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="CXX" />

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -2,11 +2,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift SDK for Windows i686"
+      Name="Swift Windows SDK (x86)"
       UpgradeCode="7ab082f9-cd6d-480e-9a97-4186782c3db0"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift SDK for Windows i686" />
+    <SummaryInformation Description="Swift Windows SDK (x86)" />
 
     <Media Id="1" Cabinet="WindowsSDK.cab" EmbedCab="yes" />
 
@@ -478,7 +478,7 @@
 
 
     <!-- Features -->
-    <Feature Id="Win32SDK" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows i686" Level="1" Title="Swift SDK for Windows i686">
+    <Feature Id="Win32SDK" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Windows SDK (x86)" Level="1" Title="Swift Windows SDK (x86)">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="CXX" />

--- a/platforms/Windows/toolchain-amd64.wxs
+++ b/platforms/Windows/toolchain-amd64.wxs
@@ -3,11 +3,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift Toolchain for Windows x86_64"
+      Name="Swift Compiler Tools"
       UpgradeCode="9871289b-f9cb-4b39-8122-2c7ec1ab24d5"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift Toolchain for Windows x86_64" />
+    <SummaryInformation Description="Swift Compiler Tools" />
 
     <!--
       NOTE(compnerd) Use high compression as this is an extrodinarily large
@@ -539,7 +539,7 @@
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Toolchains\$(var.ToolchainName)\usr\bin" />
     </Component>
 
-    <Feature Id="Toolchain" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows x86_64" Level="1" Title="Swift Toolchain for Windows x86_64">
+    <Feature Id="Toolchain" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Compiler Tools" Level="1" Title="Swift Compiler Tools">
       <ComponentGroupRef Id="binutils" />
       <ComponentGroupRef Id="clang" />
       <ComponentGroupRef Id="lld" />

--- a/platforms/Windows/toolchain-arm64.wxs
+++ b/platforms/Windows/toolchain-arm64.wxs
@@ -3,11 +3,11 @@
   <Package
       Language="1033"
       Manufacturer="swift.org"
-      Name="Swift Toolchain for Windows aarch64"
+      Name="Swift Compiler Tools"
       UpgradeCode="7e95dc06-7f84-4e8e-a038-8304af0468fb"
       Version="$(var.ProductVersion)"
       Scope="perMachine">
-    <SummaryInformation Description="Swift Toolchain for Windows aarch64" />
+    <SummaryInformation Description="Swift Compiler Tools" />
 
     <!--
       NOTE(compnerd) Use high compression as this is an extrodinarily large
@@ -539,7 +539,7 @@
       <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer\Toolchains\$(var.ToolchainName)\usr\bin" />
     </Component>
 
-    <Feature Id="Toolchain" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Toolchain for Windows aarch64" Level="1" Title="Swift Toolchain for Windows aarch64">
+    <Feature Id="Toolchain" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Compiler Tools" Level="1" Title="Swift Compiler Tools">
       <ComponentGroupRef Id="binutils" />
       <ComponentGroupRef Id="clang" />
       <ComponentGroupRef Id="lld" />


### PR DESCRIPTION
Restructure the packaging to be more homogeneous and concise.

      - Swift Software Development Kit
        * Swift Compiler Tools
        * Swift Developer Tools
        * Swift Windows Runtime (AMD64|ARM|ARM64|x86)
        * Swift Windows SDK (AMD64|ARM|ARM64|x86)

This gives a more concise description that is also easier to understand
and map.  This sets up the path for further refinement of the installer
to provide more control over the installed components.

We do not suffix the Software Development Kit nor Compiler and Developer
Tools as there will be a singular version that matches the host that is
installed.  Therefore, there is no value in differentiating that.
However, multiple SDKs and Runtimes may be present, so identify the
architecture for them.