### PR TITLE
WiX: package SwiftRefactor for sourcekit-lsp

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -382,6 +382,9 @@
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftParserDiagnostics.dll" />
       </Component>
       <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftRefactor.dll" />
+      </Component>
+      <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftSyntax.dll" />
       </Component>
       <Component>


### PR DESCRIPTION
Add the missing dependency for sourcekit-lsp as per apple/swift-installer-scripts#280.