### PR TITLE
[6.0] Add PackageModelSyntax.dll

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -222,6 +222,9 @@
         <File Source="$(DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" />
       </Component>
       <Component>
+        <File Source="$(DEVTOOLS_ROOT)\usr\bin\PackageModelSyntax.dll" />
+      </Component>
+      <Component>
         <File Source="$(DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" />
       </Component>
       <Component>


### PR DESCRIPTION
This reflects https://github.com/apple/swift-package-manager/pull/7467, adapting to https://github.com/apple/swift-package-manager/pull/7494