### PR TITLE
WiX: adjust the installer UI

### DIFF
--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -1,16 +1,21 @@
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
+<!--
+  Copyright (c) .NET Foundation and contributors. All rights reserved.
+  Licensed under the Microsoft Reciprocal License.
+  See LICENSE.TXT file in the project root for full license information.
+-->
 <Theme xmlns="http://wixtoolset.org/schemas/v4/thmutil">
     <Font Id="0" Height="-12" Weight="500" Foreground="windowtext" Background="window">Segoe UI</Font>
     <Font Id="1" Height="-24" Weight="500" Foreground="windowtext">Segoe UI</Font>
     <Font Id="2" Height="-22" Weight="500" Foreground="graytext">Segoe UI</Font>
     <Font Id="3" Height="-12" Weight="500" Foreground="windowtext" Background="window">Segoe UI</Font>
 
-    <Window Width="724" Height="362" HexStyle="100a0000" FontId="0" Caption="#(loc.Caption)">
+    <Window Width="614" Height="384" HexStyle="100a0000" FontId="0" Caption="#(loc.Caption)">
+        <ImageControl X="0" Y="0" Width="165" Height="384" ImageFile="swift_side.png"/>
+        <Label X="176" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
+
         <Page Name="Help">
-            <ImageControl X="11" Y="11" Width="165" Height="312" ImageFile="swift_side.png"/>
-            <Label X="185" Y="11" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Label>
-            <Label X="185" Y="48" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Label>
+            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Label>
+            <Label X="176" Y="91" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Label>
             <Button Name="HelpCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.HelpCloseButton)</Text>
                 <CloseWindowAction />
@@ -18,22 +23,18 @@
         </Page>
 
         <Page Name="Loading">
-            <ImageControl X="11" Y="11" Width="165" Height="312" ImageFile="swift_side.png"/>
-            <Label X="185" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
-            <Label X="185" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes" Visible="no" Name="CheckingForUpdatesLabel" />
+            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes" Visible="no" Name="CheckingForUpdatesLabel" />
         </Page>
 
         <Page Name="Install">
-            <ImageControl X="11" Y="11" Width="165" Height="312" ImageFile="swift_side.png"/>
-            <Label X="185" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
-            <Label X="185" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.InstallHeader)</Label>
-            <Label X="185" Y="91" Width="-11" Height="64" FontId="3" DisablePrefix="yes">
+            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.InstallHeader)</Label>
+            <Label X="176" Y="91" Width="-11" Height="64" FontId="3" DisablePrefix="yes">
                 <Text Condition="WixStdBASuppressOptionsUI">#(loc.InstallMessage)</Text>
                 <Text Condition="NOT WixStdBASuppressOptionsUI">#(loc.InstallMessageOptions)</Text>
             </Label>
-            <Hypertext Name="EulaHyperlink" X="185" Y="-81" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallLicenseLinkText)</Hypertext>
-            <Label Name="InstallVersion" X="185" Y="-111" Width="-11" Height="17" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBAShowVersion">#(loc.InstallVersion)</Label>
-            <Checkbox Name="EulaAcceptCheckbox" X="185" Y="-51" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
+            <Hypertext Name="EulaHyperlink" X="176" Y="-73" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallLicenseLinkText)</Hypertext>
+            <Label Name="InstallVersion" X="176" Y="-103" Width="-11" Height="17" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBAShowVersion">#(loc.InstallVersion)</Label>
+            <Checkbox Name="EulaAcceptCheckbox" X="176" Y="-51" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
             <Button Name="InstallUpdateButton" X="11" Y="-11" Width="200" Height="23" TabStop="yes" FontId="0" EnableCondition="WixStdBAUpdateAvailable" HideWhenDisabled="yes">#(loc.UpdateButton)</Button>
             <Button Name="OptionsButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" VisibleCondition="NOT WixStdBASuppressOptionsUI">
                 <Text>#(loc.InstallOptionsButton)</Text>
@@ -47,27 +48,25 @@
         </Page>
 
         <Page Name="Options">
-            <ImageControl X="11" Y="11" Width="165" Height="312" ImageFile="swift_side.png"/>
-
-            <Label X="185" Y="11" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsLocationLabel)</Label>
-            <Editbox Name="InstallRoot" X="185" Y="46" Width="-91" Height="21" TabStop="yes" FontId="3" FileSystemAutoComplete="yes" />
-            <Button Name="BrowseButton" X="-11" Y="45" Width="75" Height="23" TabStop="yes" FontId="3">
+            <Label X="176" Y="46" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsLocationLabel)</Label>
+            <Editbox Name="InstallRoot" X="176" Y="80" Width="-91" Height="21" TabStop="yes" FontId="3" FileSystemAutoComplete="yes" />
+            <Button Name="BrowseButton" X="-11" Y="79" Width="75" Height="23" TabStop="yes" FontId="3">
                 <Text>#(loc.OptionsBrowseButton)</Text>
                 <BrowseDirectoryAction VariableName="InstallRoot" />
             </Button>
 
-            <Label X="185" Y="81" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsFeaturesLabel)</Label>
-            <Checkbox Name="OptionsInstallBld" X="185" Y="116" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Bld_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallCli" X="185" Y="134" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Cli_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallDbg" X="185" Y="152" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Dbg_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallIde" X="185" Y="170" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Ide_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallRtl" X="185" Y="188" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Rtl_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallSdkAMD64" X="185" Y="206" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_amd64)</Checkbox>
-            <Checkbox Name="OptionsInstallRedistAMD64" X="203" Y="224" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkAMD64">#(loc.Redist_amd64)</Checkbox>
-            <Checkbox Name="OptionsInstallSdkX86" X="185" Y="242" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_x86)</Checkbox>
-            <Checkbox Name="OptionsInstallRedistX86" X="203" Y="260" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkX86">#(loc.Redist_x86)</Checkbox>
-            <Checkbox Name="OptionsInstallSdkArm64" X="185" Y="278" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_arm64)</Checkbox>
-            <Checkbox Name="OptionsInstallRedistArm64" X="203" Y="296" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkArm64">#(loc.Redist_arm64)</Checkbox>
+            <Label X="176" Y="111" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsFeaturesLabel)</Label>
+            <Checkbox Name="OptionsInstallBld" X="176" Y="141" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Bld_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallCli" X="176" Y="159" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Cli_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallDbg" X="176" Y="177" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Dbg_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallIde" X="176" Y="195" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Ide_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallRtl" X="176" Y="213" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Rtl_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallSdkAMD64" X="176" Y="231" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallRedistAMD64" X="194" Y="249" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkAMD64">#(loc.Redist_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallSdkArm64" X="176" Y="267" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallRedistArm64" X="194" Y="285" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkArm64">#(loc.Redist_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallSdkX86" X="176" Y="303" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_x86)</Checkbox>
+            <Checkbox Name="OptionsInstallRedistX86" X="194" Y="321" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkX86">#(loc.Redist_x86)</Checkbox>
 
             <Button Name="OptionsOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.OptionsOkButton)</Text>
@@ -80,18 +79,14 @@
         </Page>
 
         <Page Name="Progress">
-            <ImageControl X="11" Y="11" Width="165" Height="312" ImageFile="swift_side.png"/>
-            <Label X="185" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
-            <Label X="185" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Label>
-            <Label Name="OverallProgressPackageText" X="185" Y="89" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Label>
-            <Progressbar Name="OverallCalculatedProgressbar" X="185" Y="111" Width="-11" Height="20" />
+            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Label>
+            <Label Name="OverallProgressPackageText" X="176" Y="89" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Label>
+            <Progressbar Name="OverallCalculatedProgressbar" X="176" Y="111" Width="-11" Height="20" />
             <Button Name="ProgressCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
         </Page>
 
         <Page Name="Modify">
-            <Label X="185" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
-            <ImageControl X="11" Y="11" Width="165" Height="312" ImageFile="swift_side.png"/>
-            <Label X="185" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Label>
+            <Label X="176" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Label>
             <Button Name="ModifyUpdateButton" X="11" Y="-11" Width="200" Height="23" TabStop="yes" FontId="0" EnableCondition="WixStdBAUpdateAvailable" HideWhenDisabled="yes">#(loc.UpdateButton)</Button>
             <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
             <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
@@ -102,9 +97,7 @@
         </Page>
 
         <Page Name="Success">
-            <Label X="185" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
-            <ImageControl X="11" Y="11" Width="165" Height="312" ImageFile="swift_side.png"/>
-            <Label X="185" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
+            <Label X="176" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
                 <Text>#(loc.SuccessHeader)</Text>
                 <Text Condition="WixBundleAction = 2">#(loc.SuccessLayoutHeader)</Text>
                 <Text Condition="WixBundleAction = 3">#(loc.SuccessUnsafeUninstallHeader)</Text>
@@ -115,7 +108,7 @@
                 <Text Condition="WixBundleAction = 8">#(loc.SuccessRepairHeader)</Text>
             </Label>
             <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
-            <Label X="185" Y="-51" Width="400" Height="34" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
+            <Label X="176" Y="-51" Width="400" Height="34" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
                 <Text>#(loc.SuccessRestartText)</Text>
                 <Text Condition="WixBundleAction = 3">#(loc.SuccessUninstallRestartText)</Text>
             </Label>
@@ -127,9 +120,7 @@
         </Page>
 
         <Page Name="Failure">
-            <Label X="185" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
-            <ImageControl X="11" Y="11" Width="165" Height="312" ImageFile="swift_side.png"/>
-            <Label X="185" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
+            <Label X="176" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
                 <Text>#(loc.FailureHeader)</Text>
                 <Text Condition="WixBundleAction = 2">#(loc.FailureLayoutHeader)</Text>
                 <Text Condition="WixBundleAction = 3">#(loc.FailureUnsafeUninstallHeader)</Text>
@@ -139,9 +130,9 @@
                 <Text Condition="WixBundleAction = 7">#(loc.FailureModifyHeader)</Text>
                 <Text Condition="WixBundleAction = 8">#(loc.FailureRepairHeader)</Text>
             </Label>
-            <Hypertext Name="FailureLogFileLink" X="185" Y="121" Width="-11" Height="68" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
-            <Hypertext Name="FailureMessageText" X="185" Y="-115" Width="-11" Height="80" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
-            <Label X="185" Y="-57" Width="-11" Height="80" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
+            <Hypertext Name="FailureLogFileLink" X="176" Y="121" Width="-11" Height="68" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
+            <Hypertext Name="FailureMessageText" X="176" Y="-115" Width="-11" Height="80" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
+            <Label X="176" Y="-57" Width="-11" Height="80" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
             <Button Name="FailureRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
             <Button Name="FailureCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.FailureCloseButton)</Text>

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -9,17 +9,17 @@
   <String Id="Rtl_ProductName" Value="Swift Windows Utilities" />
   <String Id="Rtl_ProductName_arm64" Value="Swift Windows Utilities (ARM64)" />
   <String Id="Rtl_ProductName_amd64" Value="Swift Windows Utilities (AMD64)" />
-  <String Id="Rtl_ProductName_x86" Value="Swift Windows Utilities (x86)" />
+  <String Id="Rtl_ProductName_x86" Value="Swift Windows Utilities (X86)" />
   <String Id="Sdk_ProductName_arm64" Value="Swift Windows SDK (ARM64)" />
   <String Id="Sdk_ProductName_amd64" Value="Swift Windows SDK (AMD64)" />
-  <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (x86)" />
-  <String Id="BundleName" Value="Swift Tool Kit" />
+  <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (X86)" />
+  <String Id="BundleName" Value="Swift Developer Toolkit" />
   <String Id="ManufacturerName" Value="swift.org" />
 
-  <String Id="OptionsFeaturesLabel" Value="Choose the features you want to install" />
+  <String Id="OptionsFeaturesLabel" Value="Feature Selection" />
   <String Id="Redist_arm64" Value="Swift Windows Redistributable (ARM64)" />
   <String Id="Redist_amd64" Value="Swift Windows Redistributable (AMD64)" />
-  <String Id="Redist_x86" Value="Swift Windows Redistributable (x86)" />
+  <String Id="Redist_x86" Value="Swift Windows Redistributable (X86)" />
 
   <String Id="Caption" Value="[WixBundleName] Setup" />
   <String Id="Title" Value="[WixBundleName]" />
@@ -40,7 +40,7 @@
   <String Id="InstallInstallButton" Value="&amp;Install" />
   <String Id="InstallCancelButton" Value="&amp;Cancel" />
   <String Id="OptionsHeader" Value="Setup Options" />
-  <String Id="OptionsLocationLabel" Value="Install location" />
+  <String Id="OptionsLocationLabel" Value="Install Location" />
   <String Id="OptionsBrowseButton" Value="&amp;Browse" />
   <String Id="OptionsOkButton" Value="&amp;OK" />
   <String Id="OptionsCancelButton" Value="&amp;Cancel" />


### PR DESCRIPTION
Adjust the L&F to maintain the aspect ratio that we previously had (4:3).  This also adjusts some of the spacing to make it more uniform and adjusts the location of the side banner.  The banner is currently shorter than the desired height, but is expected to be replaced with an appropriately sized image soon.  It also enables the feature selection items for the ARM64 and X86 SDKs.