### PR TITLE
WiX: repair the x86 SDK packaging

### DIFF
--- a/platforms/Windows/sdk.wixproj
+++ b/platforms/Windows/sdk.wixproj
@@ -27,21 +27,6 @@
     <HarvestGenerateGuidsNow>true</HarvestGenerateGuidsNow>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">
-    <InstallerPlatform>x64</InstallerPlatform>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm64' ">
-    <InstallerPlatform>arm64</InstallerPlatform>
-    <InstallerVersion>500</InstallerVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm' ">
-    <InstallerPlatform>arm</InstallerPlatform>
-    <InstallerVersion>500</InstallerVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'x86' ">
-    <InstallerPlatform>x86</InstallerPlatform>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0" />
     <PackageReference Include="WixToolset.Heat" Version="4.0.0" />


### PR DESCRIPTION
We cannot set the installer platform to the architecture being packaged as this is platform agnostic content which is always installed to a 64-bit platform.  We can pass `-p:InstallerPlatform=[x64|arm64]` to enable building the SDK for installation on either of the hosts.