### PR TITLE
WiX: avoid using extended versioning on the MSIs

### DIFF
--- a/platforms/Windows/Directory.Build.props
+++ b/platforms/Windows/Directory.Build.props
@@ -89,6 +89,7 @@
       $(DefineConstants);
       ProductArchitecture=$(ProductArchitecture);
       ProductVersion=$(ProductVersion);
+      NonSemVerProductVersion=$(NonSemVerProductVersion);
       MajorMinorProductVersion=$(MajorMinorProductVersion);
       PackageScope=$(PackageScope);
       IsBundleCompressed=$(IsBundleCompressed);

--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -4,7 +4,7 @@
       Manufacturer="!(loc.ManufacturerName)"
       Name="!(loc.Bld_ProductName)"
       UpgradeCode="$(BldUpgradeCode)"
-      Version="$(ProductVersion)"
+      Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
     <Media Id="1" Cabinet="bld.cab" EmbedCab="$(ArePackageCabsEmbedded)" />

--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -4,7 +4,7 @@
       Manufacturer="!(loc.ManufacturerName)"
       Name="!(loc.Cli_ProductName)"
       UpgradeCode="$(CliUpgradeCode)"
-      Version="$(ProductVersion)"
+      Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
     <Media Id="1" Cabinet="cli.cab" EmbedCab="$(ArePackageCabsEmbedded)" />

--- a/platforms/Windows/dbg/dbg.wxs
+++ b/platforms/Windows/dbg/dbg.wxs
@@ -4,7 +4,7 @@
       Manufacturer="!(loc.ManufacturerName)"
       Name="!(loc.Dbg_ProductName)"
       UpgradeCode="$(DbgUpgradeCode)"
-      Version="$(ProductVersion)"
+      Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
     <Media Id="1" Cabinet="dbg.cab" EmbedCab="$(ArePackageCabsEmbedded)" />

--- a/platforms/Windows/ide/ide.wxs
+++ b/platforms/Windows/ide/ide.wxs
@@ -4,7 +4,7 @@
       Manufacturer="!(loc.ManufacturerName)"
       Name="!(loc.Ide_ProductName)"
       UpgradeCode="$(IdeUpgradeCode)"
-      Version="$(ProductVersion)"
+      Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
     <Media Id="1" Cabinet="ide.cab" EmbedCab="$(ArePackageCabsEmbedded)" />

--- a/platforms/Windows/rtl/msi/rtlmsi.wxs
+++ b/platforms/Windows/rtl/msi/rtlmsi.wxs
@@ -4,7 +4,7 @@
       Manufacturer="!(loc.ManufacturerName)"
       Name="!(loc.Rtl_ProductName_$(ProductArchitecture))"
       UpgradeCode="$(RtlUpgradeCode)"
-      Version="$(ProductVersion)"
+      Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
     <Media Id="1" Cabinet="rtl.cab" EmbedCab="$(ArePackageCabsEmbedded)" />

--- a/platforms/Windows/rtl/msm/rtlmsm.wxs
+++ b/platforms/Windows/rtl/msm/rtlmsm.wxs
@@ -12,7 +12,7 @@
     Guid="$(ModuleId)"
     Id="swift_runtime"
     Language="0"
-    Version="$(ProductVersion)">
+    Version="$(NonSemVerProductVersion)">
 
     <ComponentGroupRef Id="swift_runtime_$(ProductArchitecture)" />
   </Module>

--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -20,7 +20,7 @@
       Manufacturer="!(loc.ManufacturerName)"
       Name="!(loc.Sdk_ProductName_$(ProductArchitecture))"
       UpgradeCode="$(SdkUpgradeCode)"
-      Version="$(ProductVersion)"
+      Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
     <Media Id="1" Cabinet="sdk.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -134,7 +134,7 @@
 
     <Upgrade Id="!(wix.SideBySidePackageUpgradeCode)">
       <UpgradeVersion Minimum="$(MajorMinorProductVersion).65535" IncludeMinimum="no" OnlyDetect="yes" Property="NEWERVERSIONDETECTED" />
-      <UpgradeVersion Minimum="$(MajorMinorProductVersion).0" IncludeMinimum="yes" Maximum="$(ProductVersion)" IncludeMaximum="yes" Property="OLDERVERSIONBEINGUPGRADED" />
+      <UpgradeVersion Minimum="$(MajorMinorProductVersion).0" IncludeMinimum="yes" Maximum="$(NonSemVerProductVersion)" IncludeMaximum="yes" Property="OLDERVERSIONBEINGUPGRADED" />
     </Upgrade>
   </Fragment>
 


### PR DESCRIPTION
`<Package>` versions must be merely uint16's with no trailing `-`. We used to handle this in `build.ps1` on a per-wixproj basis before the refactoring that made `installer.wixproj` drive the whole build. The `<Bundle>` version still keeps using the semantic version suffix because that is supported.