### PR TITLE
WiX: CxxShim files became arch-independent (#213)

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -445,12 +445,12 @@
     </ComponentGroup>
 
     <ComponentGroup Id="CXXShims">
-      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="77450677-ce9e-43f9-9db1-35231dcf563e">
-        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.h" Checksum="yes" />
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="77450677-ce9e-43f9-9db1-35231dcf563e">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.h" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="e4fa6e5c-3dd5-49fd-9f27-a72d58c8d156">
-        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.modulemap" Checksum="yes" />
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows" Guid="e4fa6e5c-3dd5-49fd-9f27-a72d58c8d156">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
     </ComponentGroup>
 

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -445,12 +445,12 @@
     </ComponentGroup>
 
     <ComponentGroup Id="CXXShims">
-      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="d579019d-d999-47f7-8b35-1d714874de80">
-        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\libcxxshim.h" Checksum="yes" />
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="d579019d-d999-47f7-8b35-1d714874de80">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.h" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="b5f65b19-cf8f-4862-b378-3e299887afa3">
-        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\libcxxshim.modulemap" Checksum="yes" />
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows" Guid="b5f65b19-cf8f-4862-b378-3e299887afa3">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
     </ComponentGroup>
 

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -443,12 +443,12 @@
     </ComponentGroup>
 
     <ComponentGroup Id="CXXShims">
-      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="d9653245-ca31-442a-b122-f5df3a3ad752">
-        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\libcxxshim.h" Checksum="yes" />
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="d9653245-ca31-442a-b122-f5df3a3ad752">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.h" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="52c178a4-f65b-46a4-9089-c686c755bf2e">
-        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\libcxxshim.modulemap" Checksum="yes" />
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows" Guid="52c178a4-f65b-46a4-9089-c686c755bf2e">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
This adjusts the Windows installation logic after the changes in https://github.com/apple/swift/pull/66765

rdar://110788977