### PR TITLE
WiX: package and distribute `clang-scan-deps`

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -156,6 +156,12 @@
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\clang.exe" />
       </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\clang-scan-deps.exe" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\clang-deps-launcher.py" />
+      </Component>
       <!--
         TODO(compnerd) we should include:
         - clang-offload-bundler


### PR DESCRIPTION
This is scanned for and used by newer CMake releases. Include it in the toolchain distribution packaging.