### PR TITLE
WiX: package CxxStdlib on Windows

### DIFF
--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -100,6 +100,11 @@
                       <Directory Id="WindowsSDK_usr_lib_swift_windows_ARCH" Name="$(var.ArchArchDir)" />
                     </Directory>
                   </Directory>
+                  <Directory Name="swift_static">
+                    <Directory Id="WindowsSDK_usr_lib_swift_static_windows" Name="windows">
+                      <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
+                    </Directory>
+                  </Directory>
                 </Directory>
                 <Directory Id="WindowsSDK_usr_share" Name="share" />
               </Directory>
@@ -313,6 +318,21 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="CxxStdlib" Directory="CxxStdlib.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="WindowsSDK_usr_lib_swift_windows_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\$(ArchArchDir)\libswiftCxxStdlib.lib" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Distributed" Directory="Distributed.swiftmodule">
       <Component>
         <File Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\$(var.ArchTriple).swiftdoc" />
@@ -479,6 +499,7 @@
       <ComponentGroupRef Id="_StringProcessing" />
       <ComponentGroupRef Id="CRT" />
       <ComponentGroupRef Id="Cxx" />
+      <ComponentGroupRef Id="CxxStdlib" />
       <ComponentGroupRef Id="Distributed" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationXML" />


### PR DESCRIPTION
This is the first standard library component which is static only.  Add this new module to the distribution.