### PR TITLE
WiX: add `SwiftMacros.dll` to the image

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -321,6 +321,9 @@
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\ObservationMacros.dll" />
       </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftMacros.dll" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="argument_parser" Directory="_usr_bin">


### PR DESCRIPTION
This adds an additional DLL to the image. 'SwiftMacros.dll' includes macro implementations for stdlib. e.g. 'TaskLocal'

Resolves rdar://128092675.