### PR TITLE
ICU: explicitly suffix tools for cross-compiling support

### DIFF
--- a/shared/ICU/CMakeLists.txt
+++ b/shared/ICU/CMakeLists.txt
@@ -651,10 +651,14 @@ if(BUILD_TOOLS)
 
   set(ICU_TOOLS_DIR ${CMAKE_CURRENT_BINARY_DIR})
 elseif(ICU_TOOLS_DIR)
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
+    set(CMAKE_HOST_EXECUTABLE_SUFFIX .exe)
+  endif()
+
   foreach(tool gencnval;gencfu;makeconv;genbrk;gensprep;gendict;icupkg;genrb;pkgdata)
     add_executable(${tool} IMPORTED)
     set_target_properties(${tool} PROPERTIES
-      IMPORTED_LOCATION ${ICU_TOOLS_DIR}/${tool}${CMAKE_EXECUTABLE_SUFFIX})
+      IMPORTED_LOCATION ${ICU_TOOLS_DIR}/${tool}${CMAKE_HOST_EXECUTABLE_SUFFIX})
   endforeach()
 else()
   include(ExternalProject)


### PR DESCRIPTION
When cross-compiling to a different platform from Windows, we should explicitly suffix the executable binary for invocation.