### PR TITLE
Package and bundle Android SDKs into the windows toolchain installer

### DIFF
--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -26,6 +26,9 @@
     <SdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'amd64' ">{762D10FE-EBE5-4554-BB78-FB13A4A487E3}</SdkUpgradeCode>
     <SdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'arm64' ">{9749D9E6-E860-4FF6-9E8A-525270F471A3}</SdkUpgradeCode>
     <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'aarch64' ">{485f88f4-9342-48cb-853a-12da885a5818}</AndroidSdkUpgradeCode>
+    <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'x86_64' ">{0838ee60-5d4a-4832-b844-73dad6eb1cc1}</AndroidSdkUpgradeCode>
+    <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'armv7' ">{1269a926-3528-4ab7-b4d6-386d5c3f903a}</AndroidSdkUpgradeCode>
+    <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'i686' ">{d889349b-0000-4600-a04a-93602525d5db}</AndroidSdkUpgradeCode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MajorMinorProductVersion)' == '0.0'">

--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -25,6 +25,7 @@
     <SdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'x86' ">{443F4D7F-38F3-47C8-9BEE-37FEB01D13C8}</SdkUpgradeCode>
     <SdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'amd64' ">{762D10FE-EBE5-4554-BB78-FB13A4A487E3}</SdkUpgradeCode>
     <SdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'arm64' ">{9749D9E6-E860-4FF6-9E8A-525270F471A3}</SdkUpgradeCode>
+    <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'aarch64' ">{485f88f4-9342-48cb-853a-12da885a5818}</AndroidSdkUpgradeCode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MajorMinorProductVersion)' == '0.0'">
@@ -53,6 +54,7 @@
       IdeUpgradeCode=$(IdeUpgradeCode);
       RtlUpgradeCode=$(RtlUpgradeCode);
       SdkUpgradeCode=$(SdkUpgradeCode);
+      AndroidSdkUpgradeCode=$(AndroidSdkUpgradeCode);
     </DefineConstants>
   </PropertyGroup>
 </Project>

--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -22,13 +22,13 @@
     <DbgUpgradeCode>{91D382AF-1E92-44DC-A4AD-AEE91C1B5160}</DbgUpgradeCode>
     <IdeUpgradeCode>{8DD91C86-D13D-490B-B06B-9522A9CF504C}</IdeUpgradeCode>
     <RtlUpgradeCode>{BEA8C6DC-F73E-445B-9486-2333D1CF2886}</RtlUpgradeCode>
-    <SdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'x86' ">{443F4D7F-38F3-47C8-9BEE-37FEB01D13C8}</SdkUpgradeCode>
-    <SdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'amd64' ">{762D10FE-EBE5-4554-BB78-FB13A4A487E3}</SdkUpgradeCode>
-    <SdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'arm64' ">{9749D9E6-E860-4FF6-9E8A-525270F471A3}</SdkUpgradeCode>
-    <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'aarch64' ">{485f88f4-9342-48cb-853a-12da885a5818}</AndroidSdkUpgradeCode>
-    <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'x86_64' ">{0838ee60-5d4a-4832-b844-73dad6eb1cc1}</AndroidSdkUpgradeCode>
-    <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'armv7' ">{1269a926-3528-4ab7-b4d6-386d5c3f903a}</AndroidSdkUpgradeCode>
-    <AndroidSdkUpgradeCode Condition=" '$(ProductArchitecture)' == 'i686' ">{d889349b-0000-4600-a04a-93602525d5db}</AndroidSdkUpgradeCode>
+    <WindowsSDKUpgradeCode Condition=" '$(ProductArchitecture)' == 'x86' ">{443F4D7F-38F3-47C8-9BEE-37FEB01D13C8}</WindowsSDKUpgradeCode>
+    <WindowsSDKUpgradeCode Condition=" '$(ProductArchitecture)' == 'amd64' ">{762D10FE-EBE5-4554-BB78-FB13A4A487E3}</WindowsSDKUpgradeCode>
+    <WindowsSDKUpgradeCode Condition=" '$(ProductArchitecture)' == 'arm64' ">{9749D9E6-E860-4FF6-9E8A-525270F471A3}</WindowsSDKUpgradeCode>
+    <AndroidSDKUpgradeCode Condition=" '$(ProductArchitecture)' == 'aarch64' ">{485f88f4-9342-48cb-853a-12da885a5818}</AndroidSDKUpgradeCode>
+    <AndroidSDKUpgradeCode Condition=" '$(ProductArchitecture)' == 'x86_64' ">{0838ee60-5d4a-4832-b844-73dad6eb1cc1}</AndroidSDKUpgradeCode>
+    <AndroidSDKUpgradeCode Condition=" '$(ProductArchitecture)' == 'armv7' ">{1269a926-3528-4ab7-b4d6-386d5c3f903a}</AndroidSDKUpgradeCode>
+    <AndroidSDKUpgradeCode Condition=" '$(ProductArchitecture)' == 'i686' ">{d889349b-0000-4600-a04a-93602525d5db}</AndroidSDKUpgradeCode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MajorMinorProductVersion)' == '0.0'">
@@ -56,8 +56,8 @@
       DbgUpgradeCode=$(DbgUpgradeCode);
       IdeUpgradeCode=$(IdeUpgradeCode);
       RtlUpgradeCode=$(RtlUpgradeCode);
-      SdkUpgradeCode=$(SdkUpgradeCode);
-      AndroidSdkUpgradeCode=$(AndroidSdkUpgradeCode);
+      WindowsSDKUpgradeCode=$(WindowsSDKUpgradeCode);
+      AndroidSDKUpgradeCode=$(AndroidSDKUpgradeCode);
     </DefineConstants>
   </PropertyGroup>
 </Project>

--- a/platforms/Windows/android_sdk/android_sdk.wixproj
+++ b/platforms/Windows/android_sdk/android_sdk.wixproj
@@ -1,0 +1,28 @@
+<Project Sdk="WixToolset.Sdk/4.0.1">
+  <PropertyGroup>
+    <OutputName>android_sdk.$(ProductArchitecture)</OutputName>
+    <Platform>x86</Platform>
+
+    <SwiftShimsPath>$(SDK_ROOT)\usr\lib\swift\shims</SwiftShimsPath>
+
+    <DefineConstants>
+      $(DefineConstants);
+      SwiftShimsPath=$(SwiftShimsPath);
+    </DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Heat" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <HarvestDirectory Include="$(SwiftShimsPath)">
+      <ComponentGroupName>SwiftShims</ComponentGroupName>
+      <DirectoryRefId>AndroidSDK_usr_lib_swift_shims</DirectoryRefId>
+      <PreprocessorVariable>var.SwiftShimsPath</PreprocessorVariable>
+      <SuppressCom>true</SuppressCom>
+      <SuppressRegistry>true</SuppressRegistry>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+    </HarvestDirectory>
+  </ItemGroup>
+</Project>

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -2,15 +2,19 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
   <?if $(ProductArchitecture) = "aarch64"?>
+    <?define ArchName = "arm64"?>
     <?define ArchArchDir = "aarch64"?>
     <?define ArchTriple = "aarch64-unknown-linux-android"?>
   <?elseif $(ProductArchitecture) = "x86_64"?>
+    <?define ArchName = "amd64"?>
     <?define ArchArchDir = "x86_64"?>
     <?define ArchTriple = "x86_64-unknown-linux-android"?>
   <?elseif $(ProductArchitecture) = "armv7"?>
+    <?define ArchName = "arm"?>
     <?define ArchArchDir = "armv7"?>
     <?define ArchTriple = "armv7-unknown-linux-android"?>
   <?elseif $(ProductArchitecture) = "i686"?>
+    <?define ArchName = "x86"?>
     <?define ArchArchDir = "i686"?>
     <?define ArchTriple = "i686-unknown-linux-android"?>
   <?endif?>
@@ -18,7 +22,7 @@
   <Package
       Language="1033"
       Manufacturer="!(loc.ManufacturerName)"
-      Name="!(loc.AndroidSdk_ProductName_$(ProductArchitecture))"
+      Name="!(loc.Android_Sdk_$(ArchName))"
       UpgradeCode="$(AndroidSDKUpgradeCode)"
       Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
@@ -487,7 +491,7 @@
     </ComponentGroup>
 
     <!-- Features -->
-    <Feature Id="AndroidSDK" AllowAbsent="no" Title="!(loc.AndroidSdk_ProductName_$(ProductArchitecture))">
+    <Feature Id="AndroidSDK" AllowAbsent="no" Title="!(loc.Android_Sdk_$(ArchName))">
       <ComponentGroupRef Id="XCTest" />
       <ComponentGroupRef Id="SwiftRemoteMirror" />
       <ComponentGroupRef Id="BlocksRuntime" />

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -1,0 +1,512 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <?if $(ProductArchitecture) = "aarch64"?>
+    <?define ArchArchDir = "aarch64"?>
+    <?define ArchTriple = "aarch64-unknown-linux-android"?>
+  <?endif?>
+
+  <Package
+      Language="1033"
+      Manufacturer="!(loc.ManufacturerName)"
+      Name="!(loc.AndroidSdk_ProductName_$(ProductArchitecture))"
+      UpgradeCode="$(AndroidSdkUpgradeCode)"
+      Version="$(NonSemVerProductVersion)"
+      Scope="$(PackageScope)">
+
+    <Media Id="1" Cabinet="android_sdk.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+
+    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(AndroidSdkUpgradeCode)" />
+
+    <!--
+      └─ Swift
+          └─ Platforms
+              └─ Android.platform
+                  └─ Developer
+                      ├─ Library
+                      │   └─ XCTest-development
+                      │       └─ ...
+                      └─ SDKs
+                          └─ Android.sdk
+                                  └─ ...
+    -->
+    <DirectoryRef Id="PlatformsVersioned">
+      <Directory Id="AndroidPlatform" Name="Android.platform">
+        <Directory Name="Developer">
+          <Directory Name="Library">
+            <!-- XCTest -->
+            <!--
+              FIXME(compnerd) this should actually be the proper version
+              of XCTest, and needs to be reflected in the plist as well.
+            -->
+            <Directory Name="XCTest-development">
+              <Directory Name="usr">
+                <Directory Name="lib">
+                  <Directory Name="swift">
+                    <Directory Name="android">
+                      <Directory Id="XCTest_usr_lib_swift_android_ARCH" Name="$(ArchArchDir)" />
+                      <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule" />
+                    </Directory>
+                  </Directory>
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+          <Directory Name="SDKs">
+            <!-- Android.sdk -->
+            <Directory Id="AndroidSDK" Name="Android.sdk">
+              <Directory Name="usr">
+                <Directory Name="include">
+                  <Directory Id="AndroidSDK_usr_include_Block" Name="Block" />
+                  <Directory Id="AndroidSDK_usr_include_dispatch" Name="dispatch" />
+                  <Directory Id="AndroidSDK_usr_include_os" Name="os" />
+                  <Directory Name="swift">
+                    <Directory Id="AndroidSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror" />
+                  </Directory>
+                </Directory>
+                <Directory Name="lib">
+                  <Directory Name="swift">
+                    <Directory Id="AndroidSDK_usr_lib_swift_apinotes" Name="apinotes" />
+                    <Directory Id="AndroidSDK_usr_lib_swift_shims" Name="shims" />
+                    <Directory Id="AndroidSDK_usr_lib_swift_android" Name="android">
+                      <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule" />
+                      <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule" />
+                      <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule" />
+                      <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule" />
+                      <Directory Id="_Volatile.swiftmodule" Name="_Volatile.swiftmodule" />
+                      <Directory Id="Android.swiftmodule" Name="Android.swiftmodule" />
+                      <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule" />
+                      <!-- FIXME: to add: <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" /> -->
+                      <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule" />
+                      <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule" />
+                      <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule" />
+                      <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule" />
+                      <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule" />
+                      <Directory Id="Observation.swiftmodule" Name="Observation.swiftmodule" />
+                      <Directory Id="RegexBuilder.swiftmodule" Name="RegexBuilder.swiftmodule" />
+                      <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule" />
+                      <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule" />
+                      <Directory Id="Synchronization.swiftmodule" Name="Synchronization.swiftmodule" />
+                      <Directory Id="AndroidSDK_usr_lib_swift_android_ARCH" Name="$(ArchArchDir)" />
+                    </Directory>
+                  </Directory>
+                </Directory>
+                <Directory Id="AndroidSDK_usr_share" Name="share" />
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </DirectoryRef>
+
+    <ComponentGroup Id="XCTest">
+      <Component Directory="XCTest_usr_lib_swift_android_ARCH">
+        <File Source="$(PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\android\libXCTest.so" />
+      </Component>
+      <Component Directory="XCTest.swiftmodule">
+        <File Name="$(ArchTriple).swiftdoc" Source="$(PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\android\$(ArchArchDir)\XCTest.swiftdoc" />
+      </Component>
+      <Component Directory="XCTest.swiftmodule">
+        <File Name="$(ArchTriple).swiftmodule" Source="$(PLATFORM_ROOT)\Developer\Library\XCTest-development\usr\lib\swift\android\$(ArchArchDir)\XCTest.swiftmodule" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="SwiftRemoteMirror" Directory="AndroidSDK_usr_include_swift_SwiftRemoteMirror">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\MemoryReaderInterface.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\Platform.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirror.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\SwiftRemoteMirrorTypes.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\include\swift\SwiftRemoteMirror\module.modulemap" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftRemoteMirror.so" />
+      </Component>
+    </ComponentGroup>
+    
+    <ComponentGroup Id="BlocksRuntime">
+      <Component Directory="AndroidSDK_usr_include_Block">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\Block\Block.h" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libBlocksRuntime.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="libdispatch" Directory="AndroidSDK_usr_include_dispatch">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\base.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\block.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\data.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\group.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\io.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\object.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\once.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\queue.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\source.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\time.h" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_include_os">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\os\generic_base.h" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_include_os">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\os\generic_unix_base.h" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_include_os">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\os\generic_win_base.h" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_include_os">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\os\object.h" />
+      </Component>
+      <Component Directory="Dispatch.swiftmodule">
+        <File Name="$(ArchTriple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\Dispatch.swiftdoc" />
+      </Component>
+      <Component Directory="Dispatch.swiftmodule">
+        <File Name="$(ArchTriple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\Dispatch.swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libdispatch.so" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftDispatch.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Concurrency" Directory="_Concurrency.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Concurrency.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Concurrency.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Concurrency.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswift_Concurrency.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Differentiation" Directory="_Differentiation.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Differentiation.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Differentiation.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Differentiation.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswift_Differentiation.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_RegexParser" Directory="_RegexParser.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_RegexParser.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_RegexParser.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswift_RegexParser.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_StringProcessing" Directory="_StringProcessing.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_StringProcessing.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_StringProcessing.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_StringProcessing.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswift_StringProcessing.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="_Volatile" Directory="_Volatile.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Volatile.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Volatile.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Volatile.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswift_Volatile.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Android" Directory="Android.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Android.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Android.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Android.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftAndroid.so" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\android.modulemap" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\SwiftAndroidNDK.h" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\SwiftBionic.h" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Cxx" Directory="Cxx.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Cxx.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Cxx.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftCxx.a" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Distributed" Directory="Distributed.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Distributed.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Distributed.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Distributed.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftDistributed.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Foundation" Directory="Foundation.swiftmodule">
+      <Component>
+        <File Name="$(ArchTriple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\Foundation.swiftdoc" />
+      </Component>
+      <Component>
+        <File Name="$(ArchTriple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\Foundation.swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libFoundation.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="FoundationNetworking" Directory="FoundationNetworking.swiftmodule">
+      <Component>
+        <File Name="$(ArchTriple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\FoundationNetworking.swiftdoc" />
+      </Component>
+      <Component>
+        <File Name="$(ArchTriple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\FoundationNetworking.swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libFoundationNetworking.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="FoundationXML" Directory="FoundationXML.swiftmodule">
+      <Component>
+        <File Name="$(ArchTriple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\FoundationXML.swiftdoc" />
+      </Component>
+      <Component>
+        <File Name="$(ArchTriple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\FoundationXML.swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libFoundationXML.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Observation" Directory="Observation.swiftmodule">
+      <Component>
+        <File Name="$(ArchTriple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\android\Observation.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Name="$(ArchTriple).swiftinterface" Source="$(SDK_ROOT)\usr\lib\swift\android\Observation.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Name="$(ArchTriple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\android\Observation.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftObservation.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="RegexBuilder" Directory="RegexBuilder.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\RegexBuilder.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\RegexBuilder.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\RegexBuilder.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftRegexBuilder.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Swift" Directory="Swift.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Swift.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Swift.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Swift.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftCore.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="SwiftOnoneSupport" Directory="SwiftOnoneSupport.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftSwiftOnoneSupport.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Synchronization" Directory="Synchronization.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Synchronization.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Synchronization.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Synchronization.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftSynchronization.so" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="apinotes" Directory="AndroidSDK_usr_lib_swift_apinotes">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\apinotes\std.apinotes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="libcxxshim" Directory="AndroidSDK_usr_lib_swift_android">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libcxxshim.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libcxxshim.modulemap" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libcxxstdlibshim.h" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Registrar" Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\$(ArchArchDir)\swiftrt.o" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Configuration">
+      <Component Directory="AndroidSDK">
+        <File Source="$(SDK_ROOT)\SDKSettings.plist" />
+      </Component>
+      <Component Directory="AndroidPlatform">
+        <File Source="$(PLATFORM_ROOT)\Info.plist" />
+      </Component>
+    </ComponentGroup>
+
+    <!-- Features -->
+    <Feature Id="AndroidSDK" AllowAbsent="no" Title="!(loc.AndroidSdk_ProductName_$(ProductArchitecture))">
+      <ComponentGroupRef Id="XCTest" />
+      <ComponentGroupRef Id="SwiftRemoteMirror" />
+      <ComponentGroupRef Id="BlocksRuntime" />
+      <ComponentGroupRef Id="libdispatch" />
+      <ComponentGroupRef Id="_Concurrency" />
+      <ComponentGroupRef Id="_Differentiation" />
+      <ComponentGroupRef Id="_RegexParser" />
+      <ComponentGroupRef Id="_StringProcessing" />
+      <ComponentGroupRef Id="_Volatile" />
+      <ComponentGroupRef Id="Android" />
+      <ComponentGroupRef Id="Cxx" />
+      <!-- FIXME: <ComponentGroupRef Id="CxxStdlib" /> -->
+      <ComponentGroupRef Id="Distributed" />
+      <ComponentGroupRef Id="Foundation" />
+      <ComponentGroupRef Id="FoundationXML" />
+      <ComponentGroupRef Id="FoundationNetworking" />
+      <ComponentGroupRef Id="Observation" />
+      <ComponentGroupRef Id="RegexBuilder" />
+      <ComponentGroupRef Id="Swift" />
+      <ComponentGroupRef Id="SwiftOnoneSupport" />
+      <ComponentGroupRef Id="Synchronization" />
+      <ComponentGroupRef Id="apinotes" />
+      <ComponentGroupRef Id="libcxxshim" />
+      <ComponentGroupRef Id="Registrar" />
+      <ComponentGroupRef Id="Configuration" />
+      <ComponentGroupRef Id="SwiftShims" />
+
+      <ComponentGroupRef Id="VersionedDirectoryCleanup" />
+    </Feature>
+  </Package>
+</Wix>

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -95,6 +95,7 @@
                       <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule" />
                       <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule" />
                       <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule" />
+                      <Directory Id="_math.swiftmodule" Name="_math.swiftmodule" />
                       <Directory Id="Observation.swiftmodule" Name="Observation.swiftmodule" />
                       <Directory Id="RegexBuilder.swiftmodule" Name="RegexBuilder.swiftmodule" />
                       <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule" />
@@ -394,6 +395,21 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="Math" Directory="_math.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_math.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_math.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\_math.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswift_math.so" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Observation" Directory="Observation.swiftmodule">
       <Component>
         <File Name="$(ArchTriple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\android\Observation.swiftmodule\$(ArchTriple).swiftdoc" />
@@ -520,6 +536,7 @@
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationXML" />
       <ComponentGroupRef Id="FoundationNetworking" />
+      <ComponentGroupRef Id="Math" />
       <ComponentGroupRef Id="Observation" />
       <ComponentGroupRef Id="RegexBuilder" />
       <ComponentGroupRef Id="Swift" />

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -89,7 +89,7 @@
                       <Directory Id="_Volatile.swiftmodule" Name="_Volatile.swiftmodule" />
                       <Directory Id="Android.swiftmodule" Name="Android.swiftmodule" />
                       <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule" />
-                      <!-- FIXME: to add: <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" /> -->
+                      <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
                       <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule" />
                       <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule" />
                       <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule" />
@@ -331,6 +331,18 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="CxxStdlib" Directory="CxxStdlib.swiftmodule">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\CxxStdlib.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\CxxStdlib.swiftmodule\$(ArchTriple).swiftmodule" />
+      </Component>
+      <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftCxxStdlib.a" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Distributed" Directory="Distributed.swiftmodule">
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Distributed.swiftmodule\$(ArchTriple).swiftdoc" />
@@ -503,7 +515,7 @@
       <ComponentGroupRef Id="_Volatile" />
       <ComponentGroupRef Id="Android" />
       <ComponentGroupRef Id="Cxx" />
-      <!-- FIXME: <ComponentGroupRef Id="CxxStdlib" /> -->
+      <ComponentGroupRef Id="CxxStdlib" />
       <ComponentGroupRef Id="Distributed" />
       <ComponentGroupRef Id="Foundation" />
       <ComponentGroupRef Id="FoundationXML" />

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -19,13 +19,13 @@
       Language="1033"
       Manufacturer="!(loc.ManufacturerName)"
       Name="!(loc.AndroidSdk_ProductName_$(ProductArchitecture))"
-      UpgradeCode="$(AndroidSdkUpgradeCode)"
+      UpgradeCode="$(AndroidSDKUpgradeCode)"
       Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
     <Media Id="1" Cabinet="android_sdk.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
 
-    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(AndroidSdkUpgradeCode)" />
+    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(AndroidSDKUpgradeCode)" />
 
     <!--
       └─ Swift

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -470,6 +470,8 @@
       </Component>
     </ComponentGroup>
 
+    <!-- FIXME: re-enable once https://github.com/apple/swift/issues/74186 is fixed -->
+    <?if $(ProductArchitecture) != "armv7"?>
     <ComponentGroup Id="Synchronization" Directory="Synchronization.swiftmodule">
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Synchronization.swiftmodule\$(ArchTriple).swiftdoc" />
@@ -484,6 +486,7 @@
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\libswiftSynchronization.so" />
       </Component>
     </ComponentGroup>
+    <?endif?>
 
     <ComponentGroup Id="apinotes" Directory="AndroidSDK_usr_lib_swift_apinotes">
       <Component>
@@ -541,7 +544,10 @@
       <ComponentGroupRef Id="RegexBuilder" />
       <ComponentGroupRef Id="Swift" />
       <ComponentGroupRef Id="SwiftOnoneSupport" />
+      <!-- FIXME: re-enable once https://github.com/apple/swift/issues/74186 is fixed -->
+      <?if $(ProductArchitecture) != "armv7"?>
       <ComponentGroupRef Id="Synchronization" />
+      <?endif?>
       <ComponentGroupRef Id="apinotes" />
       <ComponentGroupRef Id="libcxxshim" />
       <ComponentGroupRef Id="Registrar" />

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -4,6 +4,15 @@
   <?if $(ProductArchitecture) = "aarch64"?>
     <?define ArchArchDir = "aarch64"?>
     <?define ArchTriple = "aarch64-unknown-linux-android"?>
+  <?elseif $(ProductArchitecture) = "x86_64"?>
+    <?define ArchArchDir = "x86_64"?>
+    <?define ArchTriple = "x86_64-unknown-linux-android"?>
+  <?elseif $(ProductArchitecture) = "armv7"?>
+    <?define ArchArchDir = "armv7"?>
+    <?define ArchTriple = "armv7-unknown-linux-android"?>
+  <?elseif $(ProductArchitecture) = "i686"?>
+    <?define ArchArchDir = "i686"?>
+    <?define ArchTriple = "i686-unknown-linux-android"?>
   <?endif?>
 
   <Package

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -8,10 +8,10 @@
       $(DefineConstants);
       INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
-      INCLUDE_ARM64_ANDROID_SDK=$(INCLUDE_ARM64_ANDROID_SDK);
-      INCLUDE_x86_64_ANDROID_SDK=$(INCLUDE_x86_64_ANDROID_SDK);
-      INCLUDE_ARM_ANDROID_SDK=$(INCLUDE_ARM_ANDROID_SDK);
-      INCLUDE_X86_ANDROID_SDK=$(INCLUDE_X86_ANDROID_SDK);
+      ANDROID_INCLUDE_ARM64_SDK=$(ANDROID_INCLUDE_ARM64_SDK);
+      ANDROID_INCLUDE_x86_64_SDK=$(ANDROID_INCLUDE_x86_64_SDK);
+      ANDROID_INCLUDE_ARM_SDK=$(ANDROID_INCLUDE_ARM_SDK);
+      ANDROID_INCLUDE_X86_SDK=$(ANDROID_INCLUDE_X86_SDK);
     </DefineConstants>
   </PropertyGroup>
 
@@ -36,19 +36,19 @@
     <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=arm64;Platform=x86" BindName="sdk_arm64" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_ARM64_ANDROID_SDK)' != '' ">
+  <ItemGroup Condition=" '$(ANDROID_INCLUDE_ARM64_SDK)' != '' ">
     <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=aarch64;Platform=x86" BindName="android_sdk_aarch64" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_x86_64_ANDROID_SDK)' != '' ">
+  <ItemGroup Condition=" '$(ANDROID_INCLUDE_x86_64_SDK)' != '' ">
     <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=x86_64;Platform=x86" BindName="android_sdk_x86_64" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_ARM_ANDROID_SDK)' != '' ">
+  <ItemGroup Condition=" '$(ANDROID_INCLUDE_ARM_SDK)' != '' ">
     <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=armv7;Platform=x86" BindName="android_sdk_armv7" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_X86_ANDROID_SDK)' != '' ">
+  <ItemGroup Condition=" '$(ANDROID_INCLUDE_X86_SDK)' != '' ">
     <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=i686;Platform=x86" BindName="android_sdk_i686" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -8,7 +8,10 @@
       $(DefineConstants);
       INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
-      INCLUDE_ANDROID_SDKS=$(INCLUDE_ANDROID_SDKS);
+      INCLUDE_ARM64_ANDROID_SDK=$(INCLUDE_ARM64_ANDROID_SDK);
+      INCLUDE_x86_64_ANDROID_SDK=$(INCLUDE_x86_64_ANDROID_SDK);
+      INCLUDE_ARM_ANDROID_SDK=$(INCLUDE_ARM_ANDROID_SDK);
+      INCLUDE_X86_ANDROID_SDK=$(INCLUDE_X86_ANDROID_SDK);
     </DefineConstants>
   </PropertyGroup>
 
@@ -33,7 +36,19 @@
     <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=arm64;Platform=x86" BindName="sdk_arm64" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_ANDROID_SDKS)' != '' ">
+  <ItemGroup Condition=" '$(INCLUDE_ARM64_ANDROID_SDK)' != '' ">
     <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=aarch64;Platform=x86" BindName="android_sdk_aarch64" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(INCLUDE_x86_64_ANDROID_SDK)' != '' ">
+    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=x86_64;Platform=x86" BindName="android_sdk_x86_64" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(INCLUDE_ARM_ANDROID_SDK)' != '' ">
+    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=armv7;Platform=x86" BindName="android_sdk_armv7" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(INCLUDE_X86_ANDROID_SDK)' != '' ">
+    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=i686;Platform=x86" BindName="android_sdk_i686" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -8,6 +8,7 @@
       $(DefineConstants);
       INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
+      INCLUDE_ANDROID_SDKS=$(INCLUDE_ANDROID_SDKS);
     </DefineConstants>
   </PropertyGroup>
 
@@ -30,5 +31,9 @@
 
   <ItemGroup Condition=" '$(INCLUDE_ARM64_SDK)' != '' ">
     <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=arm64;Platform=x86" BindName="sdk_arm64" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(INCLUDE_ANDROID_SDKS)' != '' ">
+    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=aarch64;Platform=x86" BindName="android_sdk_aarch64" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -124,7 +124,7 @@
         </MsiPackage>
       <?endif?>
 
-      <?if $(INCLUDE_ARM64_ANDROID_SDK) == true ?>
+      <?if $(ANDROID_INCLUDE_ARM64_SDK) == true ?>
         <MsiPackage
           SourceFile="!(bindpath.android_sdk_aarch64)\android_sdk.aarch64.msi"
           InstallCondition="OptionsInstallAndroidSdkArm64"
@@ -133,7 +133,7 @@
         </MsiPackage>
       <?endif?>
 
-      <?if $(INCLUDE_x86_64_ANDROID_SDK) == true ?>
+      <?if $(ANDROID_INCLUDE_x86_64_SDK) == true ?>
         <MsiPackage
           SourceFile="!(bindpath.android_sdk_x86_64)\android_sdk.x86_64.msi"
           InstallCondition="OptionsInstallAndroidSdkAMD64"
@@ -142,7 +142,7 @@
         </MsiPackage>
       <?endif?>
 
-      <?if $(INCLUDE_ARM_ANDROID_SDK) == true ?>
+      <?if $(ANDROID_INCLUDE_ARM_SDK) == true ?>
         <MsiPackage
           SourceFile="!(bindpath.android_sdk_armv7)\android_sdk.armv7.msi"
           InstallCondition="OptionsInstallAndroidSdkArm"
@@ -151,7 +151,7 @@
         </MsiPackage>
       <?endif?>
 
-      <?if $(INCLUDE_X86_ANDROID_SDK) == true ?>
+      <?if $(ANDROID_INCLUDE_X86_SDK) == true ?>
         <MsiPackage
           SourceFile="!(bindpath.android_sdk_i686)\android_sdk.i686.msi"
           InstallCondition="OptionsInstallAndroidSdkX86"

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -38,7 +38,10 @@
     <Variable Name="OptionsInstallRedistAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallSdkArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallRedistArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallAndroidSdks" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallAndroidSdkArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallAndroidSdkAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallAndroidSdkArm" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallAndroidSdkX86" bal:Overridable="yes" Persisted="yes" Value="1" />
 
     <!--
     For the online bundle, we need to provide a download URL for each package and its .cabs.
@@ -121,10 +124,37 @@
         </MsiPackage>
       <?endif?>
 
-      <?if $(INCLUDE_ANDROID_SDKS) == true ?>
+      <?if $(INCLUDE_ARM64_ANDROID_SDK) == true ?>
         <MsiPackage
           SourceFile="!(bindpath.android_sdk_aarch64)\android_sdk.aarch64.msi"
-          InstallCondition="OptionsInstallAndroidSdks"
+          InstallCondition="OptionsInstallAndroidSdkArm64"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_x86_64_ANDROID_SDK) == true ?>
+        <MsiPackage
+          SourceFile="!(bindpath.android_sdk_x86_64)\android_sdk.x86_64.msi"
+          InstallCondition="OptionsInstallAndroidSdkAMD64"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_ARM_ANDROID_SDK) == true ?>
+        <MsiPackage
+          SourceFile="!(bindpath.android_sdk_armv7)\android_sdk.armv7.msi"
+          InstallCondition="OptionsInstallAndroidSdkArm"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_X86_ANDROID_SDK) == true ?>
+        <MsiPackage
+          SourceFile="!(bindpath.android_sdk_i686)\android_sdk.i686.msi"
+          InstallCondition="OptionsInstallAndroidSdkX86"
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
         </MsiPackage>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -38,6 +38,7 @@
     <Variable Name="OptionsInstallRedistAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallSdkArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallRedistArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallAndroidSdks" bal:Overridable="yes" Persisted="yes" Value="1" />
 
     <!--
     For the online bundle, we need to provide a download URL for each package and its .cabs.
@@ -117,6 +118,15 @@
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
           <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistArm64]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_ANDROID_SDKS) == true ?>
+        <MsiPackage
+          SourceFile="!(bindpath.android_sdk_aarch64)\android_sdk.aarch64.msi"
+          InstallCondition="OptionsInstallAndroidSdks"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
         </MsiPackage>
       <?endif?>
      </Chain>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -40,8 +40,8 @@
     <Variable Name="OptionsInstallRedistArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallAndroidSdkArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallAndroidSdkAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallAndroidSdkArm" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallAndroidSdkX86" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallAndroidSdkArm" bal:Overridable="yes" Persisted="yes" Value="0" />
+    <Variable Name="OptionsInstallAndroidSdkX86" bal:Overridable="yes" Persisted="yes" Value="0" />
 
     <!--
     For the online bundle, we need to provide a download URL for each package and its .cabs.

--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -67,6 +67,7 @@
             <Checkbox Name="OptionsInstallRedistArm64" X="194" Y="285" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkArm64">#(loc.Redist_arm64)</Checkbox>
             <Checkbox Name="OptionsInstallSdkX86" X="176" Y="303" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_x86)</Checkbox>
             <Checkbox Name="OptionsInstallRedistX86" X="194" Y="321" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkX86">#(loc.Redist_x86)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKs" X="176" Y="338" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidSdks">#(loc.Android_Skds)</Checkbox>
 
             <Button Name="OptionsOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.OptionsOkButton)</Text>

--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -10,7 +10,7 @@
     <Font Id="3" Height="-12" Weight="500" Foreground="windowtext" Background="window">Segoe UI</Font>
 
     <Window Width="614" Height="456" HexStyle="100a0000" FontId="0" Caption="#(loc.Caption)">
-        <ImageControl X="0" Y="0" Width="165" Height="384" ImageFile="swift_side.png"/>
+        <ImageControl X="0" Y="0" Width="165" Height="456" ImageFile="swift_side.png"/>
         <Label X="176" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
 
         <Page Name="Help">

--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -9,7 +9,7 @@
     <Font Id="2" Height="-22" Weight="500" Foreground="graytext">Segoe UI</Font>
     <Font Id="3" Height="-12" Weight="500" Foreground="windowtext" Background="window">Segoe UI</Font>
 
-    <Window Width="614" Height="384" HexStyle="100a0000" FontId="0" Caption="#(loc.Caption)">
+    <Window Width="614" Height="456" HexStyle="100a0000" FontId="0" Caption="#(loc.Caption)">
         <ImageControl X="0" Y="0" Width="165" Height="384" ImageFile="swift_side.png"/>
         <Label X="176" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
 
@@ -67,7 +67,10 @@
             <Checkbox Name="OptionsInstallRedistArm64" X="194" Y="285" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkArm64">#(loc.Redist_arm64)</Checkbox>
             <Checkbox Name="OptionsInstallSdkX86" X="176" Y="303" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_x86)</Checkbox>
             <Checkbox Name="OptionsInstallRedistX86" X="194" Y="321" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkX86">#(loc.Redist_x86)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSDKs" X="176" Y="338" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidSdks">#(loc.Android_Skds)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSdkArm64" X="176" Y="339" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSdkAMD64" X="176" Y="357" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSdkArm" X="176" Y="375" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_arm)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSdkX86" X="176" Y="393" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_x86)</Checkbox>
 
             <Button Name="OptionsOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.OptionsOkButton)</Text>

--- a/platforms/Windows/readme.md
+++ b/platforms/Windows/readme.md
@@ -218,7 +218,7 @@ Note that these GUIDs are substituted at bind time so they skip the normal valid
 
 | Property | Description |
 | -------- | ----------- |
-| BldUpgradeCode, CliUpgradeCode, DbgUpgradeCode, IdeUpgradeCode, RtlUpgradeCode, SdkUpgradeCode | Upgrade codes for individual packages. Packages keep the same upgrade codes "forever" because MSI lets you specify version ranges for upgrades, which you can find in `shared/shared.wxs`. |
+| BldUpgradeCode, CliUpgradeCode, DbgUpgradeCode, IdeUpgradeCode, RtlUpgradeCode, WindowsSDKUpgradeCode, AndroidSDKUpgradeCode | Upgrade codes for individual packages. Packages keep the same upgrade codes "forever" because MSI lets you specify version ranges for upgrades, which you can find in `shared/shared.wxs`. |
 | BundleUpgradeCode | Upgrade codes for the bundle. Bundles don't support upgrade version ranges, so the bundle upgrade code must change for every minor version _and_ stay the same for the entire lifetime of that minor version (e.g., v5.10.0 through v5.10.9999). You can keep the history of upgrade codes using a condition like `Condition="'$(MajorMinorProductVersion)' == '5.10'` or just replace BundleUpgradeCode when forking to a new minor version. |
 
 
@@ -227,7 +227,7 @@ Note that these GUIDs are substituted at bind time so they skip the normal valid
 To support side-by-side installation for each minor release (the latest point release of each minor release), we need to use "old-school" `Upgrade`/`UpgradeVersion` authoring to get the upgrade version ranges, which also requires manually scheduling `RemoveExistingProducts`. (We can no longer use WiX's `MajorUpgrade` element because it's intended to support the way-more-common case of upgrading every version.) To avoid duplication, the upgrade logic is authored in `shared\shared.wxs` and referenced from the `Package` element of each package:
 
 ```xml
-<WixVariable Id="SideBySidePackageUpgradeCode" Value="$(SdkUpgradeCode)" />
+<WixVariable Id="SideBySidePackageUpgradeCode" Value="$(WindowsSDKUpgradeCode)" />
 <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 ```
 

--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -19,13 +19,13 @@
       Language="1033"
       Manufacturer="!(loc.ManufacturerName)"
       Name="!(loc.Sdk_ProductName_$(ProductArchitecture))"
-      UpgradeCode="$(SdkUpgradeCode)"
+      UpgradeCode="$(WindowsSDKUpgradeCode)"
       Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
     <Media Id="1" Cabinet="sdk.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
 
-    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(SdkUpgradeCode)" />
+    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(WindowsSDKUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
     <!--

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -24,6 +24,7 @@
   <String Id="Redist_arm64" Value="Swift Windows Redistributable (ARM64)" />
   <String Id="Redist_amd64" Value="Swift Windows Redistributable (AMD64)" />
   <String Id="Redist_x86" Value="Swift Windows Redistributable (X86)" />
+  <String Id="Android_Skds" Value="Swift Android SDKs" />
 
   <String Id="Caption" Value="[WixBundleName] Setup" />
   <String Id="Title" Value="[WixBundleName]" />

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -16,7 +16,10 @@
   <String Id="Sdk_ProductName_arm64" Value="Swift Windows SDK (ARM64)" />
   <String Id="Sdk_ProductName_amd64" Value="Swift Windows SDK (AMD64)" />
   <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (X86)" />
-  <String Id="AndroidSdk_ProductName_aarch64" Value="Swift Android SDK (Aarch64)" />
+  <String Id="AndroidSdk_ProductName_aarch64" Value="Swift Android SDK (Arm64)" />
+  <String Id="AndroidSdk_ProductName_x86_64" Value="Swift Android SDK (AMD64)" />
+  <String Id="AndroidSdk_ProductName_armv7" Value="Swift Android SDK (Arm)" />
+  <String Id="AndroidSdk_ProductName_i686" Value="Swift Android SDK (X86)" />
   <String Id="BundleName" Value="Swift Developer Toolkit" />
   <String Id="ManufacturerName" Value="swift.org" />
 

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -16,6 +16,7 @@
   <String Id="Sdk_ProductName_arm64" Value="Swift Windows SDK (ARM64)" />
   <String Id="Sdk_ProductName_amd64" Value="Swift Windows SDK (AMD64)" />
   <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (X86)" />
+  <String Id="AndroidSdk_ProductName_aarch64" Value="Swift Android SDK (Aarch64)" />
   <String Id="BundleName" Value="Swift Developer Toolkit" />
   <String Id="ManufacturerName" Value="swift.org" />
 

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -18,7 +18,7 @@
   <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (X86)" />
   <String Id="AndroidSdk_ProductName_aarch64" Value="Swift Android SDK (Arm64)" />
   <String Id="AndroidSdk_ProductName_x86_64" Value="Swift Android SDK (AMD64)" />
-  <String Id="AndroidSdk_ProductName_armv7" Value="Swift Android SDK (Arm)" />
+  <String Id="AndroidSdk_ProductName_armv7" Value="Swift Android SDK (ARM)" />
   <String Id="AndroidSdk_ProductName_i686" Value="Swift Android SDK (X86)" />
   <String Id="BundleName" Value="Swift Developer Toolkit" />
   <String Id="ManufacturerName" Value="swift.org" />
@@ -27,7 +27,10 @@
   <String Id="Redist_arm64" Value="Swift Windows Redistributable (ARM64)" />
   <String Id="Redist_amd64" Value="Swift Windows Redistributable (AMD64)" />
   <String Id="Redist_x86" Value="Swift Windows Redistributable (X86)" />
-  <String Id="Android_Skds" Value="Swift Android SDKs" />
+  <String Id="Android_Sdk_arm64" Value="Swift Android SDK (ARM64)" />
+  <String Id="Android_Sdk_amd64" Value="Swift Android SDK (AMD64)" />
+  <String Id="Android_Sdk_arm" Value="Swift Android SDK (ARM)" />
+  <String Id="Android_Sdk_x86" Value="Swift Android SDK (X86)" />
 
   <String Id="Caption" Value="[WixBundleName] Setup" />
   <String Id="Title" Value="[WixBundleName]" />

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -16,10 +16,10 @@
   <String Id="Sdk_ProductName_arm64" Value="Swift Windows SDK (ARM64)" />
   <String Id="Sdk_ProductName_amd64" Value="Swift Windows SDK (AMD64)" />
   <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (X86)" />
-  <String Id="AndroidSdk_ProductName_aarch64" Value="Swift Android SDK (Arm64)" />
-  <String Id="AndroidSdk_ProductName_x86_64" Value="Swift Android SDK (AMD64)" />
-  <String Id="AndroidSdk_ProductName_armv7" Value="Swift Android SDK (ARM)" />
-  <String Id="AndroidSdk_ProductName_i686" Value="Swift Android SDK (X86)" />
+  <String Id="Android_Sdk_arm64" Value="Swift Android SDK (ARM64)" />
+  <String Id="Android_Sdk_amd64" Value="Swift Android SDK (AMD64)" />
+  <String Id="Android_Sdk_arm" Value="Swift Android SDK (ARM)" />
+  <String Id="Android_Sdk_x86" Value="Swift Android SDK (X86)" />
   <String Id="BundleName" Value="Swift Developer Toolkit" />
   <String Id="ManufacturerName" Value="swift.org" />
 
@@ -27,10 +27,6 @@
   <String Id="Redist_arm64" Value="Swift Windows Redistributable (ARM64)" />
   <String Id="Redist_amd64" Value="Swift Windows Redistributable (AMD64)" />
   <String Id="Redist_x86" Value="Swift Windows Redistributable (X86)" />
-  <String Id="Android_Sdk_arm64" Value="Swift Android SDK (ARM64)" />
-  <String Id="Android_Sdk_amd64" Value="Swift Android SDK (AMD64)" />
-  <String Id="Android_Sdk_arm" Value="Swift Android SDK (ARM)" />
-  <String Id="Android_Sdk_x86" Value="Swift Android SDK (X86)" />
 
   <String Id="Caption" Value="[WixBundleName] Setup" />
   <String Id="Title" Value="[WixBundleName]" />


### PR DESCRIPTION
This change packages the Android SDKs that can be built using build.ps1 on windows into MSIs, which are then added to the toolchain's installer.

At the moment it covers aarch64 only, I'm adding and testing other arches and will update the PR with them as well.

For future follow-up:
- Fix the 'CxxStdlib' build issue for Android and add it to the installer. (https://github.com/apple/swift/issues/73855)