### PR TITLE
WiX: add CxxStdlib to the Windows packaging

### DIFF
--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -102,6 +102,11 @@
                               </Directory>
                             </Directory>
                           </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_static" Name="swift_static">
+                            <Directory Id="WindowsSDK_usr_lib_swift_static_windows" Name="windows">
+                              <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
+                            </Directory>
+                          </Directory>
                         </Directory>
                         <Directory Id="WindowsSDK_usr_share" Name="share">
                         </Directory>
@@ -341,7 +346,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="CXX">
+    <ComponentGroup Id="Cxx">
       <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="b170a09f-0483-486f-b7de-1e8f4e1644a4">
         <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
       </Component>
@@ -354,6 +359,22 @@
 
       <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="a90ba944-b9f6-40a6-8184-f59ae23598fe">
         <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="CxxStdlib">
+      <Component Id="CxxStdlib.swiftdoc" Directory="CxxStdlib.swiftmodule" Guid="a0156982-4705-4efb-8b2a-a4e5b0af7048">
+        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="CxxStdlib.swiftinterface" Directory="CxxStdlib.swiftmodule" Guid="77d32d60-bc1b-4455-9257-9880b329170c">
+        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="CxxStdlib.swiftmodule" Directory="CxxStdlib.swiftmodule" Guid="446847d4-09be-4377-9d25-b032d338678f">
+        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="libswiftCxxStdlib.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="654eedf7-cb83-4589-9c89-d12e8e53b9fa">
+        <File Id="libswiftCxxStdlib.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libswiftCxxStdlib.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
@@ -444,7 +465,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="CXXShims">
+    <ComponentGroup Id="CxxShims">
       <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="77450677-ce9e-43f9-9db1-35231dcf563e">
         <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.h" Checksum="yes" />
       </Component>
@@ -502,7 +523,8 @@
     <Feature Id="WinX64SDK" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows x86_64" Level="1" Title="Swift SDK for Windows x86_64" AllowAbsent="no">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
-      <ComponentGroupRef Id="CXX" />
+      <ComponentGroupRef Id="Cxx" />
+      <ComponentGroupRef Id="CxxStdlib" />
       <ComponentGroupRef Id="Distributed" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
@@ -519,7 +541,7 @@
       <ComponentGroupRef Id="dispatch" />
 
       <ComponentGroupRef Id="SwiftShims" />
-      <ComponentGroupRef Id="CXXShims" />
+      <ComponentGroupRef Id="CxxShims" />
 
       <ComponentGroupRef Id="Registrar" />
       <ComponentGroupRef Id="AuxiliaryFiles" />

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -102,6 +102,11 @@
                               </Directory>
                             </Directory>
                           </Directory>
+                          <Directory Id="WindowsSDK_usr_lib_swift_static" Name="swift_static">
+                            <Directory Id="WindowsSDK_usr_lib_swift_static_windows" Name="windows">
+                              <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
+                            </Directory>
+                          </Directory>
                         </Directory>
                         <Directory Id="WindowsSDK_usr_share" Name="share">
                         </Directory>
@@ -341,7 +346,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="CXX">
+    <ComponentGroup Id="Cxx">
       <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="2decbe47-1209-4abb-b94e-1bf6a83e2028">
         <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
       </Component>
@@ -354,6 +359,22 @@
 
       <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="f7bcc956-462e-43df-ae25-c5f4636b27d1">
         <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="CxxStdlib">
+      <Component Id="CxxStdlib.swiftdoc" Directory="CxxStdlib.swiftmodule" Guid="be4bf95b-6d55-4743-9872-f62621e903e1">
+        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="CxxStdlib.swiftinterface" Directory="CxxStdlib.swiftmodule" Guid="0cd43438-de5e-4e32-832f-2505f1f37834">
+        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="CxxStdlib.swiftmodule" Directory="CxxStdlib.swiftmodule" Guid="bd7ada20-67c4-4089-bd93-235586919d2e">
+        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="libswiftCxxStdlib.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="b30a1c97-b8af-4877-ace8-c0c9ad5e55c8">
+        <File Id="libswiftCxxStdlib.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\libswiftCxxStdlib.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
@@ -444,7 +465,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="CXXShims">
+    <ComponentGroup Id="CxxShims">
       <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="d579019d-d999-47f7-8b35-1d714874de80">
         <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.h" Checksum="yes" />
       </Component>
@@ -502,7 +523,8 @@
     <Feature Id="WinARM64SDK" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows aarch64" Level="1" Title="Swift SDK for Windows aarch64">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
-      <ComponentGroupRef Id="CXX" />
+      <ComponentGroupRef Id="Cxx" />
+      <ComponentGroupRef Id="CxxStdlib" />
       <ComponentGroupRef Id="Distributed" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
@@ -519,7 +541,7 @@
       <ComponentGroupRef Id="dispatch" />
 
       <ComponentGroupRef Id="SwiftShims" />
-      <ComponentGroupRef Id="CXXShims" />
+      <ComponentGroupRef Id="CxxShims" />
 
       <ComponentGroupRef Id="Registrar" />
       <ComponentGroupRef Id="AuxiliaryFiles" />

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -101,6 +101,11 @@
                             </Directory>
                           </Directory>
                         </Directory>
+                        <Directory Id="WindowsSDK_usr_lib_swift_static" Name="swift_static">
+                          <Directory Id="WindowsSDK_usr_lib_swift_static_windows" Name="windows">
+                            <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
+                          </Directory>
+                        </Directory>
                       </Directory>
                       <Directory Id="WindowsSDK_usr_share" Name="share">
                       </Directory>
@@ -339,7 +344,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="CXX">
+    <ComponentGroup Id="Cxx">
       <Component Id="Cxx.swiftdoc" Directory="Cxx.swiftmodule" Guid="a7c78d68-abed-4065-ba82-08d4773bf4d8">
         <File Id="Cxx.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
       </Component>
@@ -352,6 +357,22 @@
 
       <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="b2897a7a-65c2-4f0f-b14c-6b466d2e3d34">
         <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftCxx.lib" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="CxxStdlib">
+      <Component Id="CxxStdlib.swiftdoc" Directory="CxxStdlib.swiftmodule" Guid="6edc85d1-5db5-411b-9a15-d0ade693989a">
+        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+      </Component>
+      <Component Id="CxxStdlib.swiftinterface" Directory="CxxStdlib.swiftmodule" Guid="9e078f6f-1c64-4af2-8ca5-7dd231c4e545">
+        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+      </Component>
+      <Component Id="CxxStdlib.swiftmodule" Directory="CxxStdlib.swiftmodule" Guid="e49baae6-a192-4b91-af90-be5bb51d803c">
+        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <Component Id="libswiftCxxStdlib.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="f4342fea-b975-4e24-9881-8927d6ebb0fe">
+        <File Id="libswiftCxxStdlib.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\libswiftCxxStdlib.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
@@ -442,7 +463,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="CXXShims">
+    <ComponentGroup Id="CxxShims">
       <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows" Guid="d9653245-ca31-442a-b122-f5df3a3ad752">
         <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\libcxxshim.h" Checksum="yes" />
       </Component>
@@ -496,7 +517,8 @@
     <Feature Id="Win32SDK" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift SDK for Windows i686" Level="1" Title="Swift SDK for Windows i686">
       <ComponentGroupRef Id="BlocksRuntime" />
       <ComponentGroupRef Id="CRT" />
-      <ComponentGroupRef Id="CXX" />
+      <ComponentGroupRef Id="Cxx" />
+      <ComponentGroupRef Id="CxxStdlib" />
       <ComponentGroupRef Id="Distributed" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationNetworking" />
@@ -513,7 +535,7 @@
       <ComponentGroupRef Id="dispatch" />
 
       <ComponentGroupRef Id="SwiftShims" />
-      <ComponentGroupRef Id="CXXShims" />
+      <ComponentGroupRef Id="CxxShims" />
 
       <ComponentGroupRef Id="Registrar" />
       <ComponentGroupRef Id="AuxiliaryFiles" />


### PR DESCRIPTION
This adds the final missing component of the C++ interop to the 5.9 release now that it is enabled in the build.