### PR TITLE
WiX: package the VC redist as part of the installation

### DIFF
--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -2,8 +2,12 @@
   <PropertyGroup>
     <OutputType>Bundle</OutputType>
     <DefaultCompressionLevel>$(BundleCompressionLevel)</DefaultCompressionLevel>
+    <VSMajorVersion Condition=" '$(VSVersion)' != '' ">$(VSVersion.Split('.')[0])</VSMajorVersion>
+    <VCRedistDownloadUrl Condition=" '$(VCRedistDownloadUrl)' == '' AND '$(VSMajorVersion)' != '' ">https://aka.ms/vs/$(VSMajorVersion)/release/vc_redist.$(ProductArchitecture).exe</VCRedistDownloadUrl>
     <DefineConstants>
       $(DefineConstants);
+      VCRedistInstaller=$(VCRedistInstaller);
+      VCRedistDownloadUrl=$(VCRedistDownloadUrl);
       INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
     </DefineConstants>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -59,6 +59,16 @@
     -->
 
     <Chain>
+      <?if $(VCRedistInstaller) != ""?>
+        <BundlePackage
+          SourceFile="$(VCRedistInstaller)"
+          InstallCondition="OptionsInstallRtl"
+          Permanent="yes"
+          InstallArguments="/install /quiet /norestart"
+          DownloadUrl="$(VCRedistDownloadUrl)">
+        </BundlePackage>
+      <?endif?>
+
       <MsiPackage
         SourceFile="!(bindpath.rtl)\rtl.msi"
         InstallCondition="OptionsInstallRtl"


### PR DESCRIPTION
The compilers and runtime depend on the runtime. Introduce a dependency on the runtime for the VC runtime, which is a dependency for the build tools.  This should allow us to be more self-contained (there is a dependency on WinSDK and VS if not cross-compiling to another platform).