### PR TITLE
WiX: adjust Cxx module packaging

### DIFF
--- a/platforms/Windows/rtl/lib/rtllib.wxs
+++ b/platforms/Windows/rtl/lib/rtllib.wxs
@@ -29,9 +29,6 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\bin\swiftCore.dll" />
       </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\bin\swiftCxx.dll" />
-      </Component>
 
       <!-- TODO(compnerd) should we distribute the undecoration library in the runtime?
       <Component Directory="_usr_bin" Id="swiftDemangle.dll">

--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -310,7 +310,7 @@
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\$(ArchTriple).swiftmodule" />
       </Component>
       <Component Directory="WindowsSDK_usr_lib_swift_windows_ARCH">
-        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\$(ArchArchDir)\swiftCxx.lib" />
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\$(ArchArchDir)\libswiftCxx.lib" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
Adjust for Cxx being built statically now (which removes the runtime distribution content and puts the library into the SDK).  The C++ interop support now matches the Darwin and Linux platforms and distributes it as static libraries as the interface is fragile still.