### PR TITLE
WiX: add `SwiftIDEUtils.dll` to the image

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -343,6 +343,9 @@
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftDiagnostics.dll" />
       </Component>
       <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftIDEUtils.dll" />
+      </Component>
+      <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftOperators.dll" />
       </Component>
       <Component>


### PR DESCRIPTION
This adds an additional DLL to the image.  The compiler is now able to vend enough of the swift-syntax library to enable building the LSP without adding a second copy of the parser.  This shaves ~6MiB off of the LSP binary.