### PR TITLE
WiX: package up DocC conditionally

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -29,10 +29,8 @@
       <Directory Id="_usr_lib_swift_swiftToCxx" Name="swiftToCxx" />
     </DirectoryRef>
 
-    <DirectoryRef Id="_usr">
-      <Directory Name="share">
-        <Directory Id="_usr_share_swift" Name="swift" />
-      </Directory>
+    <DirectoryRef Id="_usr_share">
+      <Directory Id="_usr_share_swift" Name="swift" />
     </DirectoryRef>
 
     <ComponentGroup Id="binutils" Directory="_usr_bin">

--- a/platforms/Windows/cli/cli.wixproj
+++ b/platforms/Windows/cli/cli.wixproj
@@ -4,8 +4,26 @@
       $(DefineConstants);
       DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);
       TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);
+      SWIFT_DOCC_BUILD=$(SWIFT_DOCC_BUILD);
+      INCLUDE_SWIFT_DOCC=$(INCLUDE_SWIFT_DOCC);
       SWIFT_FORMAT_BUILD=$(SWIFT_FORMAT_BUILD);
       INCLUDE_SWIFT_FORMAT=$(INCLUDE_SWIFT_FORMAT);
+      SWIFT_DOCC_RENDER_ARTIFACT_ROOT_DIST=$(SWIFT_DOCC_RENDER_ARTIFACT_ROOT)\dist;
     </DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Heat" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(INCLUDE_SWIFT_DOCC)' == 'true'">
+    <HarvestDirectory Include="$(SWIFT_DOCC_RENDER_ARTIFACT_ROOT)\dist">
+      <ComponentGroupName>DocCRender</ComponentGroupName>
+      <DirectoryRefId>_usr_share_docc_render</DirectoryRefId>
+      <PreprocessorVariable>var.SWIFT_DOCC_RENDER_ARTIFACT_ROOT_DIST</PreprocessorVariable>
+      <SuppressCom>true</SuppressCom>
+      <SuppressRegistry>true</SuppressRegistry>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+    </HarvestDirectory>
+  </ItemGroup>
 </Project>

--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -231,6 +231,14 @@
       <!-- FIXME(compnerd) we should include the SPM import libraries -->
     </ComponentGroup>
 
+    <ComponentGroup Id="DocC" Directory="_usr_bin">
+      <?if $(INCLUDE_SWIFT_DOCC) == true ?>
+        <Component>
+          <File Source="$(SWIFT_DOCC_BUILD)\docc.exe" />
+        </Component>
+      <?endif?>
+    </ComponentGroup>
+
     <ComponentGroup Id="swift_format" Directory="ToolsVersioned">
       <?if $(INCLUDE_SWIFT_FORMAT) == true ?>
         <Component Id="swift_format.exe">
@@ -252,6 +260,12 @@
       <ComponentGroupRef Id="llbuild" />
       <ComponentGroupRef Id="system" />
       <ComponentGroupRef Id="package_manager" />
+
+      <ComponentGroupRef Id="DocC" />
+      <?if $(INCLUDE_SWIFT_DOCC) == true ?>
+        <ComponentGroupRef Id="DocCRender" />
+      <?endif?>
+
       <ComponentGroupRef Id="swift_format" />
 
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -46,6 +46,11 @@
                 <Directory Id="_usr_lib_clang" Name="clang" />
                 <Directory Id="_usr_lib_swift" Name="swift" />
               </Directory>
+              <Directory Id="_usr_share" Name="share">
+                <Directory Id="_usr_share_docc" Name="docc">
+                  <Directory Id="_usr_share_docc_render" Name="render" />
+                </Directory>
+              </Directory>
             </Directory>
           </Directory>
         </Directory>


### PR DESCRIPTION
Add support to package up DocC in the windows distribution.  This is the last large component that was missing.  At this point, the toolchain distribution is generally speaking complete with:
- Preprocessor (clang)
- Assembler (IAS)
- C/C++/Swift Compiler (clang/clang++/swiftc)
- Linker (lld)
- Binary Utilities (LLVM)
- Debugger (LLDB)
- REPL
- Package Manager (SwiftPM)
- Runtime Inspection Tools (swift-inspect)
- LSP (sourcekit-lsp)
- Code Formatter (swift-format)
- Documentation Tools (DocC)
- Additional IDE integration Tools (lldb-vscode)
- Redistributables (MSMs)
- Runtime (host-only)
- SDKs (AMD64, ARM64, X86)