### PR TITLE
WiX: package Observable into the distribution

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -293,6 +293,12 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="SwiftMacros" Directory="_usr_bin">
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\ObservationMacros.dll" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="argument_parser" Directory="_usr_bin">
       <Component>
         <File Source="$(DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" />
@@ -383,6 +389,7 @@
       <ComponentGroupRef Id="tools_support_core" />
       <ComponentGroupRef Id="swift_driver" />
       <ComponentGroupRef Id="swift_syntax" />
+      <ComponentGroupRef Id="SwiftMacros" />
 
       <ComponentGroupRef Id="ClangResources" />
 

--- a/platforms/Windows/rtl/lib/rtllib.wxs
+++ b/platforms/Windows/rtl/lib/rtllib.wxs
@@ -42,6 +42,9 @@
         <File Source="$(SDK_ROOT)\usr\bin\swiftCRT.dll" />
       </Component>
       <Component>
+        <File Source="$(SDK_ROOT)\usr\bin\swiftObservation.dll" />
+      </Component>
+      <Component>
         <File Source="$(SDK_ROOT)\usr\bin\swiftRemoteMirror.dll" />
       </Component>
       <Component>

--- a/platforms/Windows/rtl/lib/rtllib.wxs
+++ b/platforms/Windows/rtl/lib/rtllib.wxs
@@ -21,6 +21,9 @@
         <File Source="$(SDK_ROOT)\usr\bin\swiftDistributed.dll" />
       </Component>
       <Component>
+        <File Source="$(SDK_ROOT)\usr\bin\swiftRegexBuilder.dll" />
+      </Component>
+      <Component>
         <File Source="$(SDK_ROOT)\usr\bin\swift_RegexParser.dll" />
       </Component>
       <Component>

--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -92,6 +92,7 @@
                       <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule" />
                       <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule" />
                       <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule" />
+                      <Directory Id="Observation.swiftmodule" Name="Observation.swiftmodule" />
                       <Directory Id="RegexBuilder.swiftmodule" Name="RegexBuilder.swiftmodule" />
                       <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule" />
                       <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule" />
@@ -378,6 +379,21 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="Observation" Directory="Observation.swiftmodule">
+      <Component>
+        <File Name="$(ArchTriple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\windows\Observation.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Name="$(ArchTriple).swiftinterface" Source="$(SDK_ROOT)\usr\lib\swift\windows\Observation.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Name="$(ArchTriple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\windows\Observation.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="WindowsSDK_usr_lib_swift_windows_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\$(ArchArchDir)\swiftObservation.lib" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="RegexBuilder" Directory="RegexBuilder.swiftmodule">
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\RegexBuilder.swiftmodule\$(ArchTriple).swiftdoc" />
@@ -518,6 +534,7 @@
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationXML" />
       <ComponentGroupRef Id="FoundationNetworking" />
+      <ComponentGroupRef Id="Observation" />
       <ComponentGroupRef Id="RegexBuilder" />
       <ComponentGroupRef Id="Swift" />
       <ComponentGroupRef Id="SwiftOnoneSupport" />

--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -92,6 +92,7 @@
                       <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule" />
                       <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule" />
                       <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule" />
+                      <Directory Id="RegexBuilder.swiftmodule" Name="RegexBuilder.swiftmodule" />
                       <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule" />
                       <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule" />
                       <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule" />
@@ -377,6 +378,21 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="RegexBuilder" Directory="RegexBuilder.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\RegexBuilder.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\RegexBuilder.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\RegexBuilder.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="WindowsSDK_usr_lib_swift_windows_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\$(ArchArchDir)\swiftRegexBuilder.lib" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Swift" Directory="Swift.swiftmodule">
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\$(ArchTriple).swiftdoc" />
@@ -502,6 +518,7 @@
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationXML" />
       <ComponentGroupRef Id="FoundationNetworking" />
+      <ComponentGroupRef Id="RegexBuilder" />
       <ComponentGroupRef Id="Swift" />
       <ComponentGroupRef Id="SwiftOnoneSupport" />
       <ComponentGroupRef Id="WinSDK" />


### PR DESCRIPTION
Include the Observable module in the SDK and runtime.  Additionally,
include the observable macros for the toolchain into the build tools.