### PR TITLE
Remove SwiftIDEUtils from Windows toolchain

### DIFF
--- a/platforms/Windows/toolchain-amd64.wxs
+++ b/platforms/Windows/toolchain-amd64.wxs
@@ -783,9 +783,6 @@
       <Component Id="SwiftDiagnostics.dll" Directory="_usr_bin" Guid="7a22d954-714c-49f2-bd21-62b675aad2b1">
         <File Id="SwiftDiagnostics.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDiagnostics.dll" Checksum="yes" />
       </Component>
-      <Component Id="SwiftIDEUtils.dll" Directory="_usr_bin" Guid="688d421f-a1f2-43df-8aaf-c4bc53ebcf1e">
-        <File Id="SwiftIDEUtils.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftIDEUtils.dll" Checksum="yes" />
-      </Component>
       <Component Id="SwiftOperators.dll" Directory="_usr_bin" Guid="07895d1d-04f9-4529-b0fe-1398f8aaf547">
         <File Id="SwiftOperators.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOperators.dll" Checksum="yes" />
       </Component>

--- a/platforms/Windows/toolchain-arm64.wxs
+++ b/platforms/Windows/toolchain-arm64.wxs
@@ -783,9 +783,6 @@
       <Component Id="SwiftDiagnostics.dll" Directory="_usr_bin" Guid="7cf0d11e-48ab-4860-8ad0-1963996407e3">
         <File Id="SwiftDiagnostics.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftDiagnostics.dll" Checksum="yes" />
       </Component>
-      <Component Id="SwiftIDEUtils.dll" Directory="_usr_bin" Guid="23dd3d8a-5332-439d-8c27-da6a6b176701">
-        <File Id="SwiftIDEUtils.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftIDEUtils.dll" Checksum="yes" />
-      </Component>
       <Component Id="SwiftOperators.dll" Directory="_usr_bin" Guid="b69d4cd7-e924-4174-b976-f655ec40bfbc">
         <File Id="SwiftOperators.dll" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\SwiftOperators.dll" Checksum="yes" />
       </Component>


### PR DESCRIPTION
With FetchContent changes in swift repo, SwiftIDEUtils.dll is no longer installed in the toolchain.