### PR TITLE
WiX: define new upgrade code for 6.0

### DIFF
--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -39,6 +39,10 @@
     <BundleUpgradeCode>{917DAD47-82C9-4845-ACBE-57E169EDF799}</BundleUpgradeCode>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MajorMinorProductVersion)' == '6.0'">
+    <BundleUpgradeCode>{95A51A3B-1521-4A98-8BE1-6381BA688561}</BundleUpgradeCode>
+  </PropertyGroup>
+
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);


### PR DESCRIPTION
Introduce a new bundle upgrade code to get 6.0 installers built.