### PR TITLE
Package the VC runtime dlls directly

### DIFF
--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -6,8 +6,6 @@
     <VCRedistDownloadUrl Condition=" '$(VCRedistDownloadUrl)' == '' AND '$(VSMajorVersion)' != '' ">https://aka.ms/vs/$(VSMajorVersion)/release/vc_redist.$(ProductArchitecture).exe</VCRedistDownloadUrl>
     <DefineConstants>
       $(DefineConstants);
-      VCRedistInstaller=$(VCRedistInstaller);
-      VCRedistDownloadUrl=$(VCRedistDownloadUrl);
       INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
     </DefineConstants>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -59,15 +59,6 @@
     -->
 
     <Chain>
-      <?if $(VCRedistInstaller) != ""?>
-        <BundlePackage
-          SourceFile="$(VCRedistInstaller)"
-          Permanent="yes"
-          InstallArguments="/install /quiet /norestart"
-          DownloadUrl="$(VCRedistDownloadUrl)">
-        </BundlePackage>
-      <?endif?>
-
       <MsiPackage
         SourceFile="!(bindpath.rtl)\rtl.msi"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">

--- a/platforms/Windows/rtl/msi/rtlmsi.wixproj
+++ b/platforms/Windows/rtl/msi/rtlmsi.wixproj
@@ -18,4 +18,19 @@
   <ItemGroup Condition=" '$(ProductArchitecture)' == 'arm64' ">
     <ProjectReference Include="..\lib\rtllib.wixproj" Properties="ProductArchitecture=arm64;Platform=arm64" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Heat" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <HarvestDirectory Include="$(VCRedistDir)">
+      <ComponentGroupName>VCRuntime_$(ProductArchitecture)</ComponentGroupName>
+      <DirectoryRefId>RUNTIMEDIR_$(ProductArchitecture)</DirectoryRefId>
+      <PreprocessorVariable>var.VCRedistDir</PreprocessorVariable>
+      <SuppressCom>true</SuppressCom>
+      <SuppressRegistry>true</SuppressRegistry>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+    </HarvestDirectory>
+  </ItemGroup>
 </Project>

--- a/platforms/Windows/rtl/msi/rtlmsi.wixproj
+++ b/platforms/Windows/rtl/msi/rtlmsi.wixproj
@@ -1,6 +1,10 @@
 <Project Sdk="WixToolset.Sdk/4.0.1">
   <PropertyGroup>
     <OutputName>rtl</OutputName>
+    <DefineConstants>
+      $(DefineConstants);
+      VCRedistDir=$(VCRedistDir);
+    </DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(ProductArchitecture)' == 'x86' ">

--- a/platforms/Windows/rtl/msi/rtlmsi.wxs
+++ b/platforms/Windows/rtl/msi/rtlmsi.wxs
@@ -16,11 +16,48 @@
     <DirectoryRef Id="runtimes_usr_bin" />
     <SetDirectory Id="RUNTIMEDIR_$(ProductArchitecture)" Value="[runtimes_usr_bin]" Sequence="first" />
 
+    <ComponentGroup Id="vcruntime_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component>
+        <File Source="$(VCRedistDir)\concrt140.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\msvcp140.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\msvcp140_1.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\msvcp140_2.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\msvcp140_atomic_wait.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\msvcp140_codecvt_ids.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\vccorlib140.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\vcruntime140.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\vcruntime140_1.dll" />
+      </Component>
+      <Component>
+        <File Source="$(VCRedistDir)\vcruntime140_threads.dll" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="EnvironmentVariables" Directory="RUNTIMEDIR_$(ProductArchitecture)">
       <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Guid="b83f6521-8708-4e2d-afef-076d8cdd7528">
         <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[runtimes_usr_bin]" />
       </Component>
     </ComponentGroup>
+
+    <Feature Id="VCRuntime" AllowAbsent="no" Title="!(loc.VCRuntime_ProductName_$(ProductArchitecture))">
+      <ComponentGroupRef Id="vcruntime_$(ProductArchitecture)" />
+    </Feature>
 
     <Feature Id="SwiftRuntime" AllowAbsent="no" Title="!(loc.Rtl_ProductName_$(ProductArchitecture))">
       <ComponentGroupRef Id="swift_runtime_$(ProductArchitecture)" />

--- a/platforms/Windows/rtl/msi/rtlmsi.wxs
+++ b/platforms/Windows/rtl/msi/rtlmsi.wxs
@@ -17,6 +17,7 @@
     <SetDirectory Id="RUNTIMEDIR_$(ProductArchitecture)" Value="[runtimes_usr_bin]" Sequence="first" />
 
     <ComponentGroup Id="vcruntime_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <?if $(VCRedistDir) != "" ?>
       <Component>
         <File Source="$(VCRedistDir)\concrt140.dll" />
       </Component>
@@ -47,6 +48,7 @@
       <Component>
         <File Source="$(VCRedistDir)\vcruntime140_threads.dll" />
       </Component>
+      <?endif?>
     </ComponentGroup>
 
     <ComponentGroup Id="EnvironmentVariables" Directory="RUNTIMEDIR_$(ProductArchitecture)">

--- a/platforms/Windows/rtl/msi/rtlmsi.wxs
+++ b/platforms/Windows/rtl/msi/rtlmsi.wxs
@@ -16,41 +16,6 @@
     <DirectoryRef Id="runtimes_usr_bin" />
     <SetDirectory Id="RUNTIMEDIR_$(ProductArchitecture)" Value="[runtimes_usr_bin]" Sequence="first" />
 
-    <ComponentGroup Id="vcruntime_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
-      <?if $(VCRedistDir) != "" ?>
-      <Component>
-        <File Source="$(VCRedistDir)\concrt140.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\msvcp140.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\msvcp140_1.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\msvcp140_2.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\msvcp140_atomic_wait.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\msvcp140_codecvt_ids.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\vccorlib140.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\vcruntime140.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\vcruntime140_1.dll" />
-      </Component>
-      <Component>
-        <File Source="$(VCRedistDir)\vcruntime140_threads.dll" />
-      </Component>
-      <?endif?>
-    </ComponentGroup>
-
     <ComponentGroup Id="EnvironmentVariables" Directory="RUNTIMEDIR_$(ProductArchitecture)">
       <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Guid="b83f6521-8708-4e2d-afef-076d8cdd7528">
         <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[runtimes_usr_bin]" />
@@ -58,7 +23,7 @@
     </ComponentGroup>
 
     <Feature Id="VCRuntime" AllowAbsent="no" Title="!(loc.VCRuntime_ProductName_$(ProductArchitecture))">
-      <ComponentGroupRef Id="vcruntime_$(ProductArchitecture)" />
+      <ComponentGroupRef Id="VCRuntime_$(ProductArchitecture)" />
     </Feature>
 
     <Feature Id="SwiftRuntime" AllowAbsent="no" Title="!(loc.Rtl_ProductName_$(ProductArchitecture))">

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -7,6 +7,9 @@
   <String Id="Dbg_ProductName" Value="Swift Debugging Tools" />
   <String Id="Ide_ProductName" Value="Swift IDE Integration Tools" />
   <String Id="Rtl_ProductName" Value="Swift Windows Utilities" />
+  <String Id="VCRuntime_ProductName_arm64" Value="Visual C++ Runtime (ARM64)" />
+  <String Id="VCRuntime_ProductName_amd64" Value="Visual C++ Runtime (AMD64)" />
+  <String Id="VCRuntime_ProductName_x86" Value="Visual C++ Runtime (X86)" />
   <String Id="Rtl_ProductName_arm64" Value="Swift Windows Utilities (ARM64)" />
   <String Id="Rtl_ProductName_amd64" Value="Swift Windows Utilities (AMD64)" />
   <String Id="Rtl_ProductName_x86" Value="Swift Windows Utilities (X86)" />


### PR DESCRIPTION
The Swift runtime depends on the Visual C++ runtime. We currently call the `vcredist.exe` installer, as recommended by Microsoft, but this is a per-machine installer so it makes our per-user installer require elevation. I tried switching to using the vcredist merge modules, but they seem to reference machine-global paths like System64 and it causes build errors. We're left with the option to package the vcruntime dlls directly in the msi. We're not including them in the Swift runtime msm's since application developers may choose to distribute their vcruntime differently.

The new `VCRedistDir` property is optional so that this remains backwards compatible with build scripts that don't specify it.

Result:
<img width="570" alt="image" src="https://github.com/apple/swift-installer-scripts/assets/2314287/04cc1e8a-8223-4faf-a2d9-f08d955f207b">