### PR TITLE
Revert "[icu] not building BUILD_DATA should still have an install ta…

### DIFF
--- a/shared/ICU/CMakeLists.txt
+++ b/shared/ICU/CMakeLists.txt
@@ -547,14 +547,6 @@ target_link_libraries(icuin PRIVATE
 set_target_properties(icuin PROPERTIES
   OUTPUT_NAME icuin${PROJECT_VERSION_MAJOR})
 
-if(DEFINED BUILD_DATA AND NOT BUILD_DATA)
-  install(TARGETS icuuc icuin
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
-  return()
-endif()
-
 if(BUILD_TOOLS)
   add_library(icutu
     source/tools/toolutil/collationinfo.cpp


### PR DESCRIPTION
…rget"

This reverts commit 4c12ddfd870ad9bc80057e13a3169f42975f5d7b.

Revert "[icu] add a BUILD_DATA flag to let android build skip building data"

This reverts commit 955e5a9cfe5ff5bcb1cdf35cbd84583b73359c73.

This wasn't the right approach for ICU for android on Windows.