### PR TITLE
WiX: package up CompilerPluginSupport module

### DIFF
--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -143,6 +143,19 @@
         <File Id="PackageDescription.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" Checksum="yes" />
       </Component>
 
+      <Component Id="CompilerPluginSupport.dll" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="e70c1625-68a6-4b1b-8476-ccf6951008cb">
+        <File Id="CompilerPluginSupport.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.dll" Checksum="yes" />
+      </Component>
+      <Component Id="CompilerPluginSupport.lib" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="be8d4b68-9273-49bd-b7d2-e8edde22d64d">
+        <File Id="CompilerPluginSupport.lib" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.lib" Checksum="yes" />
+      </Component>
+      <Component Id="CompilerPluginSupport.swiftdoc" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="fb0b2c0c-49f3-4639-b31f-7d80fa6a8841">
+        <File Id="CompilerPluginSupport.swiftdoc" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="CompilerPluginSupport.swiftmodule" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="8af5e404-7e2d-4b86-99f3-03ce1bb03fff">
+        <File Id="CompilerPluginSupport.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.swiftmodule" Checksum="yes" />
+      </Component>
+
       <Component Id="PackagePlugin.dll" Directory="_usr_lib_swift_pm_PluginAPI" Guid="35bcc747-7923-420c-80c0-e95b6673b3b1">
         <File Id="PackagePlugin.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -143,6 +143,19 @@
         <File Id="PackageDescription.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" Checksum="yes" />
       </Component>
 
+      <Component Id="CompilerPluginSupport.dll" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="ca3c9c96-3e52-4632-a72b-e071559561fc">
+        <File Id="CompilerPluginSupport.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.dll" Checksum="yes" />
+      </Component>
+      <Component Id="CompilerPluginSupport.lib" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="2255f581-ddef-4633-8f3f-19b84d46b51b">
+        <File Id="CompilerPluginSupport.lib" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.lib" Checksum="yes" />
+      </Component>
+      <Component Id="CompilerPluginSupport.swiftdoc" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="7ac085c2-0a74-4936-b150-0aef32568e65">
+        <File Id="CompilerPluginSupport.swiftdoc" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="CompilerPluginSupport.swiftmodule" Directory="_usr_lib_swift_pm_ManifestAPI" Guid="eaf41e9f-4f71-4479-a3b3-b75a95f248ac">
+        <File Id="CompilerPluginSupport.swiftmodule" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.swiftmodule" Checksum="yes" />
+      </Component>
+
       <Component Id="PackagePlugin.dll" Directory="_usr_lib_swift_pm_PluginAPI" Guid="7ca18c18-6efa-44e9-af2c-b0196dfb9778">
         <File Id="PackagePlugin.dll" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" Checksum="yes" />
       </Component>


### PR DESCRIPTION
This is part of the Manifest API in SPM and expected to be present. Package this into the distribution as well.