### PR TITLE
WiX: adjust the for apple/swift-package-manager#6817

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -134,9 +134,7 @@
 
     <ComponentGroup Id="CompilerPluginSupport" Directory="_usr_lib_swift_pm_ManifestAPI">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.dll" />
-      </Component>
-      <Component>
+        <!-- TODO(compnerd) use a lib prefix -->
         <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.lib" />
       </Component>
       <Component>
@@ -149,9 +147,7 @@
 
     <ComponentGroup Id="PackageDescription" Directory="_usr_lib_swift_pm_ManifestAPI">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" />
-      </Component>
-      <Component>
+        <!-- TODO(compnerd) use a lib prefix -->
         <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" />
       </Component>
       <Component>
@@ -164,9 +160,7 @@
 
     <ComponentGroup Id="PackagePlugin" Directory="_usr_lib_swift_pm_PluginAPI">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" />
-      </Component>
-      <Component>
+        <!-- TODO(compnerd) use a lib prefix -->
         <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.lib" />
       </Component>
       <Component>


### PR DESCRIPTION
Adjust the packaging rules to remove the shared library to support migrating to static library forms for this.  This should avoid the need to adjust the path when executing the compiled manifest.