### PR TITLE
WiX: adjust the packaging for Cxx, CxxStdlib

### DIFF
--- a/platforms/Windows/runtime-amd64.wxs
+++ b/platforms/Windows/runtime-amd64.wxs
@@ -61,9 +61,6 @@
       <Component Id="swiftCore.dll" Guid="4098dff8-8b8d-48ee-a234-d29104d4c809">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
-      <Component Id="swiftCxx.dll" Guid="45eb46fc-a006-4fe9-abf0-42e26e3d3c87">
-        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
-      </Component>
       <Component Id="swiftDispatch.dll" Guid="312ffb9e-7ecf-423f-8f59-3041d2776e4a">
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/runtime-arm64.wxs
+++ b/platforms/Windows/runtime-arm64.wxs
@@ -61,9 +61,6 @@
       <Component Id="swiftCore.dll" Guid="b11c37b0-b6ad-4e55-b4e7-0517ff7a161f">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
-      <Component Id="swiftCxx.dll" Guid="7bbf8fd4-769d-4e4f-8d62-f1d07d568ccf">
-        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
-      </Component>
       <Component Id="swiftDispatch.dll" Guid="ce50982a-4bb3-43fc-a5ce-9fc709143b47">
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/runtime-x86.wxs
+++ b/platforms/Windows/runtime-x86.wxs
@@ -61,9 +61,6 @@
       <Component Id="swiftCore.dll" Guid="d816134d-2de1-4e50-90dd-a36675c09c3e">
         <File Id="swiftCore.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCore.dll" Checksum="yes" />
       </Component>
-      <Component Id="swiftCxx.dll" Guid="9752dfcf-b9fd-457d-b983-e2f346f97c3d">
-        <File Id="swiftCxx.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftCxx.dll" Checksum="yes" />
-      </Component>
       <Component Id="swiftDispatch.dll" Guid="fd38df32-2bcd-4da4-98b3-f26abd1ac6de">
         <File Id="swiftDispatch.dll" Source="$(var.SDK_ROOT)\usr\bin\swiftDispatch.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/sdk-amd64.wxs
+++ b/platforms/Windows/sdk-amd64.wxs
@@ -84,6 +84,8 @@
                               </Directory>
                               <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
                               </Directory>
+                              <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule">
+                              </Directory>
                               <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                               </Directory>
                               <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
@@ -100,11 +102,6 @@
                               </Directory>
                               <Directory Id="WindowsSDK_usr_lib_swift_windows_x86_64" Name="x86_64">
                               </Directory>
-                            </Directory>
-                          </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_static" Name="swift_static">
-                            <Directory Id="WindowsSDK_usr_lib_swift_static_windows" Name="windows">
-                              <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
                             </Directory>
                           </Directory>
                         </Directory>
@@ -357,20 +354,20 @@
         <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
 
-      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="a90ba944-b9f6-40a6-8184-f59ae23598fe">
-        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCxx.lib" Checksum="yes" />
+      <Component Id="libswiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="a90ba944-b9f6-40a6-8184-f59ae23598fe">
+        <File Id="libswiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libswiftCxx.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="CxxStdlib">
       <Component Id="CxxStdlib.swiftdoc" Directory="CxxStdlib.swiftmodule" Guid="a0156982-4705-4efb-8b2a-a4e5b0af7048">
-        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
       </Component>
       <Component Id="CxxStdlib.swiftinterface" Directory="CxxStdlib.swiftmodule" Guid="77d32d60-bc1b-4455-9257-9880b329170c">
-        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
       </Component>
       <Component Id="CxxStdlib.swiftmodule" Directory="CxxStdlib.swiftmodule" Guid="446847d4-09be-4377-9d25-b032d338678f">
-        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
 
       <Component Id="libswiftCxxStdlib.lib" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="654eedf7-cb83-4589-9c89-d12e8e53b9fa">

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -84,6 +84,8 @@
                               </Directory>
                               <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
                               </Directory>
+                              <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule">
+                              </Directory>
                               <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                               </Directory>
                               <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
@@ -100,11 +102,6 @@
                               </Directory>
                               <Directory Id="WindowsSDK_usr_lib_swift_windows_aarch64" Name="aarch64">
                               </Directory>
-                            </Directory>
-                          </Directory>
-                          <Directory Id="WindowsSDK_usr_lib_swift_static" Name="swift_static">
-                            <Directory Id="WindowsSDK_usr_lib_swift_static_windows" Name="windows">
-                              <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
                             </Directory>
                           </Directory>
                         </Directory>
@@ -357,20 +354,20 @@
         <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
 
-      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="f7bcc956-462e-43df-ae25-c5f4636b27d1">
-        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\swiftCxx.lib" Checksum="yes" />
+      <Component Id="libswiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="f7bcc956-462e-43df-ae25-c5f4636b27d1">
+        <File Id="libswiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\libswiftCxx.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="CxxStdlib">
       <Component Id="CxxStdlib.swiftdoc" Directory="CxxStdlib.swiftmodule" Guid="be4bf95b-6d55-4743-9872-f62621e903e1">
-        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
       </Component>
       <Component Id="CxxStdlib.swiftinterface" Directory="CxxStdlib.swiftmodule" Guid="0cd43438-de5e-4e32-832f-2505f1f37834">
-        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
       </Component>
       <Component Id="CxxStdlib.swiftmodule" Directory="CxxStdlib.swiftmodule" Guid="bd7ada20-67c4-4089-bd93-235586919d2e">
-        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
 
       <Component Id="libswiftCxxStdlib.lib" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="b30a1c97-b8af-4877-ace8-c0c9ad5e55c8">

--- a/platforms/Windows/sdk-x86.wxs
+++ b/platforms/Windows/sdk-x86.wxs
@@ -83,6 +83,8 @@
                             </Directory>
                             <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule">
                             </Directory>
+                            <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule">
+                            </Directory>
                             <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule">
                             </Directory>
                             <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule">
@@ -103,7 +105,6 @@
                         </Directory>
                         <Directory Id="WindowsSDK_usr_lib_swift_static" Name="swift_static">
                           <Directory Id="WindowsSDK_usr_lib_swift_static_windows" Name="windows">
-                            <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
                           </Directory>
                         </Directory>
                       </Directory>
@@ -355,20 +356,20 @@
         <File Id="Cxx.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
 
-      <Component Id="swiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="b2897a7a-65c2-4f0f-b14c-6b466d2e3d34">
-        <File Id="swiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\swiftCxx.lib" Checksum="yes" />
+      <Component Id="libswiftCxx.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="b2897a7a-65c2-4f0f-b14c-6b466d2e3d34">
+        <File Id="libswiftCxx.lib" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\i686\libswiftCxx.lib" Checksum="yes" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="CxxStdlib">
       <Component Id="CxxStdlib.swiftdoc" Directory="CxxStdlib.swiftmodule" Guid="6edc85d1-5db5-411b-9a15-d0ade693989a">
-        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
+        <File Id="CxxStdlib.swiftdoc" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftdoc" Checksum="yes" />
       </Component>
       <Component Id="CxxStdlib.swiftinterface" Directory="CxxStdlib.swiftmodule" Guid="9e078f6f-1c64-4af2-8ca5-7dd231c4e545">
-        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
+        <File Id="CxxStdlib.swiftinterface" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftinterface" Checksum="yes" />
       </Component>
       <Component Id="CxxStdlib.swiftmodule" Directory="CxxStdlib.swiftmodule" Guid="e49baae6-a192-4b91-af90-be5bb51d803c">
-        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
+        <File Id="CxxStdlib.swiftmodule" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftmodule" Checksum="yes" />
       </Component>
 
       <Component Id="libswiftCxxStdlib.lib" Directory="WindowsSDK_usr_lib_swift_windows_i686" Guid="f4342fea-b975-4e24-9881-8927d6ebb0fe">


### PR DESCRIPTION
These are now built statically for the dynamic standard library and should be packaged as such.