### PR TITLE
[6.0] WiX: add `SwiftMacros.dll` to the image

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -321,6 +321,9 @@
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\ObservationMacros.dll" />
       </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftMacros.dll" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="argument_parser" Directory="_usr_bin">


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-installer-scripts/pull/295 into `release/6.0`

* **Explanantion**: This adds an additional DLL to the Windows toolchains. 'SwiftMacros.dll' includes macro implementations for stdlib. e.g. 'TaskLocal'
* **Scope**: Standard library macros in Windows toolchains
* **Risk**: Low. Just adding a DLL where it was supposed to be.
* **Testing**: Locally confirmed that stdlib macros `TaskLocal` work
* **Issue**:  rdar://128092675
* **Reviewer**: @compnerd 
