### PR TITLE
[icu] add a BUILD_DATA flag to let android build skip building data

### DIFF
--- a/shared/ICU/CMakeLists.txt
+++ b/shared/ICU/CMakeLists.txt
@@ -546,6 +546,10 @@ target_link_libraries(icuin PRIVATE
 set_target_properties(icuin PROPERTIES
   OUTPUT_NAME icuin${PROJECT_VERSION_MAJOR})
 
+if(NOT BUILD_DATA)
+  return()
+endif()
+
 if(BUILD_TOOLS)
   add_library(icutu
     source/tools/toolutil/collationinfo.cpp


### PR DESCRIPTION
This is needed to build Android ICU on Windows, using https://github.com/apple/swift/pull/72014 