### PR TITLE
Install the VC++ redistributable as part of the Swift toolchain installer

### DIFF
--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -2,10 +2,12 @@
   <PropertyGroup>
     <OutputType>Bundle</OutputType>
     <DefaultCompressionLevel>$(BundleCompressionLevel)</DefaultCompressionLevel>
+    <VSMajorVersion Condition=" '$(VSVersion)' != '' ">$(VSVersion.Split('.')[0])</VSMajorVersion>
+    <VCRedistDownloadUrl Condition=" '$(VCRedistDownloadUrl)' == '' AND '$(VSMajorVersion)' != '' ">https://aka.ms/vs/$(VSMajorVersion)/release/vc_redist.$(ProductArchitecture).exe</VCRedistDownloadUrl>
     <DefineConstants>
       $(DefineConstants);
-      VCREDIST_INSTALLER=$(VCREDIST_INSTALLER);
-      VCREDIST_VERSION=$(VCREDIST_VERSION);
+      VCRedistInstaller=$(VCRedistInstaller);
+      VCRedistDownloadUrl=$(VCRedistDownloadUrl);
       INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
     </DefineConstants>

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -4,6 +4,8 @@
     <DefaultCompressionLevel>$(BundleCompressionLevel)</DefaultCompressionLevel>
     <DefineConstants>
       $(DefineConstants);
+      VCREDIST_INSTALLER=$(VCREDIST_INSTALLER);
+      VCREDIST_VERSION=$(VCREDIST_VERSION);
       INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
     </DefineConstants>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -59,23 +59,14 @@
     -->
 
     <Chain>
-      <?if $(VCREDIST_INSTALLER) != ""?>
-        <ExePackage
-          SourceFile="$(VCREDIST_INSTALLER)"
+      <?if $(VCRedistInstaller) != ""?>
+        <BundlePackage
+          SourceFile="$(VCRedistInstaller)"
           InstallCondition="OptionsInstallRtl"
           Permanent="yes"
           InstallArguments="/install /quiet /norestart"
-          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
-          <!--
-            Install only if not already in Add/Remove Programs
-            under the GUID below.
-            TODO: Is this the right GUID for arm64?
-          -->
-          <ArpEntry 
-            Id="9e10fdb5-a50b-4c3b-98a4-aefac04e5970"
-            Version="$(VCREDIST_VERSION)"
-            Win64="yes" />
-        </ExePackage>
+          DownloadUrl="$(VCRedistDownloadUrl)">
+        </BundlePackage>
       <?endif?>
 
       <MsiPackage

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -59,6 +59,25 @@
     -->
 
     <Chain>
+      <?if $(VCREDIST_INSTALLER) != ""?>
+        <ExePackage
+          SourceFile="$(VCREDIST_INSTALLER)"
+          InstallCondition="OptionsInstallRtl"
+          Permanent="yes"
+          InstallArguments="/install /quiet /norestart"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <!--
+            Install only if not already in Add/Remove Programs
+            under the GUID below.
+            TODO: Is this the right GUID for arm64?
+          -->
+          <ArpEntry 
+            Id="9e10fdb5-a50b-4c3b-98a4-aefac04e5970"
+            Version="$(VCREDIST_VERSION)"
+            Win64="yes" />
+        </ExePackage>
+      <?endif?>
+
       <MsiPackage
         SourceFile="!(bindpath.rtl)\rtl.msi"
         InstallCondition="OptionsInstallRtl"


### PR DESCRIPTION
Packages the VC++ redistributable and installs it as part of the toolchain install on Windows, since this is a dependency. Note that this will pop a UAC prompt because that installer is per-machine.

This is the [Microsoft-recommended approach](https://learn.microsoft.com/en-us/cpp/windows/deployment-in-visual-cpp?view=msvc-170): run the vcredist installer to install it globally (which makes it serviceable by microsoft), and don't uninstall it when uninstalling the toolchain since other apps may depend on it.

This requires [build script changes](https://github.com/compnerd/swift-build/pull/664) to take effect, but is backwards compatible with build scripts that don't specify the new properties.

I consciously departed from `ALL_CAPS` naming of properties because the MSBuild standard is `PascalCase` and the logic in `installer.wixproj` was looking really ugly otherwise.

# How tested:
Built with and without build script changes, uninstalled the VC runtime, installed the Swift toolchain, and verified that the VC runtime was installed in Add/Remove programs:

![image](https://github.com/apple/swift-installer-scripts/assets/2314287/96a885bb-f5ea-4a9a-ae6d-a14e9726b055)
<img width="695" alt="image" src="https://github.com/apple/swift-installer-scripts/assets/2314287/0fbc5a4f-efe8-444e-b235-c12ec5399c74">
