### PR TITLE
WiX: package `libcxxstdlibshim.h` on Windows

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -452,6 +452,10 @@
       <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows" Guid="e4fa6e5c-3dd5-49fd-9f27-a72d58c8d156">
         <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
+
+      <Component Id="libcxxstdlibshims.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="d80bdcb8-fae1-43a9-8e97-0d0649280009">
+        <File Id="libcxxstdlibshims.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshims.h" Checksum="yes" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_x86_64">

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -453,8 +453,8 @@
         <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxstdlibshims.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="d80bdcb8-fae1-43a9-8e97-0d0649280009">
-        <File Id="libcxxstdlibshims.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshims.h" Checksum="yes" />
+      <Component Id="libcxxstdlibshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="d80bdcb8-fae1-43a9-8e97-0d0649280009">
+        <File Id="libcxxstdlibshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshim.h" Checksum="yes" />
       </Component>
     </ComponentGroup>
 

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -453,8 +453,8 @@
         <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxstdlibshims.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="8277b66f-31c2-4f51-af1c-f49fb4404a13">
-        <File Id="libcxxstdlibshims.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshims.h" Checksum="yes" />
+      <Component Id="libcxxstdlibshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="8277b66f-31c2-4f51-af1c-f49fb4404a13">
+        <File Id="libcxxstdlibshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshim.h" Checksum="yes" />
       </Component>
     </ComponentGroup>
 

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -452,6 +452,10 @@
       <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows" Guid="b5f65b19-cf8f-4862-b378-3e299887afa3">
         <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
+
+      <Component Id="libcxxstdlibshims.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="8277b66f-31c2-4f51-af1c-f49fb4404a13">
+        <File Id="libcxxstdlibshims.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshims.h" Checksum="yes" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_aarch64">

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -451,8 +451,8 @@
         <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxstdlibshims.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="e46f7763-93cf-451d-bdd3-060b1c1a01a0">
-        <File Id="libcxxstdlibshims.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshims.h" Checksum="yes" />
+      <Component Id="libcxxstdlibshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="e46f7763-93cf-451d-bdd3-060b1c1a01a0">
+        <File Id="libcxxstdlibshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshim.h" Checksum="yes" />
       </Component>
     </ComponentGroup>
 

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -450,6 +450,10 @@
       <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows" Guid="52c178a4-f65b-46a4-9089-c686c755bf2e">
         <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.modulemap" Checksum="yes" />
       </Component>
+
+      <Component Id="libcxxstdlibshims.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="e46f7763-93cf-451d-bdd3-060b1c1a01a0">
+        <File Id="libcxxstdlibshims.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxstdlibshims.h" Checksum="yes" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="Registrar" Directory="WindowsSDK_usr_lib_swift_windows_i686">


### PR DESCRIPTION
This file was not being packaged into the installer, which gives us an incomplete module.

Fixes: apple/swift#67462