### PR TITLE
WiX: package `libcxxstdlibshim.h` on Windows

### DIFF
--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -416,6 +416,9 @@
       <Component>
         <File Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" />
       </Component>
+      <Component>
+        <File Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshim.h" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_ARCH">


### PR DESCRIPTION
This file was not being packaged into the installer, which gives us an incomplete module.

Partially fixes: apple/swift#67462