### PR TITLE
Amazon Linux 2023 / x64 / release/5.8

### DIFF
--- a/platforms/Linux/RPM/Amazonlinux/2023/Dockerfile
+++ b/platforms/Linux/RPM/Amazonlinux/2023/Dockerfile
@@ -1,0 +1,31 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+FROM amazonlinux:2023
+LABEL PURPOSE="This image is configured to build Swift for the version of Amazon Linux listed above"
+
+RUN dnf -y update
+
+# RPM and yum development tools
+RUN dnf install -y rpmdevtools yum-utils createrepo
+
+# Compile ld.gold from the source and install it.
+ADD install_ld.gold.sh /tmp/install_ld.gold.sh
+RUN chmod u+x /tmp/install_ld.gold.sh
+RUN cd tmp && ./install_ld.gold.sh
+
+# Optimization: Install Swift build requirements listed in the spec file
+ADD swiftlang.spec /tmp/swiftlang.spec
+
+# rewrite a minimal spec with the build requirements
+RUN echo -e "Name: optimization\nVersion: optimization\nRelease: optimization\nSummary: optimization\nLicense: optimization\n" > /tmp/optimization.spec
+RUN cat /tmp/swiftlang.spec | grep BuildRequires >> /tmp/optimization.spec
+RUN echo -e "\n%description" >> /tmp/optimization.spec
+# install the build requirements
+RUN cd /tmp && yum-builddep -y optimization.spec
+

--- a/platforms/Linux/RPM/Amazonlinux/2023/README.md
+++ b/platforms/Linux/RPM/Amazonlinux/2023/README.md
@@ -1,0 +1,31 @@
+# Building Swift on Amazon Linux
+
+
+### building with docker-compose
+
+* to run the build end-to-end
+
+```
+docker-compose run build
+```
+
+* to enter the docker env in shell mode
+
+```
+docker-compose run shell
+```
+
+then you can run `./build_rpm.sh` to run the build manually inside the docker
+
+
+* to rebuild the base image
+
+```
+docker-compose build --pull
+```
+
+note this still uses the docker cache, so will rebuild only if the version of the underlying base image changed upstream
+
+
+### Open Issues / TODO
+* the list of build requirements (BuildRequires) and especially requirements (Requires) should come from an external file, likely one per swift release version (which we can use it to also drive documentation)

--- a/platforms/Linux/RPM/Amazonlinux/2023/build_rpm.sh
+++ b/platforms/Linux/RPM/Amazonlinux/2023/build_rpm.sh
@@ -1,0 +1,1 @@
+../../Shared/scripts/build_rpm.sh

--- a/platforms/Linux/RPM/Amazonlinux/2023/createrepo_rpm.sh
+++ b/platforms/Linux/RPM/Amazonlinux/2023/createrepo_rpm.sh
@@ -1,0 +1,1 @@
+../../Shared/scripts/createrepo_rpm.sh

--- a/platforms/Linux/RPM/Amazonlinux/2023/description.inc
+++ b/platforms/Linux/RPM/Amazonlinux/2023/description.inc
@@ -1,0 +1,1 @@
+../../Shared/metadata/description.inc

--- a/platforms/Linux/RPM/Amazonlinux/2023/docker-compose.yaml
+++ b/platforms/Linux/RPM/Amazonlinux/2023/docker-compose.yaml
@@ -1,0 +1,47 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+# this setup is designed to build the RPM with docker
+# usage:
+# docker-compose -f platforms/Linux/amazonlinux/2/docker-compose.yaml build
+# to shell into the container for debugging purposes:
+# docker-compose -f platforms/Linux/amazonlinux/2/docker-compose.yaml run build
+
+version: "3"
+
+services:
+
+  docker-setup:
+    image: amazonlinux-2023-rpm-builder
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+  common: &common
+    image: amazonlinux-2023-rpm-builder
+    depends_on: [docker-setup]
+    volumes:
+      - ../../Amazonlinux/2023:/code/Amazonlinux/2023:z
+      - ../../Shared:/code/Shared:z
+      - ./.output:/output:z
+    working_dir: /code/Amazonlinux/2023
+    cap_drop:
+      - CAP_NET_RAW
+      - CAP_NET_BIND_SERVICE
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "./build_rpm.sh"
+
+  createrepo:
+    <<: *common
+    command: /bin/bash -cl "./createrepo_rpm.sh"
+
+  shell:
+    <<: *common
+    entrypoint: /bin/bash -l

--- a/platforms/Linux/RPM/Amazonlinux/2023/global.inc
+++ b/platforms/Linux/RPM/Amazonlinux/2023/global.inc
@@ -1,0 +1,1 @@
+../../Shared/metadata/global.inc

--- a/platforms/Linux/RPM/Amazonlinux/2023/install_ld.gold.sh
+++ b/platforms/Linux/RPM/Amazonlinux/2023/install_ld.gold.sh
@@ -1,0 +1,16 @@
+dnf install gmp-devel mpfr-devel texinfo bison git gcc-c++ -y
+
+mkdir ld.gold && cd ld.gold
+git clone --depth 1 git://sourceware.org/git/binutils-gdb.git binutils
+
+mkdir build && cd build
+../binutils/configure --enable-gold --enable-plugins --disable-werror
+make all-gold
+cd gold
+make all-am
+cd ..
+
+cp gold/ld-new /usr/bin/ld.gold
+cd ../..
+
+/usr/bin/ld.gold -v

--- a/platforms/Linux/RPM/Amazonlinux/2023/metadata.inc
+++ b/platforms/Linux/RPM/Amazonlinux/2023/metadata.inc
@@ -1,0 +1,1 @@
+../../Shared/metadata/metadata.inc

--- a/platforms/Linux/RPM/Amazonlinux/2023/patches/hwasan_symbolize.patch
+++ b/platforms/Linux/RPM/Amazonlinux/2023/patches/hwasan_symbolize.patch
@@ -1,0 +1,10 @@
+diff --git a/llvm-project/compiler-rt/lib/hwasan/scripts/hwasan_symbolize b/llvm-project/compiler-rt/lib/hwasan/scripts/hwasan_symbolize
+index dd5f859561e1..21d18998cf31 100755
+--- a/llvm-project/compiler-rt/lib/hwasan/scripts/hwasan_symbolize
++++ b/llvm-project/compiler-rt/lib/hwasan/scripts/hwasan_symbolize
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #===- lib/hwasan/scripts/hwasan_symbolize ----------------------------------===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/platforms/Linux/RPM/Amazonlinux/2023/swiftlang.spec
+++ b/platforms/Linux/RPM/Amazonlinux/2023/swiftlang.spec
@@ -1,0 +1,169 @@
+%include global.inc
+%include metadata.inc
+
+Source0:        https://github.com/apple/swift/archive/swift-%{swift_version}.tar.gz#/swift.tar.gz
+Source1:        https://github.com/apple/swift-corelibs-libdispatch/archive/swift-%{swift_version}.tar.gz#/corelibs-libdispatch.tar.gz
+Source2:        https://github.com/apple/swift-corelibs-foundation/archive/swift-%{swift_version}.tar.gz#/corelibs-foundation.tar.gz
+Source3:        https://github.com/apple/swift-integration-tests/archive/swift-%{swift_version}.tar.gz#/swift-integration-tests.tar.gz
+Source4:        https://github.com/apple/swift-corelibs-xctest/archive/swift-%{swift_version}.tar.gz#/corelibs-xctest.tar.gz
+Source5:        https://github.com/apple/swift-package-manager/archive/swift-%{swift_version}.tar.gz#/package-manager.tar.gz
+Source6:        https://github.com/apple/swift-llbuild/archive/swift-%{swift_version}.tar.gz#/llbuild.tar.gz
+Source7:        https://github.com/apple/swift-cmark/archive/swift-%{swift_version}.tar.gz#/cmark.tar.gz
+Source8:        https://github.com/apple/swift-xcode-playground-support/archive/swift-%{swift_version}.tar.gz#/swift-xcode-playground-support.tar.gz
+Source9:        https://github.com/apple/sourcekit-lsp/archive/swift-%{swift_version}.tar.gz#/sourcekit-lsp.tar.gz
+Source10:       https://github.com/apple/indexstore-db/archive/swift-%{swift_version}.tar.gz#/indexstore-db.tar.gz
+Source11:       https://github.com/apple/llvm-project/archive/swift-%{swift_version}.tar.gz#/llvm-project.tar.gz
+Source12:       https://github.com/apple/swift-tools-support-core/archive/swift-%{swift_version}.tar.gz#/swift-tools-support-core.tar.gz
+Source13:       https://github.com/apple/swift-argument-parser/archive/%{swift_argument_parser_version}.tar.gz#/swift-argument-parser.tar.gz
+Source14:       https://github.com/apple/swift-driver/archive/swift-%{swift_version}.tar.gz#/swift-driver.tar.gz
+Source15:       https://github.com/unicode-org/icu/archive/release-%{icu_version}.tar.gz#/icu.tar.gz
+Source16:       https://github.com/apple/swift-syntax/archive/swift-%{swift_version}.zip#/swift-syntax.tar.gz
+Source17:       https://github.com/jpsim/Yams/archive/%{yams_version}.tar.gz#/yams.tar.gz
+Source18:       https://github.com/apple/swift-crypto/archive/refs/tags/%{swift_crypto_version}.tar.gz#/swift-crypto.tar.gz
+Source19:       https://github.com/ninja-build/ninja/archive/refs/tags/v%{ninja_version}.tar.gz#/ninja.tar.gz
+Source20:       https://github.com/KitWare/CMake/archive/refs/tags/v%{cmake_version}.tar.gz#/cmake.tar.gz
+Source21:       https://github.com/apple/swift-atomics/archive/%{swift_atomics_version}.tar.gz#/swift-atomics.tar.gz
+Source23:       https://github.com/apple/swift-docc/archive/swift-%{swift_version}.tar.gz#/swift-docc.tar.gz
+Source24:       https://github.com/apple/swift-docc-render-artifact/archive/swift-%{swift_version}.tar.gz#/swift-docc-render-artifact.tar.gz
+Source25:       https://github.com/apple/swift-docc-symbolkit/archive/swift-%{swift_version}.tar.gz#/swift-docc-symbolkit.tar.gz
+Source26:       https://github.com/apple/swift-collections/archive/%{swift_collections_version}.tar.gz#/swift-collections.tar.gz
+Source27:       https://github.com/apple/swift-numerics/archive/%{swift_numerics_version}.tar.gz#/swift-numerics.tar.gz
+Source28:       https://github.com/apple/swift-system/archive/%{swift_system_version}.tar.gz#/swift-system.tar.gz
+Source29:       https://github.com/apple/swift-nio/archive/%{swift_nio_version}.tar.gz#/swift-nio.tar.gz
+Source30:       https://github.com/apple/swift-nio-ssl/archive/%{swift_nio_ssl_version}.tar.gz#/swift-nio-ssl.tar.gz
+Source31:       https://github.com/apple/swift-format/archive/swift-%{swift_version}.tar.gz#/swift-format.tar.gz
+Source32:       https://github.com/apple/swift-lmdb/archive/swift-%{swift_version}.tar.gz#/swift-lmdb.tar.gz
+Source33:       https://github.com/apple/swift-markdown/archive/swift-%{swift_version}.tar.gz#/swift-markdown.tar.gz
+Source34:       https://github.com/apple/swift-experimental-string-processing/archive/swift-%{swift_version}.tar.gz#/swift-experimental-string-processing.tar.gz
+
+Patch0:         patches/hwasan_symbolize.patch
+
+BuildRequires:  clang
+BuildRequires:  curl-devel
+BuildRequires:  gcc-c++
+BuildRequires:  git
+BuildRequires:  glibc-static
+BuildRequires:  libbsd-devel
+BuildRequires:  libedit-devel
+BuildRequires:  libicu-devel
+BuildRequires:  libuuid-devel
+BuildRequires:  libxml2-devel
+BuildRequires:  make
+BuildRequires:  ncurses-devel
+BuildRequires:  python-pexpect
+BuildRequires:  pkgconfig
+BuildRequires:  procps-ng
+BuildRequires:  python
+BuildRequires:  python-devel
+BuildRequires:  python3-pkgconfig
+BuildRequires:  python-six
+BuildRequires:  python3-devel
+BuildRequires:  rsync
+BuildRequires:  sqlite-devel
+BuildRequires:  swig
+BuildRequires:  tzdata
+BuildRequires:  uuid-devel
+BuildRequires:  wget
+BuildRequires:  which
+
+Requires:       binutils
+Requires:       gcc
+Requires:       git
+Requires:       glibc-static
+Requires:       gzip
+Requires:       libbsd
+Requires:       libcurl-devel
+Requires:       libedit
+Requires:       libicu
+Requires:       libstdc++-static
+Requires:       libuuid
+Requires:       libxml2-devel
+Requires:       sqlite
+Requires:       tar
+Requires:       tzdata
+Requires:       unzip
+Requires:       zip
+
+ExclusiveArch:  x86_64 aarch64
+
+%description
+%include description.inc
+
+%prep
+%setup -q -c -n %{swift_source_location} -a 0 -a 1 -a 2 -a 3 -a 4 -a 5 -a 6 -a 7 -a 8 -a 9 -a 10 -a 11 -a 12 -a 13 -a 14 -a 15 -a 16 -a 17 -a 18 -a 19 -a 20 -a 21 -a 23 -a 24 -a 25 -a 26 -a 27 -a 28 -a 29 -a 30 -a 31 -a 32 -a 33 -a 34
+
+# The Swift build script requires directories to be named
+# in a specific way so renaming the source directories is
+# necessary
+mv CMake-%{cmake_version} cmake
+mv icu-release-%{icu_version} icu
+mv indexstore-db-swift-%{swift_version} indexstore-db
+mv llvm-project-swift-%{swift_version} llvm-project
+mv ninja-%{ninja_version} ninja
+mv sourcekit-lsp-swift-%{swift_version} sourcekit-lsp
+mv swift-argument-parser-%{swift_argument_parser_version} swift-argument-parser
+mv swift-atomics-%{swift_atomics_version} swift-atomics
+mv swift-cmark-swift-%{swift_version} cmark
+mv swift-collections-%{swift_collections_version} swift-collections
+mv swift-corelibs-foundation-swift-%{swift_version} swift-corelibs-foundation
+mv swift-corelibs-libdispatch-swift-%{swift_version} swift-corelibs-libdispatch
+mv swift-corelibs-xctest-swift-%{swift_version} swift-corelibs-xctest
+mv swift-crypto-%{swift_crypto_version} swift-crypto
+mv swift-docc-render-artifact-swift-%{swift_version} swift-docc-render-artifact
+mv swift-docc-swift-%{swift_version} swift-docc
+mv swift-docc-symbolkit-swift-%{swift_version} swift-docc-symbolkit
+mv swift-driver-swift-%{swift_version} swift-driver
+mv swift-format-swift-%{swift_version} swift-format
+mv swift-integration-tests-swift-%{swift_version} swift-integration-tests
+mv swift-llbuild-swift-%{swift_version} llbuild
+mv swift-lmdb-swift-%{swift_version} swift-lmdb
+mv swift-markdown-swift-%{swift_version} swift-markdown
+mv swift-nio-%{swift_nio_version} swift-nio
+mv swift-nio-ssl-%{swift_nio_ssl_version} swift-nio-ssl
+mv swift-numerics-%{swift_numerics_version} swift-numerics
+mv swift-package-manager-swift-%{swift_version} swiftpm
+mv swift-swift-%{swift_version} swift
+mv swift-syntax-swift-%{swift_version} swift-syntax
+mv swift-system-%{swift_system_version} swift-system
+mv swift-tools-support-core-swift-%{swift_version} swift-tools-support-core
+mv swift-xcode-playground-support-swift-%{swift_version} swift-xcode-playground-support
+mv Yams-%{yams_version} yams
+mv swift-experimental-string-processing-swift-%{swift_version} swift-experimental-string-processing
+
+# Adjust python version hwasan_symbolize
+%patch0 -p1
+
+%build
+export VERBOSE=1
+# the flags positioned by rpmbuild conflict with the ones set by build-script. It causes this error:
+# /BUILD/swift-source/build/buildbot_linux/llvm-linux-x86_64/bin/../lib/LLVMgold.so: cannot open shared object file: No such file or directory
+# I tried this, but it does not change anything:
+# export LDFLAGS="-Wl,-L/usr/lib64 ${LDFLAGS}"
+# so, I decided to get rid of all rpmbuild's flags
+unset CFLAGS CXXFLAGS FFLAGS FCFLAGS LDFLAGS CC CXX
+
+# Run the build
+swift/utils/build-script --preset=buildbot_linux,no_assertions,no_test install_destdir=%{_builddir} installable_package=%{_builddir}/swift-%{version}-amazonlinux2023.tar.gz
+
+%install
+mkdir -p %{buildroot}%{_libexecdir}/swift/%{package_version}
+cp -r %{_builddir}/usr/* %{buildroot}%{_libexecdir}/swift/%{package_version}
+mkdir -p %{buildroot}%{_bindir}
+ln -fs %{_libexecdir}/swift/%{package_version}/bin/swift %{buildroot}%{_bindir}/swift
+ln -fs %{_libexecdir}/swift/%{package_version}/bin/swiftc %{buildroot}%{_bindir}/swiftc
+ln -fs %{_libexecdir}/swift/%{package_version}/bin/sourcekit-lsp %{buildroot}%{_bindir}/sourcekit-lsp
+mkdir -p %{buildroot}%{_mandir}/man1
+cp %{_builddir}/usr/share/man/man1/swift.1 %{buildroot}%{_mandir}/man1/swift.1
+
+%files
+%license swift/LICENSE.txt
+%{_bindir}/swift
+%{_bindir}/swiftc
+%{_bindir}/sourcekit-lsp
+%{_mandir}/man1/swift.1.gz
+%{_libexecdir}/swift/
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%changelog

--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -110,11 +110,17 @@
       <Component Id="DriverSupport.dll" Directory="_usr_bin" Guid="43b50a02-5180-49c9-b0a4-86273c822f87">
         <File Id="DriverSUpport.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.dll" Checksum="yes" />
       </Component>
+      <Component Id="PackageCollections.dll" Directory="_usr_bin" Guid="514268d3-efcc-46d9-844e-b0e813cb99ba">
+        <File Id="PackageCollections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollections.dll" Checksum="yes" />
+      </Component>
       <Component Id="PackageGraph.dll" Directory="_usr_bin" Guid="254500b8-b2ac-4c9f-add3-6511b0e5bfa7">
         <File Id="PackageGraph.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
       </Component>
       <Component Id="PackageLoading.dll" Directory="_usr_bin" Guid="cdbb8b34-7b84-48ed-8929-209a158f5d01">
         <File Id="PackageLoading.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageMetadata.dll" Directory="_usr_bin" Guid="6f403b3d-e3af-4321-8dad-9f0faf2915d5">
+        <File Id="PackageMetadata.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageMetadata.dll" Checksum="yes" />
       </Component>
       <Component Id="PackageModel.dll" Directory="_usr_bin" Guid="1e8f566e-83f0-4657-9eed-598a96a957d9">
         <File Id="PackageModel.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" Checksum="yes" />
@@ -129,8 +135,17 @@
       <Component Id="swift_build.exe" Directory="_usr_bin" Guid="5b3f6590-545c-42e3-9081-8582eb37a822">
         <File Id="swift_build.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.exe" Checksum="yes" />
       </Component>
+      <Component Id="swift_experimental_destination.exe" Directory="_usr_bin" Guid="c8201334-2fb5-475a-909b-64fe73cbb5ca">
+        <File Id="swift_experimental_destination.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-experimental-destination.exe" Checksum="yes" />
+      </Component>
       <Component Id="swift_package.exe" Directory="_usr_bin" Guid="40cee004-aa80-4948-ae39-f6ad32da56eb">
         <File Id="swift_package.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package_collection.exe" Directory="_usr_bin" Guid="9a2b16f4-6f59-42f8-b898-09a8e8e00fc1">
+        <File Id="swift_package_collection.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package-collection.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package_registry.exe" Directory="_usr_bin" Guid="0e140ce9-4e74-43a0-917f-6d643e5ef837">
+        <File Id="swift_package_registry.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package-registry.exe" Checksum="yes" />
       </Component>
       <Component Id="swift_run.exe" Directory="_usr_bin" Guid="dd9432af-c962-46ff-9639-6da39fea14f3">
         <File Id="swift_run.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.exe" Checksum="yes" />
@@ -183,11 +198,17 @@
       <Component Id="DriverSupport.pdb" Directory="_usr_bin" Guid="e228fd9f-13df-4ec5-b989-cca47925f272">
         <File Id="DriverSupport.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.pdb" Checksum="yes" />
       </Component>
+      <Component Id="PackageCollections.pdb" Directory="_usr_bin" Guid="a74f0a2d-c6ec-4a9a-97e1-bfcf7c565858">
+        <File Id="PackageCollections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollections.pdb" Checksum="yes" />
+      </Component>
       <Component Id="PackageGraph.pdb" Directory="_usr_bin" Guid="07b49917-5bdd-4491-a151-cb180a04aa90">
         <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
       </Component>
       <Component Id="PackageLoading.pdb" Directory="_usr_bin" Guid="94294eda-8c10-446c-a26f-c652bf6da155">
         <File Id="PackageLoading.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="PackageMetadata.pdb" Directory="_usr_bin" Guid="25d3539f-49be-41a9-b093-b7ce65944517">
+        <File Id="PackageMetadata.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageMetadata.pdb" Checksum="yes" />
       </Component>
       <Component Id="PackageModel.pdb" Directory="_usr_bin" Guid="3f849e3c-649f-426d-b088-d840600dbca2">
         <File Id="PackageModel.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
@@ -202,8 +223,17 @@
       <Component Id="swift_build.pdb" Directory="_usr_bin" Guid="bfea3c79-9656-4dee-8259-d041db3be1ba">
         <File Id="swift_build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
       </Component>
+      <Component Id="swift_experimental_destination.pdb" Directory="_usr_bin" Guid="15ceed68-1a0d-40c4-a177-b485151800e6">
+        <File Id="swift_experimental_destination.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-experimental-destination.pdb" Checksum="yes" />
+      </Component>
       <Component Id="swift_package.pdb" Directory="_usr_bin" Guid="0b9cf255-e141-43d3-af4b-e93984b57b4f">
         <File Id="swift_package.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package_collection.pdb" Directory="_usr_bin" Guid="8462ac6e-5c15-459d-ad4d-cf93ff2c7656">
+        <File Id="swift_package_collection.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package-collection.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package_registry.pdb" Directory="_usr_bin" Guid="d9189abb-eaf4-4b24-a93b-4c2a48312508">
+        <File Id="swift_package_registry.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package-registry.pdb" Checksum="yes" />
       </Component>
       <Component Id="swift_run.pdb" Directory="_usr_bin" Guid="aedc7604-351a-4134-baaf-6364db8d53b3">
         <File Id="swift_run.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />

--- a/platforms/Windows/devtools-amd64.wxs
+++ b/platforms/Windows/devtools-amd64.wxs
@@ -40,20 +40,6 @@
     </SetDirectory>
 
     <!-- Components -->
-    <ComponentGroup Id="SwiftCrypto">
-      <Component Id="Crypto.dll" Directory="_usr_bin" Guid="da28dfe3-2af0-45fb-b877-a5ef37da48cd">
-        <File Id="Crypto.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftCryptoDebugInfo">
-      <Component Id="Crypto.pdb" Directory="_usr_bin" Guid="e977250f-2ed1-4fd5-adb0-e4d7c0a9fbfd">
-        <File Id="Crypto.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SwiftCollections">
       <Component Id="Collections.dll" Directory="_usr_bin" Guid="fd0862f1-2e80-4040-8736-b73fc9c4230d">
         <File Id="Collections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
@@ -281,7 +267,6 @@
     <?endif?>
 
     <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows x86_64" Level="1" Title="Swift Developer Tools (Windows x86_64)">
-      <ComponentGroupRef Id="SwiftCrypto" />
       <ComponentGroupRef Id="SwiftCollections" />
       <ComponentGroupRef Id="SwiftSystem" />
       <ComponentGroupRef Id="SwiftPackageManager" />
@@ -291,7 +276,6 @@
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows x86_64" Level="0" Title="Debug Info">
         <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-        <ComponentGroupRef Id="SwiftCryptoDebugInfo" />
         <ComponentGroupRef Id="SwiftCollectionsDebugInfo" />
         <ComponentGroupRef Id="SwiftSystemDebugInfo" />
         <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -40,20 +40,6 @@
     </SetDirectory>
 
     <!-- Components -->
-    <ComponentGroup Id="SwiftCrypto">
-      <Component Id="Crypto.dll" Directory="_usr_bin" Guid="b70fbf9e-006b-4b05-9450-8b139fa90da1">
-        <File Id="Crypto.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-
-    <?ifdef INCLUDE_DEBUG_INFO ?>
-    <ComponentGroup Id="SwiftCryptoDebugInfo">
-      <Component Id="Crypto.pdb" Directory="_usr_bin" Guid="13765cd7-5212-4ce8-a3f0-83168b4e8afc">
-        <File Id="Crypto.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
-      </Component>
-    </ComponentGroup>
-    <?endif?>
-
     <ComponentGroup Id="SwiftCollections">
       <Component Id="Collections.dll" Directory="_usr_bin" Guid="b705e7a1-698a-4608-b53f-48578380696c">
         <File Id="Collections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
@@ -281,7 +267,6 @@
     <?endif?>
 
     <Feature Id="DeveloperTools" Absent="disallow" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Swift Developer Tools for Windows aarch64" Level="1" Title="Swift Developer Tools (Windows aarch64)">
-      <ComponentGroupRef Id="SwiftCrypto" />
       <ComponentGroupRef Id="SwiftCollections" />
       <ComponentGroupRef Id="SwiftSystem" />
       <ComponentGroupRef Id="SwiftPackageManager" />
@@ -291,7 +276,6 @@
       <?ifdef INCLUDE_DEBUG_INFO ?>
       <Feature Id="DebugInfo" Absent="allow" AllowAdvertise="yes" Description="Debug Information for Swift Developer Tools for Windows aarch64" Level="0" Title="Debug Info">
         <Condition Level="1">INSTALL_DEBUGINFO</Condition>
-        <ComponentGroupRef Id="SwiftCryptoDebugInfo" />
         <ComponentGroupRef Id="SwiftCollectionsDebugInfo" />
         <ComponentGroupRef Id="SwiftSystemDebugInfo" />
         <ComponentGroupRef Id="SwiftPackageManagerDebugInfo" />

--- a/platforms/Windows/devtools-arm64.wxs
+++ b/platforms/Windows/devtools-arm64.wxs
@@ -110,11 +110,17 @@
       <Component Id="DriverSupport.dll" Directory="_usr_bin" Guid="2c8f8a23-e0f3-4535-9c25-0e1300c24c32">
         <File Id="DriverSupport.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.dll" Checksum="yes" />
       </Component>
+      <Component Id="PackageCollections.dll" Directory="_usr_bin" Guid="b01dffe0-f0c6-47f4-8fb9-766d62e8137d">
+        <File Id="PackageCollections.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollections.dll" Checksum="yes" />
+      </Component>
       <Component Id="PackageGraph.dll" Directory="_usr_bin" Guid="0f4cd16f-a931-401c-9b49-9fc988e8d87e">
         <File Id="PackageGraph.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" Checksum="yes" />
       </Component>
       <Component Id="PackageLoading.dll" Directory="_usr_bin" Guid="9f086102-597f-448f-ac82-127138fba0ba">
         <File Id="PackageLoading.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" Checksum="yes" />
+      </Component>
+      <Component Id="PackageMetadata.dll" Directory="_usr_bin" Guid="a4cf92fd-d212-46d4-abf8-da7ec9cd9d5f">
+        <File Id="PackageMetadata.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageMetadata.dll" Checksum="yes" />
       </Component>
       <Component Id="PackageModel.dll" Directory="_usr_bin" Guid="faa15fdd-9ef2-46d8-af96-7a26a6c756f2">
         <File Id="PackageModel.dll" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" Checksum="yes" />
@@ -129,8 +135,17 @@
       <Component Id="swift_build.exe" Directory="_usr_bin" Guid="a1feb617-1b46-446c-8002-08729f3fa267">
         <File Id="swift_build.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.exe" Checksum="yes" />
       </Component>
+      <Component Id="swift_experimental_destination.exe" Directory="_usr_bin" Guid="7b3aaaa5-1f60-4658-a267-5f8347f168ed">
+        <File Id="swift_experimental_destination.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-experimental-destination.exe" Checksum="" />
+      </Component>
       <Component Id="swift_package.exe" Directory="_usr_bin" Guid="2d46cc7c-1831-4caf-a225-9d2f283b4c10">
         <File Id="swift_package.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package_collection.exe" Directory="_usr_bin" Guid="31e80734-a847-4784-8940-9d53f426e892">
+        <File Id="swift_package_collection.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package-collection.exe" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package_registry.exe" Directory="_usr_bin" Guid="506511cc-2a75-4de9-9475-bd74bfa76fc8">
+        <File Id="swift_package_registry.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package-registry.exe" Checksum="yes" />
       </Component>
       <Component Id="swift_run.exe" Directory="_usr_bin" Guid="247b8727-71d3-4e80-bcaf-917a478598db">
         <File Id="swift_run.exe" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.exe" Checksum="yes" />
@@ -183,11 +198,17 @@
       <Component Id="DriverSupport.pdb" Directory="_usr_bin" Guid="f8f8cb75-8f42-4522-bdd7-89499943ef32">
         <File Id="DriverSupport.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\DriverSupport.pdb" Checksum="yes" />
       </Component>
+      <Component Id="PackageCollections.pdb" Directory="_usr_bin" Guid="529f3308-391d-4972-a51b-6fe3aa467acd">
+        <File Id="PackageCollections.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageCollections.pdb" Checksum="yes" />
+      </Component>
       <Component Id="PackageGraph.pdb" Directory="_usr_bin" Guid="71a32056-bb8d-4d9b-ab76-e25ee6fd04bc">
         <File Id="PackageGraph.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageGraph.pdb" Checksum="yes" />
       </Component>
       <Component Id="PackageLoading.pdb" Directory="_usr_bin" Guid="991958ab-0f7b-4547-8286-732671282ec1">
         <File Id="PackageLoading.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageLoading.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="PackageMetadata.pdb" Directory="_usr_bin" Guid="a368f867-3934-4576-8ea5-c29f334c8b9f">
+        <File Id="PackageMetadata.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageMetadata.pdb" Checksum="yes" />
       </Component>
       <Component Id="PackageModel.pdb" Directory="_usr_bin" Guid="511fd24a-f9b9-4c7b-97c1-5845dfc308d0">
         <File Id="PackageModel.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\PackageModel.pdb" Checksum="yes" />
@@ -202,8 +223,17 @@
       <Component Id="swift_build.pdb" Directory="_usr_bin" Guid="84d4c04b-158f-446b-aa5e-9ffe3318dd02">
         <File Id="swift_build.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-build.pdb" Checksum="yes" />
       </Component>
+      <Component Id="swift_experimental_destination.pdb" Directory="_usr_bin" Guid="a36828cf-b528-4d17-ba5c-8dbaf3786208">
+        <File Id="swift_experimental_destination.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-experimental-description.pdb" Checksum="yes" />
+      </Coomponent>
       <Component Id="swift_package.pdb" Directory="_usr_bin" Guid="7038d860-c614-4c74-b2ce-d6dc84f8f638">
         <File Id="swift_package.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package_collection.pdb" Directory="_usr_bin" Guid="cf78534b-7821-45bf-94a9-8aa5748f42ae">
+        <File Id="swift_package_collection.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package-collection.pdb" Checksum="yes" />
+      </Component>
+      <Component Id="swift_package_registry.pdb" Directory="_usr_bin" Guid="2f2d6c94-45b6-4449-b476-c79a84e0c36c">
+        <File Id="swift_package_registry.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package-registry.pdb" Checksum="yes" />
       </Component>
       <Component Id="swift_run.pdb" Directory="_usr_bin" Guid="d5eb453e-1e43-4492-b9d6-e3c08b8f7b80">
         <File Id="swift_run.pdb" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.pdb" Checksum="yes" />

--- a/platforms/Windows/sdk-arm64.wxs
+++ b/platforms/Windows/sdk-arm64.wxs
@@ -437,12 +437,12 @@
     </ComponentGroup>
 
     <ComponentGroup Id="CXXShims">
-      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="d579019d-d999-47f7-8b35-1d714874de80">
-        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.h" Checksum="yes" />
+      <Component Id="libcxxshim.h" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="d579019d-d999-47f7-8b35-1d714874de80">
+        <File Id="libcxxshim.h" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\libcxxshim.h" Checksum="yes" />
       </Component>
 
-      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_x86_64" Guid="b5f65b19-cf8f-4862-b378-3e299887afa3">
-        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\libcxxshim.modulemap" Checksum="yes" />
+      <Component Id="libcxxshim.modulemap" Directory="WindowsSDK_usr_lib_swift_windows_aarch64" Guid="b5f65b19-cf8f-4862-b378-3e299887afa3">
+        <File Id="libcxxshim.modulemap" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\aarch64\libcxxshim.modulemap" Checksum="yes" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
This PR adds a new directory under `Platforms/Linux/RPM/AmazonLinux` to support building RPMs for [Amazon Linux 2023].

The main changes are:

- It adds a step to build `ld.gold` from sources (see https://github.com/apple/swift/issues/65495) (with [this script](https://gist.github.com/sebsto/219315a80333fb0661e03be2e0d00c80) to download, compile, and install the linker)
- it remove the dependency on Swift Mark GFM that is not required for Swift 5.8+ (see https://github.com/apple/swift-installer-scripts/issues/261) 
- it let `build_script` set the required compiler and linker flags, instead of `rpmbuild` 